### PR TITLE
chore(dp): gitignore Build/dp_test_results/ -- resolves Q-2026-05-12-004

### DIFF
--- a/Build/dp_test_results/BuildingWallClosure_Test.json
+++ b/Build/dp_test_results/BuildingWallClosure_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "BuildingWallClosure_Test",
-  "passed": true,
-  "frames": 4,
-  "failures": []
-}

--- a/Build/dp_test_results/ChestInteract_Test.json
+++ b/Build/dp_test_results/ChestInteract_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "ChestInteract_Test",
-  "passed": true,
-  "frames": 6,
-  "failures": []
-}

--- a/Build/dp_test_results/DPFogPass_Test.json
+++ b/Build/dp_test_results/DPFogPass_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DPFogPass_Test",
-  "passed": true,
-  "frames": 9,
-  "failures": []
-}

--- a/Build/dp_test_results/DP_FindItemByTag_Test.json
+++ b/Build/dp_test_results/DP_FindItemByTag_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DP_FindItemByTag_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/DP_Fog_Test.json
+++ b/Build/dp_test_results/DP_Fog_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DP_Fog_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/DP_HeldItem_Test.json
+++ b/Build/dp_test_results/DP_HeldItem_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DP_HeldItem_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/DP_Unlock_Test.json
+++ b/Build/dp_test_results/DP_Unlock_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DP_Unlock_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/DP_Win_Test.json
+++ b/Build/dp_test_results/DP_Win_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DP_Win_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/DimLightsCutFog_Test.json
+++ b/Build/dp_test_results/DimLightsCutFog_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DimLightsCutFog_Test",
-  "passed": true,
-  "frames": 8,
-  "failures": []
-}

--- a/Build/dp_test_results/DoorUnlock_Test.json
+++ b/Build/dp_test_results/DoorUnlock_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DoorUnlock_Test",
-  "passed": true,
-  "frames": 6,
-  "failures": []
-}

--- a/Build/dp_test_results/DoubleDoor_Test.json
+++ b/Build/dp_test_results/DoubleDoor_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "DoubleDoor_Test",
-  "passed": true,
-  "frames": 35,
-  "failures": []
-}

--- a/Build/dp_test_results/Forge_Test.json
+++ b/Build/dp_test_results/Forge_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "Forge_Test",
-  "passed": true,
-  "frames": 9,
-  "failures": []
-}

--- a/Build/dp_test_results/FrontEndPlay_Test.json
+++ b/Build/dp_test_results/FrontEndPlay_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "FrontEndPlay_Test",
-  "passed": true,
-  "frames": 6,
-  "failures": []
-}

--- a/Build/dp_test_results/FullPlaythrough_Test.json
+++ b/Build/dp_test_results/FullPlaythrough_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "FullPlaythrough_Test",
-  "passed": true,
-  "frames": 94,
-  "failures": []
-}

--- a/Build/dp_test_results/GameLevelScene_Test.json
+++ b/Build/dp_test_results/GameLevelScene_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "GameLevelScene_Test",
-  "passed": true,
-  "frames": 3,
-  "failures": []
-}

--- a/Build/dp_test_results/GameRenderHook_Test.json
+++ b/Build/dp_test_results/GameRenderHook_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "GameRenderHook_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/GymScenes_Test.json
+++ b/Build/dp_test_results/GymScenes_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "GymScenes_Test",
-  "passed": true,
-  "frames": 10,
-  "failures": []
-}

--- a/Build/dp_test_results/HUDLifeBar_Test.json
+++ b/Build/dp_test_results/HUDLifeBar_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "HUDLifeBar_Test",
-  "passed": true,
-  "frames": 8,
-  "failures": []
-}

--- a/Build/dp_test_results/HearingFlow_Test.json
+++ b/Build/dp_test_results/HearingFlow_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "HearingFlow_Test",
-  "passed": true,
-  "frames": 10,
-  "failures": []
-}

--- a/Build/dp_test_results/Hello_Test.json
+++ b/Build/dp_test_results/Hello_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "Hello_Test",
-  "passed": true,
-  "frames": 11,
-  "failures": []
-}

--- a/Build/dp_test_results/ItemPickup_Test.json
+++ b/Build/dp_test_results/ItemPickup_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "ItemPickup_Test",
-  "passed": true,
-  "frames": 7,
-  "failures": []
-}

--- a/Build/dp_test_results/LifeTimer_Test.json
+++ b/Build/dp_test_results/LifeTimer_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "LifeTimer_Test",
-  "passed": true,
-  "frames": 65,
-  "failures": []
-}

--- a/Build/dp_test_results/Materials_Test.json
+++ b/Build/dp_test_results/Materials_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "Materials_Test",
-  "passed": true,
-  "frames": 2,
-  "failures": []
-}

--- a/Build/dp_test_results/MouseWheel_Test.json
+++ b/Build/dp_test_results/MouseWheel_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "MouseWheel_Test",
-  "passed": true,
-  "frames": 6,
-  "failures": []
-}

--- a/Build/dp_test_results/NoiseMachineFlow_Test.json
+++ b/Build/dp_test_results/NoiseMachineFlow_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "NoiseMachineFlow_Test",
-  "passed": true,
-  "frames": 11,
-  "failures": []
-}

--- a/Build/dp_test_results/OrbitCameraStaysFixed_Test.json
+++ b/Build/dp_test_results/OrbitCameraStaysFixed_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "OrbitCameraStaysFixed_Test",
-  "passed": true,
-  "frames": 35,
-  "failures": []
-}

--- a/Build/dp_test_results/PentagramVictory_Test.json
+++ b/Build/dp_test_results/PentagramVictory_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "PentagramVictory_Test",
-  "passed": true,
-  "frames": 36,
-  "failures": []
-}

--- a/Build/dp_test_results/Possession_RoundTrip_Test.json
+++ b/Build/dp_test_results/Possession_RoundTrip_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "Possession_RoundTrip_Test",
-  "passed": true,
-  "frames": 8,
-  "failures": []
-}

--- a/Build/dp_test_results/PostFogHookFires_Test.json
+++ b/Build/dp_test_results/PostFogHookFires_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "PostFogHookFires_Test",
-  "passed": true,
-  "frames": 1,
-  "failures": []
-}

--- a/Build/dp_test_results/PriestBBBridge_Test.json
+++ b/Build/dp_test_results/PriestBBBridge_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "PriestBBBridge_Test",
-  "passed": true,
-  "frames": 10,
-  "failures": []
-}

--- a/Build/dp_test_results/PriestPursuit_Test.json
+++ b/Build/dp_test_results/PriestPursuit_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "PriestPursuit_Test",
-  "passed": true,
-  "frames": 126,
-  "failures": []
-}

--- a/Build/dp_test_results/VillagerDeath_Test.json
+++ b/Build/dp_test_results/VillagerDeath_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "VillagerDeath_Test",
-  "passed": true,
-  "frames": 16,
-  "failures": []
-}

--- a/Build/dp_test_results/VisualWiring_Test.json
+++ b/Build/dp_test_results/VisualWiring_Test.json
@@ -1,6 +1,0 @@
-{
-  "name": "VisualWiring_Test",
-  "passed": true,
-  "frames": 3,
-  "failures": []
-}


### PR DESCRIPTION
## Summary

Adds `Build/dp_test_results/` to `.gitignore` and untracks the 33 per-test JSON files under it. They are run-output artefacts written by the engine harness on every test run -- frame counts vary, so they were producing noisy diffs on every PR that touched the DP tests.

CI artefact upload via `dp-tests.yml`'s `actions/upload-artifact` step still captures the JSONs for download per-run; this PR only stops them from polluting git.

Resolves Q-2026-05-12-004 (a deferred follow-up from the very first DP session).

## Test plan

- [x] `.gitignore` updated
- [x] 33 tracked JSONs removed from index (`git rm --cached`)
- [x] Local rerun of `run_dp_tests.ps1` writes fresh JSONs to the now-untracked directory without complaint
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green (still runs as required check, ignored from artifact upload behaviour)

[Claude Code](https://claude.com/claude-code) co-authored.