### PR TITLE
feat(dp): MVP-0.2.1+2 -- DP_Archetypes accessor + spec test

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -185,6 +185,7 @@
     <ClInclude Include="..\Source\DPFogPass.h" />
     <ClInclude Include="..\Source\DPInputActions.h" />
     <ClInclude Include="..\Source\DPMaterials.h" />
+    <ClInclude Include="..\Source\DP_Archetypes.h" />
     <ClInclude Include="..\Source\DP_LevelData.h" />
     <ClInclude Include="..\Source\DP_Tuning.h" />
     <ClInclude Include="..\Source\PublicInterfaces.h" />
@@ -193,6 +194,7 @@
     <ClCompile Include="..\DevilsPlayground.cpp" />
     <ClCompile Include="..\Source\DPFogPass.cpp" />
     <ClCompile Include="..\Source\DPMaterials.cpp" />
+    <ClCompile Include="..\Source\DP_Archetypes.cpp" />
     <ClCompile Include="..\Source\DP_Tuning.cpp" />
     <ClCompile Include="..\Source\PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_BuildingWallClosure.cpp" />
@@ -216,6 +218,7 @@
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -8,6 +8,9 @@
     <ClCompile Include="..\Source\DPMaterials.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\DP_Archetypes.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source\DP_Tuning.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -75,6 +78,9 @@
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
@@ -167,6 +173,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DPMaterials.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DP_Archetypes.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DP_LevelData.h">

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -479,6 +479,7 @@
     <ClInclude Include="..\Source\DPFogPass.h" />
     <ClInclude Include="..\Source\DPInputActions.h" />
     <ClInclude Include="..\Source\DPMaterials.h" />
+    <ClInclude Include="..\Source\DP_Archetypes.h" />
     <ClInclude Include="..\Source\DP_LevelData.h" />
     <ClInclude Include="..\Source\DP_Tuning.h" />
     <ClInclude Include="..\Source\PublicInterfaces.h" />
@@ -487,6 +488,7 @@
     <ClCompile Include="..\DevilsPlayground.cpp" />
     <ClCompile Include="..\Source\DPFogPass.cpp" />
     <ClCompile Include="..\Source\DPMaterials.cpp" />
+    <ClCompile Include="..\Source\DP_Archetypes.cpp" />
     <ClCompile Include="..\Source\DP_Tuning.cpp" />
     <ClCompile Include="..\Source\PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_BuildingWallClosure.cpp" />
@@ -510,6 +512,7 @@
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -8,6 +8,9 @@
     <ClCompile Include="..\Source\DPMaterials.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\DP_Archetypes.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source\DP_Tuning.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -75,6 +78,9 @@
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
@@ -167,6 +173,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DPMaterials.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DP_Archetypes.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DP_LevelData.h">

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -6,6 +6,7 @@
 #include "Source/DP_LevelData.h"
 #include "Source/DPMaterials.h"
 #include "Source/DP_Tuning.h"
+#include "Source/DP_Archetypes.h"
 
 #include <cstdio>
 #include <cstring>
@@ -71,6 +72,11 @@ namespace DevilsPlayground
 		// can read tuning values during their own bring-up.
 		DP_Tuning::Initialize();
 
+		// MVP-0.2.1+2: Config/Archetypes.json into the archetype cache. Loaded
+		// right after Tuning so DPVillager_Behaviour::OnAwake can consult both.
+		// Idempotent.
+		DP_Archetypes::Initialize();
+
 		// Author Zenith_MaterialAssets from the UE parameter dumps under
 		// Assets/Materials/*.json. Idempotent — safe across Editor Stop/Play.
 		DPMaterials::Initialize();
@@ -106,6 +112,11 @@ namespace DevilsPlayground
 
 		// B6 fog: drop the PFX_Witch config so a relaunch doesn't double-register.
 		DPFogPass::UnregisterParticleConfigs();
+
+		// Drop the archetype cache before tuning -- archetypes don't depend on
+		// tuning, but keep teardown order paired so future cross-deps are
+		// surfaced by the Editor Stop/Play smoke runs. Idempotent.
+		DP_Archetypes::Shutdown();
 
 		// Drop the tuning cache last so materials/fog teardown above can still
 		// query tuning values if they ever start to. Idempotent.

--- a/Games/DevilsPlayground/Source/DP_Archetypes.cpp
+++ b/Games/DevilsPlayground/Source/DP_Archetypes.cpp
@@ -1,0 +1,391 @@
+#include "Zenith.h"
+
+#include "Source/DP_Archetypes.h"
+
+#include "Collections/Zenith_Vector.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+	// ---------------------------------------------------------------------------
+	// Tiny JSON parser (hand-rolled). Mirrors the parser in DP_Tuning.cpp /
+	// DPMaterials.cpp's anonymous namespaces. Per the existing DP_Tuning comment,
+	// the duplication is intentional and scope-controlled; a shared utility lift
+	// is explicitly deferred.
+	// ---------------------------------------------------------------------------
+	enum JsonType : uint8_t
+	{
+		JSON_NULL,
+		JSON_BOOL,
+		JSON_NUMBER,
+		JSON_STRING,
+		JSON_ARRAY,
+		JSON_OBJECT,
+	};
+
+	struct JsonValue
+	{
+		JsonType m_eType = JSON_NULL;
+		double m_fNumber = 0.0;
+		bool m_bBool = false;
+		std::string m_strString;
+		std::vector<JsonValue> m_axArray;
+		std::vector<std::pair<std::string, JsonValue>> m_axObject;
+
+		const JsonValue* FindKey(const char* szKey) const
+		{
+			if (m_eType != JSON_OBJECT) return nullptr;
+			for (const auto& xPair : m_axObject)
+			{
+				if (xPair.first == szKey) return &xPair.second;
+			}
+			return nullptr;
+		}
+	};
+
+	class JsonParser
+	{
+	public:
+		explicit JsonParser(const std::string& strSrc) : m_strSrc(strSrc), m_uPos(0) {}
+
+		bool Parse(JsonValue& xOut)
+		{
+			SkipWhitespace();
+			if (!ParseValue(xOut)) return false;
+			SkipWhitespace();
+			return m_uPos == m_strSrc.size();
+		}
+
+	private:
+		const std::string& m_strSrc;
+		size_t m_uPos;
+
+		bool AtEnd() const { return m_uPos >= m_strSrc.size(); }
+		char Peek() const { return m_strSrc[m_uPos]; }
+
+		void SkipWhitespace()
+		{
+			while (!AtEnd())
+			{
+				char c = m_strSrc[m_uPos];
+				if (c == ' ' || c == '\t' || c == '\n' || c == '\r') ++m_uPos;
+				else break;
+			}
+		}
+
+		bool ParseValue(JsonValue& xOut)
+		{
+			SkipWhitespace();
+			if (AtEnd()) return false;
+			char c = Peek();
+			if (c == '{') return ParseObject(xOut);
+			if (c == '[') return ParseArray(xOut);
+			if (c == '"') return ParseString(xOut);
+			if (c == 't' || c == 'f') return ParseBool(xOut);
+			if (c == 'n') return ParseNull(xOut);
+			if (c == '-' || (c >= '0' && c <= '9')) return ParseNumber(xOut);
+			return false;
+		}
+
+		bool ParseObject(JsonValue& xOut)
+		{
+			xOut.m_eType = JSON_OBJECT;
+			++m_uPos;
+			SkipWhitespace();
+			if (!AtEnd() && Peek() == '}') { ++m_uPos; return true; }
+			while (!AtEnd())
+			{
+				SkipWhitespace();
+				JsonValue xKey;
+				if (!ParseString(xKey)) return false;
+				SkipWhitespace();
+				if (AtEnd() || Peek() != ':') return false;
+				++m_uPos;
+				JsonValue xVal;
+				if (!ParseValue(xVal)) return false;
+				xOut.m_axObject.emplace_back(std::move(xKey.m_strString), std::move(xVal));
+				SkipWhitespace();
+				if (AtEnd()) return false;
+				if (Peek() == ',') { ++m_uPos; continue; }
+				if (Peek() == '}') { ++m_uPos; return true; }
+				return false;
+			}
+			return false;
+		}
+
+		bool ParseArray(JsonValue& xOut)
+		{
+			xOut.m_eType = JSON_ARRAY;
+			++m_uPos;
+			SkipWhitespace();
+			if (!AtEnd() && Peek() == ']') { ++m_uPos; return true; }
+			while (!AtEnd())
+			{
+				JsonValue xVal;
+				if (!ParseValue(xVal)) return false;
+				xOut.m_axArray.push_back(std::move(xVal));
+				SkipWhitespace();
+				if (AtEnd()) return false;
+				if (Peek() == ',') { ++m_uPos; continue; }
+				if (Peek() == ']') { ++m_uPos; return true; }
+				return false;
+			}
+			return false;
+		}
+
+		bool ParseString(JsonValue& xOut)
+		{
+			if (AtEnd() || Peek() != '"') return false;
+			++m_uPos;
+			xOut.m_eType = JSON_STRING;
+			while (!AtEnd())
+			{
+				char c = m_strSrc[m_uPos++];
+				if (c == '"') return true;
+				if (c == '\\' && !AtEnd())
+				{
+					char cEsc = m_strSrc[m_uPos++];
+					switch (cEsc)
+					{
+					case '"': xOut.m_strString.push_back('"'); break;
+					case '\\': xOut.m_strString.push_back('\\'); break;
+					case '/': xOut.m_strString.push_back('/'); break;
+					case 'n': xOut.m_strString.push_back('\n'); break;
+					case 't': xOut.m_strString.push_back('\t'); break;
+					case 'r': xOut.m_strString.push_back('\r'); break;
+					case 'b': xOut.m_strString.push_back('\b'); break;
+					case 'f': xOut.m_strString.push_back('\f'); break;
+					default:  xOut.m_strString.push_back(cEsc); break;
+					}
+				}
+				else
+				{
+					xOut.m_strString.push_back(c);
+				}
+			}
+			return false;
+		}
+
+		bool ParseNumber(JsonValue& xOut)
+		{
+			size_t uStart = m_uPos;
+			if (!AtEnd() && Peek() == '-') ++m_uPos;
+			while (!AtEnd())
+			{
+				char c = Peek();
+				bool bDigit = (c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E'
+				           || c == '+' || c == '-';
+				if (!bDigit) break;
+				++m_uPos;
+			}
+			if (m_uPos == uStart) return false;
+			xOut.m_eType = JSON_NUMBER;
+			std::string strNum = m_strSrc.substr(uStart, m_uPos - uStart);
+			xOut.m_fNumber = std::strtod(strNum.c_str(), nullptr);
+			return true;
+		}
+
+		bool ParseBool(JsonValue& xOut)
+		{
+			if (m_strSrc.compare(m_uPos, 4, "true") == 0)
+			{
+				m_uPos += 4;
+				xOut.m_eType = JSON_BOOL;
+				xOut.m_bBool = true;
+				return true;
+			}
+			if (m_strSrc.compare(m_uPos, 5, "false") == 0)
+			{
+				m_uPos += 5;
+				xOut.m_eType = JSON_BOOL;
+				xOut.m_bBool = false;
+				return true;
+			}
+			return false;
+		}
+
+		bool ParseNull(JsonValue& xOut)
+		{
+			if (m_strSrc.compare(m_uPos, 4, "null") == 0)
+			{
+				m_uPos += 4;
+				xOut.m_eType = JSON_NULL;
+				return true;
+			}
+			return false;
+		}
+	};
+
+	bool LoadJsonFile(const std::filesystem::path& xPath, JsonValue& xOut)
+	{
+		std::ifstream xIn(xPath, std::ios::binary);
+		if (!xIn.is_open()) return false;
+		std::stringstream xBuf;
+		xBuf << xIn.rdbuf();
+		std::string strSrc = xBuf.str();
+		JsonParser xParser(strSrc);
+		return xParser.Parse(xOut);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Cache storage. Stable for the lifetime of the namespace -- Get(id) returns
+	// a pointer into this vector. Linear lookup over the 24 entries is fine; the
+	// API is not called from hot paths.
+	// ---------------------------------------------------------------------------
+	Zenith_Vector<DP_Archetypes::Archetype>* s_pxArchetypes = nullptr;
+	bool s_bInitialized = false;
+
+	// Helper: read a number with a fallback if the key is missing or the wrong
+	// type. JSON-comment / metadata fields (_comment etc.) are silently skipped.
+	float ReadNumber(const JsonValue& xObj, const char* szKey, float fFallback = 0.0f)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_NUMBER) return fFallback;
+		return static_cast<float>(pxV->m_fNumber);
+	}
+
+	int ReadInt(const JsonValue& xObj, const char* szKey, int iFallback = 0)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_NUMBER) return iFallback;
+		return static_cast<int>(pxV->m_fNumber);
+	}
+
+	bool ReadBool(const JsonValue& xObj, const char* szKey, bool bFallback = false)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_BOOL) return bFallback;
+		return pxV->m_bBool;
+	}
+
+	std::string ReadString(const JsonValue& xObj, const char* szKey)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_STRING) return std::string();
+		return pxV->m_strString;
+	}
+
+	void ParseTint(const JsonValue& xObj, DP_Archetypes::Archetype& xOut)
+	{
+		const JsonValue* pxArr = xObj.FindKey("tint_rgb");
+		if (pxArr == nullptr || pxArr->m_eType != JSON_ARRAY) return;
+		if (pxArr->m_axArray.size() < 3) return;
+		const JsonValue& xR = pxArr->m_axArray[0];
+		const JsonValue& xG = pxArr->m_axArray[1];
+		const JsonValue& xB = pxArr->m_axArray[2];
+		if (xR.m_eType == JSON_NUMBER) xOut.tint_r = static_cast<float>(xR.m_fNumber);
+		if (xG.m_eType == JSON_NUMBER) xOut.tint_g = static_cast<float>(xG.m_fNumber);
+		if (xB.m_eType == JSON_NUMBER) xOut.tint_b = static_cast<float>(xB.m_fNumber);
+	}
+
+	const DP_Archetypes::Archetype* FindById(const char* szId)
+	{
+		if (s_pxArchetypes == nullptr) return nullptr;
+		for (u_int u = 0; u < s_pxArchetypes->GetSize(); ++u)
+		{
+			const DP_Archetypes::Archetype& xA = s_pxArchetypes->Get(u);
+			if (xA.id == szId) return &s_pxArchetypes->Get(u);
+		}
+		return nullptr;
+	}
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+namespace DP_Archetypes
+{
+	void Initialize()
+	{
+		if (s_bInitialized) return;
+
+		s_pxArchetypes = new Zenith_Vector<Archetype>();
+
+		const std::filesystem::path xPath =
+			(std::filesystem::path(GAME_ASSETS_DIR) / ".." / "Config" / "Archetypes.json").lexically_normal();
+
+		JsonValue xRoot;
+		if (!LoadJsonFile(xPath, xRoot))
+		{
+			Zenith_Assert(false, "DP_Archetypes: failed to load %s", xPath.string().c_str());
+			return;
+		}
+
+		const JsonValue* pxArr = xRoot.FindKey("archetypes");
+		Zenith_Assert(pxArr != nullptr && pxArr->m_eType == JSON_ARRAY,
+			"DP_Archetypes: 'archetypes' key missing or not an array");
+		if (pxArr == nullptr || pxArr->m_eType != JSON_ARRAY) return;
+
+		for (const auto& xEntry : pxArr->m_axArray)
+		{
+			if (xEntry.m_eType != JSON_OBJECT) continue;
+			Archetype xA;
+			xA.id                   = ReadString(xEntry, "id");
+			xA.display_name_key     = ReadString(xEntry, "display_name_key");
+			xA.mvp                  = ReadBool(xEntry, "mvp", false);
+			xA.life_timer_s         = ReadNumber(xEntry, "life_timer_s");
+			xA.walk_speed_mps       = ReadNumber(xEntry, "walk_speed_mps");
+			xA.jog_speed_mps        = ReadNumber(xEntry, "jog_speed_mps");
+			xA.sprint_speed_mps     = ReadNumber(xEntry, "sprint_speed_mps");
+			xA.possession_channel_s = ReadNumber(xEntry, "possession_channel_s");
+			xA.demon_scent_floor    = ReadNumber(xEntry, "demon_scent_floor");
+			xA.rarity               = ReadNumber(xEntry, "rarity");
+			xA.min_spawns           = ReadInt(xEntry, "min_spawns");
+			xA.max_spawns           = ReadInt(xEntry, "max_spawns");
+			ParseTint(xEntry, xA);
+			if (!xA.id.empty())
+			{
+				s_pxArchetypes->PushBack(xA);
+			}
+		}
+
+		Zenith_Log(LOG_CATEGORY_ASSET,
+			"DP_Archetypes: loaded %zu archetypes from %s",
+			static_cast<size_t>(s_pxArchetypes->GetSize()), xPath.string().c_str());
+
+		s_bInitialized = true;
+	}
+
+	void Shutdown()
+	{
+		if (!s_bInitialized) return;
+		delete s_pxArchetypes;
+		s_pxArchetypes = nullptr;
+		s_bInitialized = false;
+	}
+
+	const Archetype* Get(const char* szId)
+	{
+		Zenith_Assert(s_bInitialized, "DP_Archetypes::Get called before Initialize");
+		const Archetype* pxA = FindById(szId);
+		Zenith_Assert(pxA != nullptr, "DP_Archetypes: unknown archetype id '%s'", szId);
+		return pxA;
+	}
+
+	size_t Count()
+	{
+		if (!s_bInitialized || s_pxArchetypes == nullptr) return 0;
+		return static_cast<size_t>(s_pxArchetypes->GetSize());
+	}
+
+	const Archetype* GetByIndex(size_t uIdx)
+	{
+		if (!s_bInitialized || s_pxArchetypes == nullptr) return nullptr;
+		if (uIdx >= static_cast<size_t>(s_pxArchetypes->GetSize())) return nullptr;
+		return &s_pxArchetypes->Get(static_cast<u_int>(uIdx));
+	}
+
+	bool IsMvp(const char* szId)
+	{
+		const Archetype* pxA = FindById(szId);
+		return pxA != nullptr && pxA->mvp;
+	}
+}

--- a/Games/DevilsPlayground/Source/DP_Archetypes.h
+++ b/Games/DevilsPlayground/Source/DP_Archetypes.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <string>
+
+// ============================================================================
+// DP_Archetypes -- runtime accessor for Devil's Playground villager archetypes.
+//
+// Loads Games/DevilsPlayground/Config/Archetypes.json once at boot and exposes
+// each archetype struct by id via Get(id). The full 24-entry table is loaded
+// regardless of the "mvp": true flag; consumers filter via IsMvp(id) where
+// MVP-only behaviour is required.
+//
+// Asserts on miss for Get(id). Returns nullptr from FindByIndex when out of
+// range. Initialize is idempotent.
+// ============================================================================
+namespace DP_Archetypes
+{
+	struct Archetype
+	{
+		std::string id;
+		std::string display_name_key;
+		bool        mvp                  = false;
+		float       life_timer_s         = 0.0f;
+		float       walk_speed_mps       = 0.0f;
+		float       jog_speed_mps        = 0.0f;
+		float       sprint_speed_mps     = 0.0f;
+		float       possession_channel_s = 0.0f;
+		float       demon_scent_floor    = 0.0f;
+		float       rarity               = 0.0f;
+		int         min_spawns           = 0;
+		int         max_spawns           = 0;
+		float       tint_r               = 1.0f;
+		float       tint_g               = 1.0f;
+		float       tint_b               = 1.0f;
+	};
+
+	void Initialize();
+	void Shutdown();
+
+	// Lookup by archetype id (e.g. "Farmhand"). Asserts on miss.
+	// Pointer is stable for the lifetime of the cache (until Shutdown).
+	const Archetype* Get(const char* szId);
+
+	// Returns total number of archetypes loaded (24 in the ratified config).
+	size_t Count();
+
+	// Returns nullptr if uIdx >= Count().
+	const Archetype* GetByIndex(size_t uIdx);
+
+	// Convenience: true iff Get(szId)->mvp == true.
+	bool IsMvp(const char* szId);
+}

--- a/Games/DevilsPlayground/Tests/Test_P2Archetype_TimersMatchSpec.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Archetype_TimersMatchSpec.cpp
@@ -1,0 +1,254 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "Source/DP_Archetypes.h"
+
+#include <cmath>
+#include <cstring>
+
+// ============================================================================
+// Test_P2Archetype_TimersMatchSpec (MVP-0.2.1)
+//
+// Verifies that the DP_Archetypes subsystem (initialised during
+// DevilsPlayground::InitializeResources) has loaded Config/Archetypes.json
+// and exposes the 4 MVP-priority archetypes with the expected stats.
+//
+// Per TestPlan section 3.1 (updated 2026-05-12), the MVP expectation table
+// contains only Farmhand, Beggar, Devout, Child (Sexton was swapped out for
+// Beggar; see DecisionLog 2026-05-12). The remaining 20 archetypes are
+// present in Archetypes.json with mvp=false; this test does NOT iterate
+// them (Test_P3Inventory_ArchetypeCount in MVP-0.2.4 handles that).
+//
+// Coverage classes:
+//   1. Exact-equality spot checks against the ratified Archetypes.json
+//      (catches accidental edits to load-bearing constants like the 30 s
+//      life timer or movement speed defaults).
+//   2. Cross-archetype invariants (walk < jog < sprint speeds; mvp flag
+//      true for the 4 MVP archetypes and false for the rest).
+//
+// 1-phase pattern: Setup is a no-op, Step terminates on iFrame==0 (no
+// ticking needed -- we're reading cached values), Verify holds all
+// assertions.
+// ============================================================================
+
+namespace
+{
+	int g_iFailures = 0;
+}
+
+static void Setup_P2Archetype_TimersMatchSpec()
+{
+	g_iFailures = 0;
+}
+
+static bool Step_P2Archetype_TimersMatchSpec(int iFrame)
+{
+	(void)iFrame;
+	return false;
+}
+
+static bool CheckFloatEqual(const char* szLabel, float fActual, float fExpected)
+{
+	const float fTol = 0.001f;
+	if (std::fabs(fActual - fExpected) >= fTol)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: '%s' expected %f got %f",
+			szLabel, fExpected, fActual);
+		++g_iFailures;
+		return false;
+	}
+	return true;
+}
+
+static bool CheckIntEqual(const char* szLabel, int iActual, int iExpected)
+{
+	if (iActual != iExpected)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: '%s' expected %d got %d",
+			szLabel, iExpected, iActual);
+		++g_iFailures;
+		return false;
+	}
+	return true;
+}
+
+static bool CheckBoolEqual(const char* szLabel, bool bActual, bool bExpected)
+{
+	if (bActual != bExpected)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: '%s' expected %d got %d",
+			szLabel, bExpected ? 1 : 0, bActual ? 1 : 0);
+		++g_iFailures;
+		return false;
+	}
+	return true;
+}
+
+struct MvpExpect
+{
+	const char* szId;
+	float       fLifeTimer;
+	float       fWalk;
+	float       fJog;
+	float       fSprint;
+	float       fPossessionChannel;
+	float       fDemonScentFloor;
+	int         iMinSpawns;
+	int         iMaxSpawns;
+};
+
+// Ratified Archetypes.json values for the 4 MVP archetypes (TestPlan §3.1
+// expectation table updated 2026-05-12 -- Sexton -> Beggar swap).
+static const MvpExpect g_axMvpExpect[] = {
+	{ "Farmhand", 30.0f, 4.0f, 8.0f, 12.0f, 0.0f, 0.0f, 6, 10 },
+	{ "Beggar",   25.0f, 4.0f, 8.0f, 12.0f, 0.0f, 0.0f, 1,  2 },
+	{ "Devout",   30.0f, 4.0f, 8.0f, 12.0f, 0.8f, 0.4f, 1,  3 },
+	{ "Child",    15.0f, 4.0f, 8.0f, 12.0f, 0.0f, 0.0f, 1,  2 },
+};
+
+static void CheckMvpArchetype(const MvpExpect& xExp)
+{
+	const DP_Archetypes::Archetype* pxA = DP_Archetypes::Get(xExp.szId);
+	if (pxA == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: archetype '%s' not found", xExp.szId);
+		++g_iFailures;
+		return;
+	}
+
+	// 1) MVP flag must be true for the 4 ratified MVP archetypes.
+	{
+		std::string strLabel = std::string(xExp.szId) + ".mvp";
+		CheckBoolEqual(strLabel.c_str(), pxA->mvp, true);
+	}
+
+	// 2) Per-archetype stats. Life timer + spawn ranges vary by archetype
+	//    (Child=15s frail, Beggar=25s, Farmhand+Devout=30s baseline);
+	//    Devout has the unique possession_channel_s=0.8 and demon_scent_floor=0.4
+	//    that gate the "harder to possess + always slightly noticeable" design
+	//    (GDD section 5.4). Test asserts the exact ratified values.
+	{
+		std::string strLabel = std::string(xExp.szId) + ".life_timer_s";
+		CheckFloatEqual(strLabel.c_str(), pxA->life_timer_s, xExp.fLifeTimer);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".walk_speed_mps";
+		CheckFloatEqual(strLabel.c_str(), pxA->walk_speed_mps, xExp.fWalk);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".jog_speed_mps";
+		CheckFloatEqual(strLabel.c_str(), pxA->jog_speed_mps, xExp.fJog);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".sprint_speed_mps";
+		CheckFloatEqual(strLabel.c_str(), pxA->sprint_speed_mps, xExp.fSprint);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".possession_channel_s";
+		CheckFloatEqual(strLabel.c_str(), pxA->possession_channel_s, xExp.fPossessionChannel);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".demon_scent_floor";
+		CheckFloatEqual(strLabel.c_str(), pxA->demon_scent_floor, xExp.fDemonScentFloor);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".min_spawns";
+		CheckIntEqual(strLabel.c_str(), pxA->min_spawns, xExp.iMinSpawns);
+	}
+	{
+		std::string strLabel = std::string(xExp.szId) + ".max_spawns";
+		CheckIntEqual(strLabel.c_str(), pxA->max_spawns, xExp.iMaxSpawns);
+	}
+
+	// 4) Movement speeds must monotonically increase walk < jog < sprint.
+	if (!(pxA->walk_speed_mps < pxA->jog_speed_mps && pxA->jog_speed_mps < pxA->sprint_speed_mps))
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: '%s' movement speeds out of order "
+			"(walk=%f jog=%f sprint=%f)",
+			xExp.szId, pxA->walk_speed_mps, pxA->jog_speed_mps, pxA->sprint_speed_mps);
+		++g_iFailures;
+	}
+
+	// 5) Min/max spawns must be sane (min <= max, both >= 0).
+	if (pxA->min_spawns < 0 || pxA->max_spawns < pxA->min_spawns)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: '%s' spawn range invalid (min=%d max=%d)",
+			xExp.szId, pxA->min_spawns, pxA->max_spawns);
+		++g_iFailures;
+	}
+}
+
+static bool Verify_P2Archetype_TimersMatchSpec()
+{
+	g_iFailures = 0;
+
+	// Per-MVP-archetype spot checks (4 entries) against the ratified table.
+	for (const MvpExpect& xExp : g_axMvpExpect)
+	{
+		CheckMvpArchetype(xExp);
+	}
+
+	// Global invariants on the cache.
+	const size_t uCount = DP_Archetypes::Count();
+	CheckIntEqual("DP_Archetypes::Count() == 24",
+		static_cast<int>(uCount), 24);
+
+	// Exactly 4 archetypes have mvp=true.
+	int iMvpCount = 0;
+	for (size_t u = 0; u < uCount; ++u)
+	{
+		const DP_Archetypes::Archetype* pxA = DP_Archetypes::GetByIndex(u);
+		if (pxA && pxA->mvp) ++iMvpCount;
+	}
+	CheckIntEqual("number of mvp:true archetypes == 4", iMvpCount, 4);
+
+	// Sexton is in the table but is NOT mvp (was demoted to post-MVP per
+	// DecisionLog 2026-05-12). Beggar replaced it.
+	const DP_Archetypes::Archetype* pxSexton = DP_Archetypes::Get("Sexton");
+	if (pxSexton == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: Sexton not found in archetypes "
+			"(should be present with mvp=false)");
+		++g_iFailures;
+	}
+	else
+	{
+		CheckBoolEqual("Sexton.mvp == false (post-MVP demotion)",
+			pxSexton->mvp, false);
+	}
+
+	// IsMvp convenience returns the right answer for both buckets.
+	CheckBoolEqual("IsMvp(Farmhand)", DP_Archetypes::IsMvp("Farmhand"), true);
+	CheckBoolEqual("IsMvp(Sexton)",   DP_Archetypes::IsMvp("Sexton"),   false);
+
+	if (g_iFailures > 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Archetype_TimersMatchSpec: %d assertion(s) failed", g_iFailures);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xArchetypeTimersTest = {
+	"Test_P2Archetype_TimersMatchSpec",
+	&Setup_P2Archetype_TimersMatchSpec,
+	&Step_P2Archetype_TimersMatchSpec,
+	&Verify_P2Archetype_TimersMatchSpec,
+	30, // m_iMaxFrames -- pure cache read; no ticking needed
+	// m_bRequiresGraphics: false -- reads cached config values, doesn't load
+	// scenes or spawn entities. Runs cleanly in headless CI.
+	false
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xArchetypeTimersTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Lands **MVP-0.2.1 + MVP-0.2.2** together (per TDD-in-PR rule):

- **`Source/DP_Archetypes.{h,cpp}`** — runtime accessor that loads `Config/Archetypes.json` (24 entries: 4 MVP + 20 post-MVP) and exposes each archetype struct via `Get(id)`, `GetByIndex(i)`, `Count()`, `IsMvp(id)`. Initialized in `Project_InitializeResources` alongside `DP_Tuning::Initialize`.
- **`Test_P2Archetype_TimersMatchSpec`** asserts the 4 MVP-priority archetypes' ratified stats per TestPlan §3.1 (updated 2026-05-12 — Sexton → Beggar swap).

### MVP archetype expectation table

| Archetype | life_s | walk | jog | sprint | chan_s | scent_floor | min | max |
|-----------|-------:|-----:|----:|-------:|-------:|------------:|----:|----:|
| Farmhand  | 30.0   | 4.0  | 8.0 | 12.0   | 0.0    | 0.0         | 6   | 10  |
| Beggar    | 25.0   | 4.0  | 8.0 | 12.0   | 0.0    | 0.0         | 1   | 2   |
| Devout    | 30.0   | 4.0  | 8.0 | 12.0   | 0.8    | 0.4         | 1   | 3   |
| Child     | 15.0   | 4.0  | 8.0 | 12.0   | 0.0    | 0.0         | 1   | 2   |

Per-archetype life timers genuinely differ — Child = 15s (frail), Beggar = 25s. That's intentional per GDD §5.4 and motivates **MVP-0.2.3** (DPVillager OnAwake reading archetype-specific timer + abilities). For now, the test catches mis-tuning of the JSON while MVP-0.2.3 ships the runtime consumer.

### Global invariants in the test

- `Count() == 24`
- Exactly 4 archetypes with `mvp == true`
- `Sexton` is present with `mvp == false` (post-MVP demotion per DecisionLog 2026-05-12)
- `IsMvp("Farmhand") == true`, `IsMvp("Sexton") == false`
- walk < jog < sprint monotonicity per archetype
- min_spawns ≤ max_spawns

### Test plan

- [x] DP target builds clean (`vs2022_Debug_Win64_True`, `-maxCpuCount:1`)
- [x] `Test_P2Archetype_TimersMatchSpec` PASS per-test
- [x] Full headless batch: 38 passed, 0 failed
- [x] Test tagged `m_bRequiresGraphics = false` (pure cache read, no scene load)
- [ ] dp-build green on PR
- [ ] complexity-gate green on PR
- [ ] dp-tests green on PR

[Claude Code](https://claude.com/claude-code) co-authored.
