### PR TITLE
feat(dp): MVP-0.2.3 -- DPVillager reads archetype-specific stats

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -219,6 +219,7 @@
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -513,6 +513,7 @@
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
@@ -29,6 +29,7 @@
 #include "Source/DPInputActions.h"
 #include "Source/DPMaterials.h"
 #include "Source/DP_Tuning.h"
+#include "Source/DP_Archetypes.h"
 
 #include <cstdio>
 
@@ -49,13 +50,15 @@ public:
 
 	void OnAwake() ZENITH_FINAL override
 	{
-		// MVP-0.1.2: read tuning constants from DP_Tuning (Config/Tuning.json)
-		// instead of hard-coded field initializers. Run before m_fRemainingLife
-		// is seeded below so the timer uses the tuned value. The class-body
-		// initializers (m_fMaxLife = 30.0f, m_fMoveSpeed = 8.0f) are now
-		// fallbacks only; production gameplay always overwrites them here.
-		m_fMaxLife   = DP_Tuning::Get<float>("possession.life_timer_default_s");
-		m_fMoveSpeed = DP_Tuning::Get<float>("movement.jog_speed_mps");
+		// MVP-0.2.3: apply the archetype's life_timer + jog_speed. Archetype
+		// id is stored in m_strArchetypeId; default "Farmhand" matches the
+		// pre-MVP-0.2.3 behaviour (life=30s, jog=8m/s). Per-villager authoring
+		// or test setup can override via ApplyArchetype("Beggar") /
+		// ApplyArchetype("Child") to switch stats before OnAwake fires (call
+		// pattern: SetArchetype on the freshly-attached script before the
+		// Awake wave drains in EditorAutomation), or after OnAwake to retune
+		// at runtime.
+		ApplyArchetype(m_strArchetypeId.c_str());
 
 		// Reset transient state — Editor Stop/Play would otherwise leave a
 		// stale possession flag from a previous play session.
@@ -142,6 +145,59 @@ public:
 
 	float GetRemainingLife() const { return m_fRemainingLife; }
 	float GetMaxLife() const { return m_fMaxLife; }
+	const std::string& GetArchetypeId() const { return m_strArchetypeId; }
+
+	// Re-resolve stats from DP_Archetypes for a new archetype id. Persists
+	// the id and re-seeds m_fMaxLife + m_fMoveSpeed; resets m_fRemainingLife
+	// only if the villager isn't currently possessed (a mid-possession swap
+	// would otherwise interrupt the player's life-timer countdown). MVP-0.2.3
+	// authoring path: scene authoring calls SetArchetype("...") on the
+	// freshly-attached script before the OnAwake wave drains so the entity
+	// awakens with archetype-correct stats. Falls back to DP_Tuning's
+	// possession.life_timer_default_s + movement.jog_speed_mps if the
+	// archetype id is missing or DP_Archetypes wasn't initialized.
+	void ApplyArchetype(const char* szId)
+	{
+		if (szId != nullptr) m_strArchetypeId = szId;
+		float fLife  = DP_Tuning::Get<float>("possession.life_timer_default_s");
+		float fSpeed = DP_Tuning::Get<float>("movement.jog_speed_mps");
+		if (m_strArchetypeId.empty()) m_strArchetypeId = "Farmhand";
+		const DP_Archetypes::Archetype* pxA = nullptr;
+		if (DP_Archetypes::Count() > 0)
+		{
+			// Use FindByIndex linear scan so a missing-id silently falls back
+			// to DP_Tuning rather than asserting (matches the soft-fail style
+			// of LoadModel for missing assets on fresh CI checkouts).
+			for (size_t u = 0; u < DP_Archetypes::Count(); ++u)
+			{
+				const DP_Archetypes::Archetype* pxCandidate = DP_Archetypes::GetByIndex(u);
+				if (pxCandidate && pxCandidate->id == m_strArchetypeId)
+				{
+					pxA = pxCandidate;
+					break;
+				}
+			}
+		}
+		if (pxA != nullptr)
+		{
+			fLife  = pxA->life_timer_s;
+			fSpeed = pxA->jog_speed_mps;
+		}
+		m_fMaxLife   = fLife;
+		m_fMoveSpeed = fSpeed;
+		if (!m_bIsPossessed)
+		{
+			m_fRemainingLife = m_fMaxLife;
+		}
+	}
+
+	// Pre-OnAwake authoring setter: stash the id so the next OnAwake call
+	// resolves with the new archetype. Does NOT immediately apply -- safe to
+	// call from EditorAutomation before the Awake wave fires.
+	void SetArchetype(const char* szId)
+	{
+		if (szId != nullptr) m_strArchetypeId = szId;
+	}
 	// Test-only accessor — MVP-0.1.2's Test_P1Villager_TuningMigration reads
 	// the move speed back to verify it matches DP_Tuning's
 	// movement.jog_speed_mps after OnAwake. Production gameplay never reads
@@ -373,6 +429,11 @@ private:
 
 	float m_fMaxLife        = 30.0f;
 	float m_fRemainingLife  = 30.0f;
+	// MVP-0.2.3: archetype id (resolved at OnAwake via DP_Archetypes). Default
+	// "Farmhand" keeps pre-MVP-0.2.3 stats (life=30s, jog=8m/s) for scenes
+	// that don't yet override per-villager. Updated through SetArchetype()
+	// before OnAwake or ApplyArchetype() at runtime.
+	std::string m_strArchetypeId = "Farmhand";
 	// 8 m/s — a brisk jog. The previous 4 m/s value made the
 	// HumanPlaythrough_Test miss the 3-minute wall-clock budget by a wide
 	// margin; doubling it cuts every walk leg in half without changing

--- a/Games/DevilsPlayground/Tests/Test_P2Villager_ArchetypeStatsApplied.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Villager_ArchetypeStatsApplied.cpp
@@ -1,0 +1,188 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Archetypes.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P2Villager_ArchetypeStatsApplied (MVP-0.2.3)
+//
+// Verifies DPVillager_Behaviour's OnAwake reads archetype-specific stats
+// from DP_Archetypes when SetArchetype is called before the Awake wave
+// drains, and that ApplyArchetype at runtime re-resolves the stats.
+//
+// Coverage:
+//   1. Default ("Farmhand") archetype: life=30s, jog=8m/s. Matches the
+//      pre-MVP-0.2.3 hard-coded values and the post-MVP-0.1.2 DP_Tuning
+//      values exactly -- nothing breaks if a scene's authoring hasn't
+//      called SetArchetype yet.
+//   2. ApplyArchetype("Child") at runtime: life=15s (frail), jog=8m/s.
+//   3. ApplyArchetype("Beggar"): life=25s, jog=8m/s.
+//   4. ApplyArchetype("Devout"): life=30s, jog=8m/s. (Devout's distinct
+//      possession_channel + scent_floor aren't yet consumed by
+//      DPVillager; they're set on the archetype struct for MVP-0.2.4+.)
+//
+// Uses the first authored villager from GameLevel and calls ApplyArchetype
+// directly on it (bypasses authoring API which is deferred per the roadmap
+// note: "AddStep_AttachScript takes archetype id as parameter" is the
+// follow-up that wires archetype assignment through EditorAutomation).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kA_Start, kA_WaitVillager, kA_VerifyDefault, kA_VerifyChild,
+	                   kA_VerifyBeggar, kA_VerifyDevout, kA_Done };
+
+	int  g_iPhase        = kA_Start;
+	bool g_bFoundVillager = false;
+	DPVillager_Behaviour* g_pxVillager = nullptr;
+
+	float g_fDefaultLife  = -1.0f;
+	float g_fDefaultSpeed = -1.0f;
+	float g_fChildLife    = -1.0f;
+	float g_fChildSpeed   = -1.0f;
+	float g_fBeggarLife   = -1.0f;
+	float g_fBeggarSpeed  = -1.0f;
+	float g_fDevoutLife   = -1.0f;
+	float g_fDevoutSpeed  = -1.0f;
+}
+
+static void Setup_P2Villager_ArchetypeStatsApplied()
+{
+	g_iPhase = kA_Start;
+	g_bFoundVillager = false;
+	g_pxVillager = nullptr;
+}
+
+static bool Step_P2Villager_ArchetypeStatsApplied(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kA_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kA_WaitVillager;
+		return true;
+
+	case kA_WaitVillager:
+	{
+		Zenith_EntityID xFoundId;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[](Zenith_EntityID xId, DPVillager_Behaviour& xV) {
+				if (!g_bFoundVillager)
+				{
+					g_bFoundVillager = true;
+					g_pxVillager = &xV;
+					// Capture default ("Farmhand") stats from OnAwake.
+					g_fDefaultLife  = xV.GetMaxLife();
+					g_fDefaultSpeed = xV.GetMoveSpeed();
+				}
+				(void)xId;
+			});
+
+		if (g_pxVillager != nullptr)
+		{
+			g_iPhase = kA_VerifyDefault;
+			return true;
+		}
+		if (iFrame > 120)
+		{
+			g_iPhase = kA_Done;
+			return false;
+		}
+		return true;
+	}
+
+	case kA_VerifyDefault:
+		// Switch to Child and capture.
+		g_pxVillager->ApplyArchetype("Child");
+		g_fChildLife  = g_pxVillager->GetMaxLife();
+		g_fChildSpeed = g_pxVillager->GetMoveSpeed();
+		g_iPhase = kA_VerifyChild;
+		return true;
+
+	case kA_VerifyChild:
+		g_pxVillager->ApplyArchetype("Beggar");
+		g_fBeggarLife  = g_pxVillager->GetMaxLife();
+		g_fBeggarSpeed = g_pxVillager->GetMoveSpeed();
+		g_iPhase = kA_VerifyBeggar;
+		return true;
+
+	case kA_VerifyBeggar:
+		g_pxVillager->ApplyArchetype("Devout");
+		g_fDevoutLife  = g_pxVillager->GetMaxLife();
+		g_fDevoutSpeed = g_pxVillager->GetMoveSpeed();
+		g_iPhase = kA_Done;
+		return false;
+
+	case kA_Done:
+	default:
+		return false;
+	}
+}
+
+static int g_iFailures = 0;
+static void CheckEq(const char* szLabel, float fActual, float fExpected)
+{
+	const float fTol = 0.001f;
+	if (std::fabs(fActual - fExpected) >= fTol)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Villager_ArchetypeStatsApplied: '%s' expected %f got %f",
+			szLabel, fExpected, fActual);
+		++g_iFailures;
+	}
+}
+
+static bool Verify_P2Villager_ArchetypeStatsApplied()
+{
+	if (!g_bFoundVillager)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P2Villager_ArchetypeStatsApplied: no DPVillager_Behaviour in active scene");
+		return false;
+	}
+
+	g_iFailures = 0;
+
+	// 1) Default Farmhand: 30s life, 8m/s jog. Matches pre-MVP-0.2.3.
+	CheckEq("default.life",  g_fDefaultLife,  30.0f);
+	CheckEq("default.speed", g_fDefaultSpeed, 8.0f);
+
+	// 2) Child: 15s life (frail), 8m/s jog.
+	CheckEq("child.life",  g_fChildLife,  15.0f);
+	CheckEq("child.speed", g_fChildSpeed, 8.0f);
+
+	// 3) Beggar: 25s life, 8m/s jog.
+	CheckEq("beggar.life",  g_fBeggarLife,  25.0f);
+	CheckEq("beggar.speed", g_fBeggarSpeed, 8.0f);
+
+	// 4) Devout: 30s life (baseline), 8m/s jog. The distinct
+	//    possession_channel_s + demon_scent_floor that gate Devout-specific
+	//    behaviour are NOT yet consumed by DPVillager -- those land in a
+	//    follow-up (possession-channel migration is a separate MVP item).
+	CheckEq("devout.life",  g_fDevoutLife,  30.0f);
+	CheckEq("devout.speed", g_fDevoutSpeed, 8.0f);
+
+	return g_iFailures == 0;
+}
+
+static const Zenith_AutomatedTest g_xVillagerArchetypeTest = {
+	"Test_P2Villager_ArchetypeStatsApplied",
+	&Setup_P2Villager_ArchetypeStatsApplied,
+	&Step_P2Villager_ArchetypeStatsApplied,
+	&Verify_P2Villager_ArchetypeStatsApplied,
+	180,
+	// m_bRequiresGraphics: this test depends on an authored DPVillager_Behaviour
+	// in GameLevel. CI checkouts without .zmodel assets may not spawn villagers
+	// reliably; tag so headless CI skips and we keep coverage on local windowed.
+	true
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xVillagerArchetypeTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

MVP-0.2.3: `DPVillager_Behaviour` now resolves life-timer + jog-speed from `DP_Archetypes` in `OnAwake`. Archetype id is stored on the behaviour and authoring/tests can switch via `ApplyArchetype("Beggar")`.

## API additions

```cpp
class DPVillager_Behaviour {
public:
    void ApplyArchetype(const char* szId);   // resolves + applies stats now
    void SetArchetype(const char* szId);     // stashes id for next OnAwake
    const std::string& GetArchetypeId() const;
};
```

Default is `"Farmhand"` — matches pre-MVP-0.2.3 stats exactly (life=30s, jog=8m/s) so unmigrated scenes keep current behaviour. Fallback path: if `DP_Archetypes` isn't initialized or the id is missing, `ApplyArchetype` falls back to `DP_Tuning` (post-MVP-0.1.2 values).

## What the new test verifies

`Test_P2Villager_ArchetypeStatsApplied`:
- Loads `GameLevel`, finds the first authored villager → captures default Farmhand stats (30s, 8m/s)
- Calls `ApplyArchetype("Child")` → asserts life=15s (frail), jog=8m/s
- Calls `ApplyArchetype("Beggar")` → asserts life=25s, jog=8m/s
- Calls `ApplyArchetype("Devout")` → asserts life=30s, jog=8m/s

Tagged `m_bRequiresGraphics=true` since the test depends on the authored villager in `GameLevel`.

## Out-of-scope follow-ups

- **`AddStep_AttachScript("DPVillager_Behaviour", "Beggar")`**: per the MvpRoadmap entry, authoring should be able to specify archetype per-villager. The setter `SetArchetype()` is the bridge for now; the engine-side EditorAutomation step-type extension is a separate task.
- **Devout's `possession_channel_s` + `demon_scent_floor`**: set on the archetype struct in PR #19 but not yet consumed by DPVillager. Ships when the possession-channel system lands (post-MVP).

## Test plan

- [x] Builds clean
- [x] `Test_P2Villager_ArchetypeStatsApplied` PASS windowed
- [x] Full headless batch: 40 passed, 0 failed
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green

## Base note

Opened while PR #19 (DP_Archetypes accessor) is still in CI. This PR depends on #19's `Source/DP_Archetypes.h` being on master; will auto-rebase once #19 merges.

[Claude Code](https://claude.com/claude-code) co-authored.
