### PR TITLE
feat(dp): MVP-0.3.2 -- doc_lint.ps1 + CI workflow + 10 stale-link fixes

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -1,0 +1,41 @@
+# doc-lint (MVP-0.3.2): cross-document consistency check.
+#
+# Runs Tools/doc_lint.ps1 on every PR + push-to-master. Six checks:
+#   1. Test count consistency across Status / TestPlan / BuildEnvironment /
+#      AgentBriefing / Shortfalls.
+#   2. MVP archetype names agree across docs + Archetypes.json mvp:true.
+#   3. Roadmap task IDs are unique.
+#   4. No [SUPERSEDED] markers in active text (only DecisionLog).
+#   5. No false "X does not exist" claims for files that do exist.
+#   6. Cross-references via markdown links resolve.
+#
+# Each violation is printed in a grep-able single-line form:
+#   VIOLATION [check-id] path:line description
+# CI fails on any violation.
+
+name: doc-lint
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  doc-lint:
+    name: doc-lint
+    runs-on: windows-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run doc_lint.ps1
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File ./Tools/doc_lint.ps1 -ShowPassed
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/Games/DevilsPlayground/Docs/AgentBriefing.md
+++ b/Games/DevilsPlayground/Docs/AgentBriefing.md
@@ -199,7 +199,7 @@ Every PR body uses this template (paste into `gh pr create --body "$(cat <<'EOF'
 <one-line summary>
 
 ## Why
-Closes MVP-X.Y.Z (see [MvpRoadmap.md](../Games/DevilsPlayground/Docs/MvpRoadmap.md)).
+Closes MVP-X.Y.Z (see [MvpRoadmap.md](MvpRoadmap.md)).
 <link to the GDD / Shortfalls / TestPlan section that justifies the change, if relevant>
 
 ## Tests
@@ -305,7 +305,7 @@ pwsh.exe -File Tools/run_dp_tests.ps1 -Filter "Apprehend_PriestCatches" -PerProc
 
 ### 4.6 Parallel agents
 
-Per memory ([feedback_parallel_agents_msbuild_thrash.md](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/feedback_parallel_agents_msbuild_thrash.md)): **default sequential.** mspdbsrv + output-dir locks force one MSBuild at a time. Parallel works only when:
+Per the engine-knowledge note `feedback_parallel_agents_msbuild_thrash` (Claude user-memory): **default sequential.** mspdbsrv + output-dir locks force one MSBuild at a time. Parallel works only when:
 - Tasks touch different files entirely.
 - One agent finishes its build before another starts.
 - You're running asset linter (no MSBuild) or test runner (single build artefact reused).
@@ -346,16 +346,16 @@ These are not deadlines — they're triggers to ask *"is this task ill-defined, 
 
 Read these before you touch code; they're permanent footguns:
 
-- **`std::function` / `std::vector` / `std::mutex` are forbidden in NEW production code** ([memory](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/MEMORY.md)). Use `Zenith_Vector`, `Zenith_Mutex`, function pointers. **Existing prototype code that already uses STL is grandfathered** — `Source/PublicInterfaces.cpp` uses `std::unordered_map` at lines 39, 42, 50; `Source/DPMaterials.cpp` uses it too. These were ported from UE5 and remain until a dedicated cleanup task replaces them with `Zenith_HashMap` (which exists at `Zenith/Collections/Zenith_HashMap.h`). **Do not introduce new STL containers**; if you need to read from or extend grandfathered code, the surrounding STL stays for now. **Test code (wrapped in `#ifdef ZENITH_INPUT_SIMULATOR`) may use STL freely** — `Test_HumanPlaythrough.cpp` uses `std::vector`. Production headers and runtime `.cpp` files added going forward remain strict.
+- **`std::function` / `std::vector` / `std::mutex` are forbidden in NEW production code** (Claude user-memory `MEMORY.md`). Use `Zenith_Vector`, `Zenith_Mutex`, function pointers. **Existing prototype code that already uses STL is grandfathered** — `Source/PublicInterfaces.cpp` uses `std::unordered_map` at lines 39, 42, 50; `Source/DPMaterials.cpp` uses it too. These were ported from UE5 and remain until a dedicated cleanup task replaces them with `Zenith_HashMap` (which exists at `Zenith/Collections/Zenith_HashMap.h`). **Do not introduce new STL containers**; if you need to read from or extend grandfathered code, the surrounding STL stays for now. **Test code (wrapped in `#ifdef ZENITH_INPUT_SIMULATOR`) may use STL freely** — `Test_HumanPlaythrough.cpp` uses `std::vector`. Production headers and runtime `.cpp` files added going forward remain strict.
 - **`Zenith_Vector` has no STL iterators.** Index-based loops only.
-- **Non-tools builds were fixed 2026-05-10** ([memory: project_nontools_build_broken.md](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/project_nontools_build_broken.md)). Easy to regress. *Verify* `*_False` configurations build green before declaring a foundation feature done.
+- **Non-tools builds were fixed 2026-05-10** (Claude user-memory `project_nontools_build_broken`). Easy to regress. *Verify* `*_False` configurations build green before declaring a foundation feature done.
 - **Sharpmake regen required after adding `.cpp` files** — `cd Build && cmd /c '.\Sharpmake_Build.bat < nul'`. Forgetting this means your new file isn't in the solution and tests fail with "not found."
-- **`ZENITH_REGISTER_COMPONENT` doesn't fire if the `.obj` is dead-stripped** ([memory: feedback_msvc_static_init_dead_strip.md](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/feedback_msvc_static_init_dead_strip.md)). Fix by `AddComponent` at runtime from a script that *is* referenced.
-- **Parallel MSBuild thrashes** ([memory: feedback_parallel_agents_msbuild_thrash.md](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/feedback_parallel_agents_msbuild_thrash.md)). Use `-maxCpuCount:1`.
+- **`ZENITH_REGISTER_COMPONENT` doesn't fire if the `.obj` is dead-stripped** (Claude user-memory `feedback_msvc_static_init_dead_strip`). Fix by `AddComponent` at runtime from a script that *is* referenced.
+- **Parallel MSBuild thrashes** (Claude user-memory `feedback_parallel_agents_msbuild_thrash`). Use `-maxCpuCount:1`.
 - **Hanging compiler processes** lock build files. If a build fails on "cannot access file," run `Build/CleanBuild.bat` (kills cl.exe/mspdbsrv.exe).
 - **`SimulateClickOnUIElement` asserts on missing element.** Only call after the element is known to exist in the active scene's canvas.
 - **Tests must be wrapped in `#ifdef ZENITH_INPUT_SIMULATOR`** or they won't compile in non-tools builds.
-- **Scene authoring lives in `Project_RegisterEditorAutomationSteps`** ([memory: feedback_scene_setup_via_editor_automation.md](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/feedback_scene_setup_via_editor_automation.md)). Don't write imperative scene construction; use `AddStep_*` calls. Marble.cpp is the canonical reference.
+- **Scene authoring lives in `Project_RegisterEditorAutomationSteps`** (Claude user-memory `feedback_scene_setup_via_editor_automation`). Don't write imperative scene construction; use `AddStep_*` calls. Marble.cpp is the canonical reference.
 - **DevilsPlayground is in `C:\dev\Zenith\Games\DevilsPlayground\` (main repo)**, NOT in any worktree under `.claude/worktrees/`. Always work on `master` branch.
 - **Engine work is in-scope for autonomous agents** (per user direction 2026-05-12). Subagents may edit anywhere under `Zenith/` for tasks like MVP-0.4 (instrumentation hooks) and MVP-1.2 (navmesh generator). Engine PRs trigger mandatory Reviewer-subagent dispatch (OrchestratorPlaybook §5.4) and a Combat smoke build (catches cross-game regressions). Design rationale logged in `DecisionLog.md` before opening the PR for any net-new engine namespace.
 

--- a/Games/DevilsPlayground/Docs/MvpRoadmap.md
+++ b/Games/DevilsPlayground/Docs/MvpRoadmap.md
@@ -339,7 +339,7 @@ The three playthrough tests that define MVP done.
 
 ## Roadmap meta-rules
 
-- **Sequencing.** Tasks within a sub-section (e.g. 1.3.1–1.3.5) are strictly sequential. Tasks across sub-sections within the same phase (e.g. 1.3.x vs. 1.4.x) can run in parallel agents if Sharpmake regeneration / build-output locks aren't a problem ([per memory](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/feedback_parallel_agents_msbuild_thrash.md): they often are. Default to sequential unless the agent confirms isolation).
+- **Sequencing.** Tasks within a sub-section (e.g. 1.3.1–1.3.5) are strictly sequential. Tasks across sub-sections within the same phase (e.g. 1.3.x vs. 1.4.x) can run in parallel agents if Sharpmake regeneration / build-output locks aren't a problem (per Claude user-memory `feedback_parallel_agents_msbuild_thrash`: they often are. Default to sequential unless the agent confirms isolation).
 - **Branch hygiene.** One PR per task. Branch name `dp/mvp-<task-id>`.
 - **Test-first discipline.** Every task starts with a failing test, ends with a passing test. PRs that change behaviour without a corresponding test change are rejected by the reviewer rubric.
 - **Tuning changes.** Any change to `Config/*.json` is its own PR, separate from code changes. Easier to review and revert.

--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -12,7 +12,7 @@
 
 ### ⚠️ Q-2026-05-12-001 — No CI gate for DP. Auto-merge merges immediately without running DP tests.
 
-**Context:** [.github/workflows/msbuild.yml](../../../.github/workflows/msbuild.yml) builds `Games/Test/Build/zenith_win64.vcxproj` and runs a complexity gate, but does NOT build DP and does NOT run `Tools/run_dp_tests.ps1`. [AgentBriefing.md §3.5](AgentBriefing.md) describes required checks (`build-debug-tools`, `tests-headless`) but they're aspirational, not implemented yet — they're MVP-0.3 territory.
+**Context:** [.github/workflows/complexity.yml](../../../.github/workflows/complexity.yml) (renamed from msbuild.yml in MVP-0.0.2) runs a complexity gate but did not originally build DP or run `Tools/run_dp_tests.ps1` -- those checks landed in MVP-0.0.2 (`dp-build`) and MVP-0.0.3 (`dp-tests`) workflows. [AgentBriefing.md §3.5](AgentBriefing.md) describes required checks (`build-debug-tools`, `tests-headless`) but they're aspirational, not implemented yet — they're MVP-0.3 territory.
 
 **Implication:** `gh pr merge --auto --squash --delete-branch` will merge immediately because there are no DP-relevant required checks. The DP test suite is never validated by CI.
 
@@ -169,4 +169,4 @@ User confirmed:
 - Autonomous agent workflow.
 - Zero external service spend until art assets (then user decides).
 
-See [project_dp_mvp_scope.md](../../../../Users/tomos/.claude/projects/C--dev-Zenith/memory/project_dp_mvp_scope.md) for the durable record.
+See Claude user-memory `project_dp_mvp_scope` for the durable record.

--- a/Tools/doc_lint.ps1
+++ b/Tools/doc_lint.ps1
@@ -1,0 +1,327 @@
+# =============================================================================
+# doc_lint.ps1 -- MVP-0.3.2 documentation cross-check linter.
+#
+# Runs 6 cross-document consistency checks per the round-5 peer-review
+# consensus (see Games/DevilsPlayground/Docs/MvpRoadmap.md MVP-0.3.2 entry):
+#
+#   1. Test count consistency across Status.md / TestPlan.md /
+#      BuildEnvironment.md / AgentBriefing.md / Shortfalls.md.
+#   2. MVP archetype names agree across MVPScope.md / TestPlan.md /
+#      MvpRoadmap.md section 0.2.1 / Archetypes.json "mvp": true entries.
+#   3. Roadmap task IDs are unique within MvpRoadmap.md.
+#   4. No [SUPERSEDED] markers in active doc text (only in DecisionLog).
+#   5. No false "X does not exist" claims for files that DO exist
+#      (recurring stale-claim failure mode).
+#   6. Cross-references via markdown links resolve (no dead (./Path.md)
+#      pointers).
+#
+# Usage:
+#   pwsh -NoProfile -File Tools/doc_lint.ps1
+#   powershell -NoProfile -File Tools/doc_lint.ps1
+#
+# Exit codes:
+#   0 -- all 6 checks pass.
+#   1 -- one or more violations detected (each violation is printed in
+#        a single grep-able line: "VIOLATION [check-id] path:line description").
+#
+# Written in PowerShell to match the existing Tools/ convention
+# (verify_build_env.ps1, run_dp_tests.ps1, agent_session_close.ps1)
+# rather than introduce a new Python dependency. ASCII-only body so
+# PS 5.1 (default CP1252 codepage) can read it without mojibake. See
+# Q-2026-05-12-005 for the parser-error history.
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+
+    # When -Verbose-equivalent: print PASS lines for each check too,
+    # not just the summary. Helpful for CI logs.
+    [switch]$ShowPassed
+)
+
+$ErrorActionPreference = "Stop"
+
+$docsDir = Join-Path $RepoRoot 'Games/DevilsPlayground/Docs'
+$configDir = Join-Path $RepoRoot 'Games/DevilsPlayground/Config'
+
+if (-not (Test-Path $docsDir)) {
+    Write-Error "Docs dir not found: $docsDir"
+    exit 1
+}
+
+# Violation reporter -- prepends VIOLATION tag + check id so failures are
+# easy to grep out of CI logs.
+$script:violations = 0
+function Report-Violation {
+    param([string]$Check, [string]$Msg)
+    Write-Host "VIOLATION [$Check] $Msg" -ForegroundColor Red
+    $script:violations++
+}
+
+function Report-Pass {
+    param([string]$Check, [string]$Msg)
+    if ($ShowPassed) {
+        Write-Host "PASS [$Check] $Msg" -ForegroundColor Green
+    }
+}
+
+# =============================================================================
+# Check 1: test count consistency.
+#
+# Each doc may mention "N tests" or "N/M passing" in its text. The expected
+# number is the count of Test_*.cpp files under Games/DevilsPlayground/Tests/
+# that contain a ZENITH_AUTOMATED_TEST_REGISTER call. Numbers in docs are
+# allowed to undershoot (e.g. "34 tests" while reality is 36) but must not
+# overshoot. Drift is detected as "doc claims N, registry has M, N > M".
+# =============================================================================
+function Check-TestCount {
+    $testsDir = Join-Path $RepoRoot 'Games/DevilsPlayground/Tests'
+    if (-not (Test-Path $testsDir)) {
+        Report-Pass 'C1' "Tests dir missing -- skipping count check"
+        return
+    }
+
+    # Count ZENITH_AUTOMATED_TEST_REGISTER call sites. Each maps to one
+    # registered test. Some .cpp files declare multiple tests; counting
+    # registration calls is the accurate signal.
+    $registerCount = 0
+    Get-ChildItem -Path $testsDir -Filter 'Test_*.cpp' -Recurse | ForEach-Object {
+        $content = Get-Content $_.FullName -Raw
+        $matches = [regex]::Matches($content, 'ZENITH_AUTOMATED_TEST_REGISTER\s*\(')
+        $registerCount += $matches.Count
+    }
+
+    # Doc claim sites. Each docs file may have multiple "N tests" mentions;
+    # report any that overshoot.
+    $docFiles = @(
+        'Status.md',
+        'TestPlan.md',
+        'BuildEnvironment.md',
+        'AgentBriefing.md',
+        'Shortfalls.md'
+    )
+
+    foreach ($docFile in $docFiles) {
+        $path = Join-Path $docsDir $docFile
+        if (-not (Test-Path $path)) { continue }
+        $lines = Get-Content $path
+        for ($i = 0; $i -lt $lines.Length; $i++) {
+            $line = $lines[$i]
+            # Skip approximate / future-projection mentions (~N tests).
+            if ($line -match '~\s*\d') { continue }
+            # Match concrete claims only: "N/M passing|tests", "N tests passing|registered|in the suite".
+            # Bounded to 1-3 digit counts to avoid hits on years like 2026.
+            $claimed = $null
+            if ($line -match '\b(\d{1,3})\s*\/\s*(\d{1,3})\s+(?:tests?|passing)') {
+                # "N/M passing" or "N/M tests" -- claim is N or M, whichever is larger.
+                $a = [int]$matches[1]
+                $b = [int]$matches[2]
+                $claimed = [Math]::Max($a, $b)
+            }
+            elseif ($line -match '\b(\d{1,3})\s+tests?\s+(?:passing|registered|in\s+the\s+suite|in\s+batch)') {
+                $claimed = [int]$matches[1]
+            }
+            if ($null -ne $claimed -and $claimed -gt $registerCount -and $claimed -gt 5) {
+                Report-Violation 'C1' "${docFile}:$($i+1): claims $claimed tests but registry has $registerCount"
+            }
+        }
+    }
+    Report-Pass 'C1' "test-count consistency (registry=$registerCount)"
+}
+
+# =============================================================================
+# Check 2: MVP archetype names agree across docs + JSON.
+# =============================================================================
+function Check-MvpArchetypeNames {
+    $archetypesPath = Join-Path $configDir 'Archetypes.json'
+    if (-not (Test-Path $archetypesPath)) {
+        Report-Pass 'C2' "Archetypes.json missing -- skipping archetype check"
+        return
+    }
+
+    # Parse the MVP archetype list from the JSON. Hand-rolled regex over the
+    # interleaved "id" + "mvp" fields -- the existing DP_Archetypes parser
+    # is C++ and not invokable from here.
+    $jsonContent = Get-Content $archetypesPath -Raw
+    $jsonMvp = New-Object System.Collections.ArrayList
+    # Match each archetype object: capture "id": "X" followed (within ~20
+    # lines) by "mvp": true. PS regex with the dotall (?s) modifier handles
+    # multi-line matches.
+    $entryMatches = [regex]::Matches($jsonContent, '"id"\s*:\s*"([^"]+)"[^{]*?"mvp"\s*:\s*(true|false)', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+    foreach ($m in $entryMatches) {
+        if ($m.Groups[2].Value -eq 'true') {
+            $null = $jsonMvp.Add($m.Groups[1].Value)
+        }
+    }
+
+    if ($jsonMvp.Count -eq 0) {
+        Report-Violation 'C2' "Archetypes.json has no mvp:true entries"
+        return
+    }
+
+    $sortedJson = ($jsonMvp | Sort-Object) -join ','
+
+    # Doc files claim MVP archetype names too. Look for explicit list
+    # expressions like "Farmhand, Beggar, Devout, Child" (the ratified order
+    # documented in DecisionLog 2026-05-12).
+    $docPaths = @(
+        (Join-Path $docsDir 'MVPScope.md'),
+        (Join-Path $docsDir 'TestPlan.md'),
+        (Join-Path $docsDir 'MvpRoadmap.md')
+    )
+    foreach ($path in $docPaths) {
+        if (-not (Test-Path $path)) { continue }
+        $name = Split-Path -Leaf $path
+        $content = Get-Content $path -Raw
+        # Look for any of the JSON-MVP names mentioned in a list context.
+        # If a doc mentions ALL 4 JSON-MVP names, it agrees. If it mentions
+        # OTHER names (e.g. "Sexton" still listed) in an MVP context, that
+        # is a violation -- but "Sexton" can appear in DecisionLog context.
+        # Pragmatic rule: warn only if the JSON-MVP set doesn't appear in
+        # full anywhere in the file.
+        $missing = @()
+        foreach ($id in $jsonMvp) {
+            if ($content -notmatch [regex]::Escape($id)) {
+                $missing += $id
+            }
+        }
+        if ($missing.Count -gt 0) {
+            Report-Violation 'C2' "${name}: doc never mentions MVP archetype(s): $($missing -join ', ') (expected per Archetypes.json mvp:true: $sortedJson)"
+        }
+    }
+    Report-Pass 'C2' "MVP archetype name agreement (JSON mvp:true = $sortedJson)"
+}
+
+# =============================================================================
+# Check 3: roadmap task IDs are unique.
+# =============================================================================
+function Check-RoadmapUniqueIds {
+    $path = Join-Path $docsDir 'MvpRoadmap.md'
+    if (-not (Test-Path $path)) { return }
+
+    $seen = @{}
+    $lines = Get-Content $path
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        if ($lines[$i] -match '\*\*(MVP-\d+\.\d+\.\d+)\*\*') {
+            $id = $matches[1]
+            if ($seen.ContainsKey($id)) {
+                Report-Violation 'C3' "MvpRoadmap.md:$($i+1): duplicate task id '$id' (first seen line $($seen[$id]))"
+            } else {
+                $seen[$id] = $i + 1
+            }
+        }
+    }
+    Report-Pass 'C3' "roadmap task ID uniqueness ($($seen.Count) ids)"
+}
+
+# =============================================================================
+# Check 4: no [SUPERSEDED] markers in active text (only in DecisionLog).
+# =============================================================================
+function Check-SupersededMarkers {
+    Get-ChildItem -Path $docsDir -Filter '*.md' | ForEach-Object {
+        if ($_.Name -eq 'DecisionLog.md') { return }
+        $lines = Get-Content $_.FullName
+        for ($i = 0; $i -lt $lines.Length; $i++) {
+            $line = $lines[$i]
+            # Skip backtick-quoted occurrences (the literal `[SUPERSEDED]`
+            # text being described, e.g. inside this linter's own spec entry
+            # in MvpRoadmap.md). Active text means unquoted.
+            if ($line -match '`\[SUPERSEDED\]`') { continue }
+            if ($line -match '\[SUPERSEDED\]') {
+                Report-Violation 'C4' "$($_.Name):$($i+1): contains [SUPERSEDED] marker (only DecisionLog.md may carry these)"
+            }
+        }
+    }
+    Report-Pass 'C4' "no [SUPERSEDED] markers in active text"
+}
+
+# =============================================================================
+# Check 5: no false "X does not exist" claims for files that DO exist.
+# =============================================================================
+function Check-StaleClaims {
+    Get-ChildItem -Path $docsDir -Filter '*.md' -Recurse | ForEach-Object {
+        $name = $_.Name
+        $lines = Get-Content $_.FullName
+        for ($i = 0; $i -lt $lines.Length; $i++) {
+            $line = $lines[$i]
+            # Match patterns like "FOO.bar does not exist" or "FOO.bar is missing".
+            # The matched filename pattern allows backtick or plain prose mention.
+            $m = [regex]::Match($line, '[`\s](\S+\.(slang|cpp|h|json|md|ps1))[`\s][^.]*?(does not exist|is missing|not present|not yet created)', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+            if ($m.Success) {
+                $claimedFile = $m.Groups[1].Value
+                # Skip URL-like fragments and quoted absolutes.
+                if ($claimedFile -match '^https?:' -or $claimedFile -match '^/') { continue }
+                # Try common locations -- repo root + common Tools/ Source/ etc.
+                $candidates = @(
+                    (Join-Path $RepoRoot $claimedFile),
+                    (Get-ChildItem -Path $RepoRoot -Filter (Split-Path -Leaf $claimedFile) -Recurse -ErrorAction SilentlyContinue -File | Select-Object -First 1 -ExpandProperty FullName)
+                )
+                foreach ($c in $candidates) {
+                    if ($c -and (Test-Path $c)) {
+                        Report-Violation 'C5' "${name}:$($i+1): claims '$claimedFile' does not exist, but it exists at $c"
+                        break
+                    }
+                }
+            }
+        }
+    }
+    Report-Pass 'C5' "no false 'X does not exist' claims"
+}
+
+# =============================================================================
+# Check 6: cross-references via markdown links resolve.
+# =============================================================================
+function Check-MarkdownLinks {
+    Get-ChildItem -Path $docsDir -Filter '*.md' -Recurse | ForEach-Object {
+        $name = $_.Name
+        $dir = $_.DirectoryName
+        $lines = Get-Content $_.FullName
+        for ($i = 0; $i -lt $lines.Length; $i++) {
+            $line = $lines[$i]
+            # Match markdown link targets like (./File.md) or (../Path/File.md).
+            # Skip absolute URLs (http: https: mailto:) and anchors (#section).
+            $linkMatches = [regex]::Matches($line, '\]\(([^)]+)\)')
+            foreach ($m in $linkMatches) {
+                $target = $m.Groups[1].Value
+                # Strip trailing #anchor.
+                $target = ($target -split '#')[0]
+                if ($target -eq '') { continue }
+                # Skip external URLs.
+                if ($target -match '^https?://' -or $target -match '^mailto:') { continue }
+                # Relative path -- resolve against the doc's own directory.
+                try {
+                    $resolved = Join-Path $dir $target
+                    $normalized = [System.IO.Path]::GetFullPath($resolved)
+                    if (-not (Test-Path -LiteralPath $normalized)) {
+                        Report-Violation 'C6' "${name}:$($i+1): broken markdown link: '$target' (resolved to $normalized)"
+                    }
+                } catch {
+                    # Malformed path -- count as broken.
+                    Report-Violation 'C6' "${name}:$($i+1): malformed markdown link: '$target'"
+                }
+            }
+        }
+    }
+    Report-Pass 'C6' "markdown cross-references resolve"
+}
+
+# =============================================================================
+# Run all checks.
+# =============================================================================
+Write-Host "doc_lint.ps1: running 6 checks against $docsDir" -ForegroundColor Cyan
+Check-TestCount
+Check-MvpArchetypeNames
+Check-RoadmapUniqueIds
+Check-SupersededMarkers
+Check-StaleClaims
+Check-MarkdownLinks
+
+Write-Host ""
+if ($script:violations -eq 0) {
+    Write-Host "doc_lint.ps1: ALL CHECKS PASS" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "doc_lint.ps1: $($script:violations) violation(s) found" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## Summary

`Tools/doc_lint.ps1` cross-checks 6 documentation consistency rules per the MVP-0.3.2 roadmap entry (round-5 peer-review consensus):

1. Test count consistency across Status / TestPlan / BuildEnvironment / AgentBriefing / Shortfalls (skips `~N` future projections).
2. MVP archetype names agree across docs + `Archetypes.json` `mvp:true`.
3. Roadmap task IDs are unique.
4. No `[SUPERSEDED]` markers in active text (only DecisionLog).
5. No false 'X does not exist' claims for files that exist.
6. Cross-references via markdown links resolve.

Each violation prints a grep-able `VIOLATION [check-id] path:line description` line.

## Why PowerShell, not Python

Matches the existing Tools/ convention (verify_build_env.ps1, run_dp_tests.ps1, agent_session_close.ps1) and avoids introducing a new Python dependency — the linter runs on every CI cycle. ASCII-only body for PS 5.1 compatibility per Q-2026-05-12-005.

## New CI workflow

`.github/workflows/doc-lint.yml` runs the linter on PR + push-to-master. ~5s per run (no compile, no DLL setup). Not yet a required-checks gate — after a couple of clean runs, the next branch-protection update can add `doc-lint` as a fourth gate alongside `dp-build` / `complexity-gate` / `dp-tests`.

## 10 legitimate findings fixed in this PR

The linter immediately caught real issues:
- **AgentBriefing.md:202**: relative-path bug — link to MvpRoadmap.md from inside same directory had an extra `/Games/DevilsPlayground/Docs/` prefix.
- **8 links** to user-local Claude memory files (`/Users/tomos/.claude/projects/.../memory/*.md`) — never resolved on any other machine. Replaced with plain-text memory-note references.
- **Questions.md:15**: `msbuild.yml` link — renamed to `complexity.yml` in MVP-0.0.2. Updated + clarified the sentence (`dp-build`/`dp-tests` now exist).

## Test plan

- [x] doc_lint.ps1 reports `ALL CHECKS PASS` locally after fixes
- [x] Linter false-positive surface tightened (test-count regex requires `N tests passing/registered/in the suite` or `N/M passing/tests`; SUPERSEDED check skips backtick-quoted occurrences)
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green
- [ ] doc-lint green (the new workflow's first run)

## Base note

Branched fresh from `origin/master` (independent of the in-flight stack #20-#23).

[Claude Code](https://claude.com/claude-code) co-authored.