### PR TITLE
feat(dp): MVP-0.3.3 -- Git LFS .gitattributes patterns for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -46,9 +46,9 @@
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 #*.doc   diff=astextplain
@@ -61,3 +61,46 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# Git LFS (MVP-0.3.3, added 2026-05-13)
+#
+# All binary asset types route through Git LFS instead of being stored inline
+# in pack files. Reasons:
+#   - GitHub has a 100 MB per-file commit limit (already bit us on
+#     opencv_world4100d.dll = 120 MB and slang-llvm.dll = 105 MB; both
+#     are fetched per-CI-run today rather than tracked).
+#   - Repo clones stay small for new contributors who don't need every
+#     historical asset revision.
+#   - Binary diffs are unreadable anyway -- LFS hashing them is a strict
+#     win for git operations.
+#
+# Prerequisite: `git lfs install` must have run on the developer's machine
+# AND on the CI runner. Tracked in ManualSetupChecklist section F.
+#
+# Patterns chosen per the MVP-0.3.3 roadmap entry. Add new binary asset
+# extensions to this section when they appear; do NOT inline-track them.
+###############################################################################
+*.zmodel  filter=lfs diff=lfs merge=lfs -text
+*.zskel   filter=lfs diff=lfs merge=lfs -text
+*.zanim   filter=lfs diff=lfs merge=lfs -text
+*.zmesh   filter=lfs diff=lfs merge=lfs -text
+*.ztxtr   filter=lfs diff=lfs merge=lfs -text
+*.zaudio  filter=lfs diff=lfs merge=lfs -text
+*.spv     filter=lfs diff=lfs merge=lfs -text
+*.fbx     filter=lfs diff=lfs merge=lfs -text
+*.png     filter=lfs diff=lfs merge=lfs -text
+*.jpg     filter=lfs diff=lfs merge=lfs -text
+*.jpeg    filter=lfs diff=lfs merge=lfs -text
+*.tga     filter=lfs diff=lfs merge=lfs -text
+*.dds     filter=lfs diff=lfs merge=lfs -text
+*.exr     filter=lfs diff=lfs merge=lfs -text
+*.hdr     filter=lfs diff=lfs merge=lfs -text
+*.wav     filter=lfs diff=lfs merge=lfs -text
+*.ogg     filter=lfs diff=lfs merge=lfs -text
+*.mp3     filter=lfs diff=lfs merge=lfs -text
+*.flac    filter=lfs diff=lfs merge=lfs -text
+*.gltf    filter=lfs diff=lfs merge=lfs -text
+*.glb     filter=lfs diff=lfs merge=lfs -text
+*.obj     filter=lfs diff=lfs merge=lfs -text
+*.blend   filter=lfs diff=lfs merge=lfs -text

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -220,6 +220,7 @@
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
+    <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -514,6 +514,7 @@
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
+    <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_P3Inventory_ArchetypeCount.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P3Inventory_ArchetypeCount.cpp
@@ -1,0 +1,201 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "Source/DP_Archetypes.h"
+
+#include <cstring>
+
+// ============================================================================
+// Test_P3Inventory_ArchetypeCount (MVP-0.2.4)
+//
+// Proves GDD section 6.2: all 24 archetypes are registered and instantiable.
+//
+// Coverage:
+//   1. DP_Archetypes::Count() == 24 (every entry in Archetypes.json loaded).
+//   2. Each MVP archetype (Farmhand, Beggar, Devout, Child) is queryable
+//      by id and returns a non-empty struct with positive life timer.
+//   3. The full 24-id roster matches the ratified Archetypes.json -- no
+//      ids accidentally renamed, dropped, or duplicated.
+//
+// Per TestPlan section 3.1, post-MVP archetypes (20 entries) sit behind a
+// DP_POST_MVP_ARCHETYPES guard. When that macro is defined the test
+// additionally walks every post-MVP archetype's struct and asserts
+// life_timer > 0 + movement speeds in band. Default build (DP_POST_MVP_
+// ARCHETYPES undefined) skips that sweep; only the count + MVP-4
+// instantiation are asserted.
+// ============================================================================
+
+namespace
+{
+	int g_iFailures = 0;
+
+	// Ratified 24-archetype roster -- order matches Archetypes.json's
+	// "archetypes" array. Adding a new archetype to the JSON requires
+	// adding its id here AND -- per the TestPlan -- gating its post-MVP
+	// behaviour test behind DP_POST_MVP_ARCHETYPES.
+	const char* const g_apszAllArchetypes[] = {
+		"Farmhand", "Sexton", "Devout", "Child",
+		"Carter", "SmithApp", "Beggar", "Stoneborn",
+		"Seer", "Stonemason", "Drunk", "BellRinger",
+		"Cooper", "Weaver", "Miller", "Hunter",
+		"Midwife", "Tinker", "Pilgrim", "Shepherd",
+		"Reeve", "WidowWalker", "Greenwoman", "BlacksmithMaster",
+	};
+	const size_t g_uExpectedCount = sizeof(g_apszAllArchetypes) / sizeof(g_apszAllArchetypes[0]);
+
+	const char* const g_apszMvpArchetypes[] = {
+		"Farmhand", "Beggar", "Devout", "Child",
+	};
+	const size_t g_uExpectedMvpCount = sizeof(g_apszMvpArchetypes) / sizeof(g_apszMvpArchetypes[0]);
+}
+
+static void Setup_P3Inventory_ArchetypeCount()
+{
+	g_iFailures = 0;
+}
+
+static bool Step_P3Inventory_ArchetypeCount(int iFrame)
+{
+	(void)iFrame;
+	return false;
+}
+
+static bool Verify_P3Inventory_ArchetypeCount()
+{
+	g_iFailures = 0;
+
+	// 1) Count invariant.
+	const size_t uActualCount = DP_Archetypes::Count();
+	if (uActualCount != g_uExpectedCount)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P3Inventory_ArchetypeCount: Count()=%zu expected %zu",
+			uActualCount, g_uExpectedCount);
+		++g_iFailures;
+	}
+
+	// 2) Each MVP archetype is queryable and has positive life timer +
+	//    monotonic movement speeds.
+	int iMvpFound = 0;
+	for (const char* szId : g_apszMvpArchetypes)
+	{
+		const DP_Archetypes::Archetype* pxA = DP_Archetypes::Get(szId);
+		if (pxA == nullptr)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: MVP archetype '%s' missing", szId);
+			++g_iFailures;
+			continue;
+		}
+		if (!pxA->mvp)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: '%s' should have mvp=true", szId);
+			++g_iFailures;
+		}
+		if (pxA->life_timer_s <= 0.0f)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: '%s' life_timer_s=%f must be > 0",
+				szId, pxA->life_timer_s);
+			++g_iFailures;
+		}
+		if (!(pxA->walk_speed_mps < pxA->jog_speed_mps && pxA->jog_speed_mps < pxA->sprint_speed_mps))
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: '%s' speeds not monotonic (walk=%f jog=%f sprint=%f)",
+				szId, pxA->walk_speed_mps, pxA->jog_speed_mps, pxA->sprint_speed_mps);
+			++g_iFailures;
+		}
+		++iMvpFound;
+	}
+	if (iMvpFound != static_cast<int>(g_uExpectedMvpCount))
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P3Inventory_ArchetypeCount: found %d MVP archetypes, expected %zu",
+			iMvpFound, g_uExpectedMvpCount);
+		++g_iFailures;
+	}
+
+	// 3) Roster integrity: every expected id is present in the registry and
+	//    every registry id is in the expected roster (no extras / no drops).
+	for (const char* szId : g_apszAllArchetypes)
+	{
+		const DP_Archetypes::Archetype* pxA = DP_Archetypes::Get(szId);
+		if (pxA == nullptr)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: roster archetype '%s' missing from registry",
+				szId);
+			++g_iFailures;
+		}
+	}
+	for (size_t u = 0; u < DP_Archetypes::Count(); ++u)
+	{
+		const DP_Archetypes::Archetype* pxA = DP_Archetypes::GetByIndex(u);
+		if (pxA == nullptr) continue;
+		bool bInRoster = false;
+		for (const char* szId : g_apszAllArchetypes)
+		{
+			if (pxA->id == szId) { bInRoster = true; break; }
+		}
+		if (!bInRoster)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: registry has archetype '%s' "
+				"not in the expected 24-roster (add it to g_apszAllArchetypes or "
+				"remove from Archetypes.json)",
+				pxA->id.c_str());
+			++g_iFailures;
+		}
+	}
+
+#ifdef DP_POST_MVP_ARCHETYPES
+	// 4) Post-MVP archetype sweep: every non-MVP entry has plausible stats.
+	// Only enabled once the post-MVP archetypes are actually implemented
+	// (DP_POST_MVP_ARCHETYPES macro is undefined in the MVP build).
+	for (size_t u = 0; u < DP_Archetypes::Count(); ++u)
+	{
+		const DP_Archetypes::Archetype* pxA = DP_Archetypes::GetByIndex(u);
+		if (pxA == nullptr || pxA->mvp) continue;
+		if (pxA->life_timer_s <= 0.0f)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: post-MVP archetype '%s' life_timer_s=%f must be > 0",
+				pxA->id.c_str(), pxA->life_timer_s);
+			++g_iFailures;
+		}
+		if (!(pxA->walk_speed_mps < pxA->jog_speed_mps && pxA->jog_speed_mps < pxA->sprint_speed_mps))
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_P3Inventory_ArchetypeCount: post-MVP archetype '%s' speeds not monotonic",
+				pxA->id.c_str());
+			++g_iFailures;
+		}
+	}
+#endif // DP_POST_MVP_ARCHETYPES
+
+	if (g_iFailures > 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_P3Inventory_ArchetypeCount: %d assertion(s) failed", g_iFailures);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xArchetypeCountTest = {
+	"Test_P3Inventory_ArchetypeCount",
+	&Setup_P3Inventory_ArchetypeCount,
+	&Step_P3Inventory_ArchetypeCount,
+	&Verify_P3Inventory_ArchetypeCount,
+	30,
+	// m_bRequiresGraphics: false -- reads DP_Archetypes' cached registry,
+	// no scene load or entity spawning required. Runs cleanly in headless CI.
+	false
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xArchetypeCountTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Tools/Test_T0Harness_SessionCloseFlagsExist.ps1
+++ b/Tools/Test_T0Harness_SessionCloseFlagsExist.ps1
@@ -1,0 +1,123 @@
+# Test_T0Harness_SessionCloseFlagsExist.ps1
+#
+# MVP-0.3.1 smoke test: proves Tools/agent_session_close.ps1 parses cleanly
+# under both Windows PowerShell 5.1 and pwsh 7.x, declares the expected
+# -TaskId / -Summary parameters, and exits cleanly on a dry-run invocation.
+#
+# Why static parse-check + dry-run: the script mutates Status.md /
+# DecisionLog.md. A full invocation against the real docs would pollute
+# them with test-only entries. Instead we parse-check (catches parser
+# errors) AND invoke against temp-dir copies of the doc files so the
+# real docs stay untouched.
+#
+# Usage:
+#   powershell -NoProfile -File Tools/Test_T0Harness_SessionCloseFlagsExist.ps1
+#   pwsh -NoProfile -File Tools/Test_T0Harness_SessionCloseFlagsExist.ps1
+#
+# Exit codes:
+#   0 -- script parses cleanly, declares expected params, and successfully
+#        mutates the temp-dir copies.
+#   1 -- any of the above fail.
+#
+# ASCII-only body so PS 5.1 (CP1252 default) can read it without mojibake.
+# See Q-2026-05-12-005.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$script = Join-Path $PSScriptRoot 'agent_session_close.ps1'
+if (-not (Test-Path $script)) {
+    Write-Error "Script not found at $script"
+    exit 1
+}
+
+# 1) Parse-check.
+try {
+    $cmd = Get-Command $script -ErrorAction Stop
+} catch {
+    Write-Error "Failed to parse $script -- $($_.Exception.Message)"
+    exit 1
+}
+
+# 2) Param declarations.
+$expected = @('TaskId', 'Summary', 'RepoRoot')
+$missing = @()
+foreach ($flag in $expected) {
+    if (-not $cmd.Parameters.ContainsKey($flag)) {
+        $missing += $flag
+    }
+}
+if ($missing.Count -gt 0) {
+    Write-Error "Missing expected parameters: $($missing -join ', ')"
+    exit 1
+}
+
+# 3) Dry-run against temp-dir fixtures.
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dp_session_close_test_$([Guid]::NewGuid().ToString('N'))"
+try {
+    $docsDir = Join-Path $tmpRoot 'Games/DevilsPlayground/Docs'
+    New-Item -ItemType Directory -Path $docsDir -Force | Out-Null
+
+    # Minimal fixture content matching the real file shapes the script
+    # expects (## Last completed heading, --- separators).
+    $statusFixture = @"
+# DP Status
+
+**Last updated:** 2026-05-13 (fixture)
+
+## Current task
+
+(none)
+
+## Last completed
+
+- placeholder
+"@
+    Set-Content -Path (Join-Path $docsDir 'Status.md') -Value $statusFixture -NoNewline
+
+    $decisionFixture = @"
+# DP Decision Log
+
+**Purpose:** fixture.
+
+---
+
+## 2026-05-13 -- placeholder
+
+placeholder
+"@
+    Set-Content -Path (Join-Path $docsDir 'DecisionLog.md') -Value $decisionFixture -NoNewline
+
+    $roadmapFixture = @"
+# Devil's Playground -- MVP Roadmap
+
+- [x] **MVP-0.3.1** -- session-end helper (done)
+- [ ] **MVP-0.3.2** -- doc linter
+- [ ] **MVP-0.3.3** -- git LFS
+"@
+    Set-Content -Path (Join-Path $docsDir 'MvpRoadmap.md') -Value $roadmapFixture -NoNewline
+
+    # Invoke. Suppress stdout to keep the test output focused.
+    & $script -TaskId 'TEST-0.0.0' -Summary 'fixture smoke run' -RepoRoot $tmpRoot | Out-Null
+
+    # Verify side-effects.
+    $statusAfter = Get-Content (Join-Path $docsDir 'Status.md') -Raw
+    if ($statusAfter -notmatch 'TEST-0.0.0') {
+        Write-Error "Status.md was not updated with TEST-0.0.0 bullet"
+        exit 1
+    }
+    $decisionAfter = Get-Content (Join-Path $docsDir 'DecisionLog.md') -Raw
+    if ($decisionAfter -notmatch 'TEST-0.0.0') {
+        Write-Error "DecisionLog.md was not updated with TEST-0.0.0 entry"
+        exit 1
+    }
+} finally {
+    if (Test-Path $tmpRoot) {
+        Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "Test_T0Harness_SessionCloseFlagsExist: PASS" -ForegroundColor Green
+exit 0

--- a/Tools/agent_session_close.ps1
+++ b/Tools/agent_session_close.ps1
@@ -1,0 +1,124 @@
+# =============================================================================
+# agent_session_close.ps1 -- MVP-0.3.1 session-end helper.
+#
+# Agents call this at the end of an orchestrator session to:
+#   1. Update Games/DevilsPlayground/Docs/Status.md's "Last completed"
+#      bullet with the just-finished task id + a one-line summary.
+#   2. Append a DecisionLog.md entry with the same summary.
+#   3. Print the next un-checked roadmap task so the next session has
+#      a clear handoff.
+#
+# Usage:
+#   pwsh -NoProfile -File Tools/agent_session_close.ps1 `
+#       -TaskId MVP-0.2.4 `
+#       -Summary "Test_P3Inventory_ArchetypeCount asserts 24-roster + MVP-4 instantiation"
+#
+# Idempotency: the script appends rather than replaces. Running twice with
+# the same -TaskId produces two DecisionLog entries -- by design (each
+# session's append captures the wall-clock time the work landed).
+#
+# ASCII-only body so it parses under both PowerShell 5.1 (powershell.exe)
+# and 7.x (pwsh.exe). See Q-2026-05-12-005.
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TaskId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Summary,
+
+    # Repo root (the directory containing Games/DevilsPlayground/). Defaults
+    # to the script's grandparent (Tools/.. = repo root).
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+
+$statusPath     = Join-Path $RepoRoot 'Games/DevilsPlayground/Docs/Status.md'
+$decisionPath   = Join-Path $RepoRoot 'Games/DevilsPlayground/Docs/DecisionLog.md'
+$roadmapPath    = Join-Path $RepoRoot 'Games/DevilsPlayground/Docs/MvpRoadmap.md'
+
+if (-not (Test-Path $statusPath))   { Write-Error "Status.md not found at $statusPath";   exit 1 }
+if (-not (Test-Path $decisionPath)) { Write-Error "DecisionLog.md not found at $decisionPath"; exit 1 }
+if (-not (Test-Path $roadmapPath))  { Write-Error "MvpRoadmap.md not found at $roadmapPath";  exit 1 }
+
+$today = (Get-Date).ToString("yyyy-MM-dd")
+
+# ----- 1) Update Status.md ---------------------------------------------------
+# Insert a new "Last completed" bullet immediately under the "## Last completed"
+# heading. Preserves the rest of the file untouched. If no such heading exists,
+# fall back to appending at end of file (and warn).
+$statusContent = Get-Content $statusPath -Raw
+$newBullet = "- **$TaskId** ($today) -- $Summary"
+$headingPattern = '(?m)^## Last completed\s*$'
+
+if ($statusContent -match $headingPattern) {
+    # Insert the new bullet right after the heading line.
+    $updated = $statusContent -replace $headingPattern, "## Last completed`n`n$newBullet"
+    Set-Content -Path $statusPath -Value $updated -NoNewline
+    Write-Host "Status.md: prepended '$TaskId' to Last completed" -ForegroundColor Cyan
+} else {
+    Write-Warning "Status.md has no '## Last completed' heading; appending bullet at end."
+    Add-Content -Path $statusPath -Value "`n$newBullet"
+}
+
+# ----- 2) Append to DecisionLog.md -------------------------------------------
+# Insert a new dated entry at the top (just under the "---" separator that
+# follows the file header). Newest entries go first per the file's own
+# format note.
+$decisionContent = Get-Content $decisionPath -Raw
+$entry = @"
+## $today -- $TaskId
+
+$Summary
+
+---
+
+"@
+
+# Find the first "---" separator after the file header and insert the new
+# entry right after it. If no separator found, prepend to the body.
+$lines = $decisionContent -split "`n"
+$insertIdx = -1
+for ($i = 0; $i -lt $lines.Length; $i++) {
+    if ($lines[$i].Trim() -eq '---') {
+        $insertIdx = $i + 1
+        break
+    }
+}
+
+if ($insertIdx -ge 0) {
+    $before = $lines[0..$insertIdx] -join "`n"
+    $after  = if ($insertIdx + 1 -lt $lines.Length) { $lines[($insertIdx + 1)..($lines.Length - 1)] -join "`n" } else { "" }
+    $newContent = $before + "`n" + $entry + $after
+    Set-Content -Path $decisionPath -Value $newContent -NoNewline
+    Write-Host "DecisionLog.md: appended entry for '$TaskId'" -ForegroundColor Cyan
+} else {
+    Write-Warning "DecisionLog.md has no '---' separator after header; appending at end."
+    Add-Content -Path $decisionPath -Value $entry
+}
+
+# ----- 3) Print next un-checked roadmap task ---------------------------------
+$roadmap = Get-Content $roadmapPath
+$nextLine = $null
+foreach ($line in $roadmap) {
+    # Match unchecked bullets like "- [ ] **MVP-X.Y.Z** -- description"
+    if ($line -match '^\- \[ \] \*\*(MVP-\d+\.\d+\.\d+)\*\*\s*--\s*(.+?)\s*$' -or
+        $line -match '^\- \[ \] \*\*(MVP-\d+\.\d+\.\d+)\*\*\s*[—-]+\s*(.+?)\s*$') {
+        $nextLine = "$($matches[1]) -- $($matches[2])"
+        break
+    }
+}
+
+Write-Host ""
+if ($null -ne $nextLine) {
+    Write-Host "Next un-checked roadmap task: $nextLine" -ForegroundColor Green
+} else {
+    Write-Host "No un-checked tasks found in MvpRoadmap.md (Phase 0 complete?)" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "agent_session_close.ps1: done." -ForegroundColor Cyan
+exit 0


### PR DESCRIPTION
## Summary

Routes binary asset extensions through Git LFS. Patterns: `*.zmodel`, `*.zskel`, `*.zanim`, `*.zmesh`, `*.ztxtr`, `*.zaudio`, `*.spv`, `*.fbx`, `*.png`, `*.jpg`, `*.jpeg`, `*.tga`, `*.dds`, `*.exr`, `*.hdr`, `*.wav`, `*.ogg`, `*.mp3`, `*.flac`, `*.gltf`, `*.glb`, `*.obj`, `*.blend`.

## Why this matters

- GitHub's 100 MB per-file commit limit already bit us twice (opencv_world4100d.dll = 120 MB and slang-llvm.dll = 105 MB; both fetched per-CI-run today rather than tracked).
- Retrofitting LFS to existing binary commits is painful and CI-disruptive — lands NOW per the roadmap before Phase 3 binary imports.
- Repo clones stay small for new contributors.

## Prerequisite

`git lfs install` must have run on each developer's machine AND each CI runner. Tracked in ManualSetupChecklist §F. This PR doesn't run the install; it declares the routing.

## Test plan

No smoke test — verification is the diff itself (LFS line patterns visible) plus the next binary asset commit's CI behaviour. Adding a test for LFS would either require runner-side `git lfs` install + fixture (heavy) or duplicate trivial pattern-matching logic.

- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green

## Base note

Stacked on PRs #19/#20/#21/#22. Will auto-rebase as those merge.

[Claude Code](https://claude.com/claude-code) co-authored.