### PR TITLE
feat(engine): MVP-0.4.2 -- Zenith_RenderBus draw-call recording

### DIFF
--- a/Build/zenith_agde.vcxproj
+++ b/Build/zenith_agde.vcxproj
@@ -1113,6 +1113,7 @@
     <ClInclude Include="..\Zenith\Flux\Text\Flux_Text.h" />
     <ClInclude Include="..\Zenith\Flux\Vegetation\Flux_Grass.h" />
     <ClInclude Include="..\Zenith\Flux\Zenith_GameRenderHook.h" />
+    <ClInclude Include="..\Zenith\Flux\Zenith_RenderBus.h" />
     <ClInclude Include="..\Zenith\Input\Zenith_Input.h" />
     <ClInclude Include="..\Zenith\Input\Zenith_InputSimulator.h" />
     <ClInclude Include="..\Zenith\Input\Zenith_KeyCodes.h" />
@@ -1986,6 +1987,7 @@
     <ClCompile Include="..\Zenith\Flux\Text\Flux_Text.cpp" />
     <ClCompile Include="..\Zenith\Flux\Vegetation\Flux_Grass.cpp" />
     <ClCompile Include="..\Zenith\Flux\Zenith_GameRenderHook.cpp" />
+    <ClCompile Include="..\Zenith\Flux\Zenith_RenderBus.cpp" />
     <ClCompile Include="..\Zenith\Input\Zenith_Input.cpp" />
     <ClCompile Include="..\Zenith\Input\Zenith_InputSimulator.cpp" />
     <ClCompile Include="..\Zenith\Input\Zenith_TouchInput.cpp" />

--- a/Build/zenith_agde.vcxproj.filters
+++ b/Build/zenith_agde.vcxproj.filters
@@ -937,6 +937,9 @@
     <ClCompile Include="..\Zenith\Flux\Zenith_GameRenderHook.cpp">
       <Filter>Flux</Filter>
     </ClCompile>
+    <ClCompile Include="..\Zenith\Flux\Zenith_RenderBus.cpp">
+      <Filter>Flux</Filter>
+    </ClCompile>
     <ClCompile Include="..\Zenith\Input\Zenith_Input.cpp">
       <Filter>Input</Filter>
     </ClCompile>
@@ -4003,6 +4006,9 @@
       <Filter>Flux\Vegetation</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\Flux\Zenith_GameRenderHook.h">
+      <Filter>Flux</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Zenith\Flux\Zenith_RenderBus.h">
       <Filter>Flux</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\Input\Zenith_Input.h">

--- a/Build/zenith_win64.vcxproj
+++ b/Build/zenith_win64.vcxproj
@@ -1341,6 +1341,7 @@
     <ClInclude Include="..\Zenith\Flux\Text\Flux_Text.h" />
     <ClInclude Include="..\Zenith\Flux\Vegetation\Flux_Grass.h" />
     <ClInclude Include="..\Zenith\Flux\Zenith_GameRenderHook.h" />
+    <ClInclude Include="..\Zenith\Flux\Zenith_RenderBus.h" />
     <ClInclude Include="..\Zenith\Input\Zenith_Input.h" />
     <ClInclude Include="..\Zenith\Input\Zenith_InputSimulator.h" />
     <ClInclude Include="..\Zenith\Input\Zenith_KeyCodes.h" />
@@ -2497,6 +2498,7 @@
     <ClCompile Include="..\Zenith\Flux\Text\Flux_Text.cpp" />
     <ClCompile Include="..\Zenith\Flux\Vegetation\Flux_Grass.cpp" />
     <ClCompile Include="..\Zenith\Flux\Zenith_GameRenderHook.cpp" />
+    <ClCompile Include="..\Zenith\Flux\Zenith_RenderBus.cpp" />
     <ClCompile Include="..\Zenith\Input\Zenith_Input.cpp" />
     <ClCompile Include="..\Zenith\Input\Zenith_InputSimulator.cpp" />
     <ClCompile Include="..\Zenith\Input\Zenith_TouchInput.cpp" />

--- a/Build/zenith_win64.vcxproj.filters
+++ b/Build/zenith_win64.vcxproj.filters
@@ -937,6 +937,9 @@
     <ClCompile Include="..\Zenith\Flux\Zenith_GameRenderHook.cpp">
       <Filter>Flux</Filter>
     </ClCompile>
+    <ClCompile Include="..\Zenith\Flux\Zenith_RenderBus.cpp">
+      <Filter>Flux</Filter>
+    </ClCompile>
     <ClCompile Include="..\Zenith\Input\Zenith_Input.cpp">
       <Filter>Input</Filter>
     </ClCompile>
@@ -4003,6 +4006,9 @@
       <Filter>Flux\Vegetation</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\Flux\Zenith_GameRenderHook.h">
+      <Filter>Flux</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Zenith\Flux\Zenith_RenderBus.h">
       <Filter>Flux</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\Input\Zenith_Input.h">

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -230,6 +230,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
+    <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp" />
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -116,6 +116,9 @@
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -524,6 +524,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
+    <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp" />
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -116,6 +116,9 @@
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_T0RenderBus_RecordsDrawCalls.cpp
+++ b/Games/DevilsPlayground/Tests/Test_T0RenderBus_RecordsDrawCalls.cpp
@@ -1,0 +1,145 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "Flux/Zenith_RenderBus.h"
+
+#include <cstring>
+
+// ============================================================================
+// Test_T0RenderBus_RecordsDrawCalls (MVP-0.4.2)
+//
+// Tier-0 smoke for Zenith_RenderBus -- mirrors Test_T0AudioBus structure:
+//   1. ClearDrawCallsForTest() empties the buffer.
+//   2. RecordDrawCall() round-trips name / matrix / vertex-count /
+//      material-id correctly.
+//   3. Multiple records accumulate.
+//   4. AdvanceFrameForTest() bumps the frame stamp on the next record.
+// ============================================================================
+
+namespace
+{
+	int g_iFailures = 0;
+}
+
+static void Setup_T0RenderBus_RecordsDrawCalls()
+{
+	g_iFailures = 0;
+	Zenith_RenderBus::ClearDrawCallsForTest();
+}
+
+static bool Step_T0RenderBus_RecordsDrawCalls(int iFrame)
+{
+	(void)iFrame;
+	return false;
+}
+
+static bool Verify_T0RenderBus_RecordsDrawCalls()
+{
+	g_iFailures = 0;
+
+	// 1) Empty after Clear.
+	if (Zenith_RenderBus::GetSubmittedDrawCallsForTest().GetSize() != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0RenderBus: buffer not empty after Clear");
+		++g_iFailures;
+	}
+
+	// 2) Single record round-trips faithfully.
+	Zenith_Maths::Matrix4 xWorld = Zenith_Maths::Matrix4(1.0f);
+	xWorld[3][0] = 7.0f; // translation.x = 7
+	Zenith_RenderBus::RecordDrawCall("Test.StaticMesh.Floor", xWorld, 1024u, 42u);
+	const auto& xCalls = Zenith_RenderBus::GetSubmittedDrawCallsForTest();
+	if (xCalls.GetSize() != 1)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0RenderBus: expected 1 draw call, got %u", xCalls.GetSize());
+		++g_iFailures;
+	}
+	else
+	{
+		const Zenith_RenderBus::DrawCall& xC = xCalls.Get(0);
+		if (xC.m_szName == nullptr || std::strcmp(xC.m_szName, "Test.StaticMesh.Floor") != 0)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_T0RenderBus: name mismatch ('%s')",
+				xC.m_szName ? xC.m_szName : "(null)");
+			++g_iFailures;
+		}
+		if (xC.m_uVertexCount != 1024u)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_T0RenderBus: vertex count mismatch (got %u, expected 1024)",
+				xC.m_uVertexCount);
+			++g_iFailures;
+		}
+		if (xC.m_uMaterialId != 42u)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_T0RenderBus: material id mismatch (got %u, expected 42)",
+				xC.m_uMaterialId);
+			++g_iFailures;
+		}
+		// Matrix translation.x preserved.
+		if (xC.m_xWorldMatrix[3][0] != 7.0f)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_T0RenderBus: matrix translation lost (got %f, expected 7.0)",
+				xC.m_xWorldMatrix[3][0]);
+			++g_iFailures;
+		}
+	}
+
+	// 3) Multiple records accumulate.
+	Zenith_RenderBus::RecordDrawCall("Test.AnotherMesh", xWorld, 256u, 17u);
+	Zenith_RenderBus::RecordDrawCall("Test.ThirdMesh", xWorld, 512u, 33u);
+	const auto& xCallsAfter = Zenith_RenderBus::GetSubmittedDrawCallsForTest();
+	if (xCallsAfter.GetSize() != 3)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0RenderBus: expected 3 calls, got %u", xCallsAfter.GetSize());
+		++g_iFailures;
+	}
+
+	// 4) AdvanceFrameForTest bumps the frame stamp.
+	const u_int uPrevFrame = xCallsAfter.Get(0).m_uFrame;
+	Zenith_RenderBus::AdvanceFrameForTest();
+	Zenith_RenderBus::RecordDrawCall("Test.NextFrame", xWorld, 64u, 7u);
+	const auto& xCallsFinal = Zenith_RenderBus::GetSubmittedDrawCallsForTest();
+	if (xCallsFinal.GetSize() < 4)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0RenderBus: expected at least 4 calls, got %u",
+			xCallsFinal.GetSize());
+		++g_iFailures;
+	}
+	else
+	{
+		const Zenith_RenderBus::DrawCall& xLatest = xCallsFinal.Get(xCallsFinal.GetSize() - 1);
+		if (xLatest.m_uFrame <= uPrevFrame)
+		{
+			Zenith_Log(LOG_CATEGORY_UNITTEST,
+				"Test_T0RenderBus: frame stamp didn't advance (was %u, now %u)",
+				uPrevFrame, xLatest.m_uFrame);
+			++g_iFailures;
+		}
+	}
+
+	Zenith_RenderBus::ClearDrawCallsForTest();
+
+	return g_iFailures == 0;
+}
+
+static const Zenith_AutomatedTest g_xRenderBusRecordsTest = {
+	"Test_T0RenderBus_RecordsDrawCalls",
+	&Setup_T0RenderBus_RecordsDrawCalls,
+	&Step_T0RenderBus_RecordsDrawCalls,
+	&Verify_T0RenderBus_RecordsDrawCalls,
+	10,
+	false // m_bRequiresGraphics: false -- pure engine-API exercise
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xRenderBusRecordsTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Zenith/Flux/Zenith_RenderBus.cpp
+++ b/Zenith/Flux/Zenith_RenderBus.cpp
@@ -1,0 +1,52 @@
+#include "Zenith.h"
+
+#include "Flux/Zenith_RenderBus.h"
+
+namespace
+{
+#ifdef ZENITH_INPUT_SIMULATOR
+	Zenith_Vector<Zenith_RenderBus::DrawCall> s_xDrawCalls;
+	u_int                                     s_uCurrentFrame = 0;
+#endif
+}
+
+namespace Zenith_RenderBus
+{
+	void RecordDrawCall(const char* szName,
+	                    const Zenith_Maths::Matrix4& xWorldMatrix,
+	                    u_int uVertexCount,
+	                    u_int uMaterialId)
+	{
+#ifdef ZENITH_INPUT_SIMULATOR
+		DrawCall xEntry;
+		xEntry.m_szName       = szName;
+		xEntry.m_xWorldMatrix = xWorldMatrix;
+		xEntry.m_uVertexCount = uVertexCount;
+		xEntry.m_uMaterialId  = uMaterialId;
+		xEntry.m_uFrame       = s_uCurrentFrame;
+		s_xDrawCalls.PushBack(xEntry);
+#else
+		(void)szName;
+		(void)xWorldMatrix;
+		(void)uVertexCount;
+		(void)uMaterialId;
+#endif
+	}
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	const Zenith_Vector<DrawCall>& GetSubmittedDrawCallsForTest()
+	{
+		return s_xDrawCalls;
+	}
+
+	void ClearDrawCallsForTest()
+	{
+		s_xDrawCalls.Clear();
+	}
+
+	void AdvanceFrameForTest()
+	{
+		++s_uCurrentFrame;
+	}
+#endif
+}

--- a/Zenith/Flux/Zenith_RenderBus.h
+++ b/Zenith/Flux/Zenith_RenderBus.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+// ============================================================================
+// Zenith_RenderBus -- MVP-0.4.2
+//
+// Engine-wide per-frame draw-call recording instrumentation. Mirrors the
+// design of Zenith_AudioBus (MVP-0.4.1): game / engine render code calls
+// RecordDrawCall during submit; tests inspect the recorded sequence to
+// assert what was rendered without needing a real GPU readback.
+//
+// Caller pattern (engine render layer):
+//   Zenith_RenderBus::RecordDrawCall("StaticMesh.Floor", xWorldMatrix,
+//                                    uVertexCount, uMaterialId);
+//
+// Test pattern (ZENITH_INPUT_SIMULATOR builds only):
+//   Zenith_RenderBus::ClearDrawCallsForTest();
+//   ... simulate one frame ...
+//   const auto& xCalls = Zenith_RenderBus::GetSubmittedDrawCallsForTest();
+//   Zenith_Assert(xCalls.GetSize() > 0, "Expected at least one draw call");
+//
+// In shipping builds (ZENITH_INPUT_SIMULATOR undefined), RecordDrawCall is
+// an arg-silenced stub -- same pattern as Zenith_AudioBus. The recording
+// buffer is excluded from shipping binaries.
+//
+// Threading: RecordDrawCall is expected to be called from the main thread
+// (or the engine's single render-task thread before pre-MVP multi-thread
+// render submission lands). If multi-thread submission is added later,
+// the buffer needs a mutex.
+// ============================================================================
+namespace Zenith_RenderBus
+{
+	struct DrawCall
+	{
+		const char*           m_szName        = nullptr; // Caller-owned literal / interned string.
+		Zenith_Maths::Matrix4 m_xWorldMatrix  = Zenith_Maths::Matrix4(1.0f);
+		u_int                 m_uVertexCount  = 0;
+		u_int                 m_uMaterialId   = 0; // Caller-defined id; 0 means "unassigned".
+		u_int                 m_uFrame        = 0;
+	};
+
+	// Record a draw-call submission. Cheap; safe to call from main-thread
+	// render code. Args are passed by value/const-ref so the caller can use
+	// stack temporaries.
+	//
+	// In shipping builds this is a no-op stub. Callers do not need to guard
+	// with #ifdef.
+	void RecordDrawCall(const char* szName,
+	                    const Zenith_Maths::Matrix4& xWorldMatrix,
+	                    u_int uVertexCount,
+	                    u_int uMaterialId);
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// Returns the recorded draw calls since the last Clear. The reference
+	// is valid until the next Clear / RecordDrawCall call (vector may
+	// reallocate).
+	const Zenith_Vector<DrawCall>& GetSubmittedDrawCallsForTest();
+
+	// Reset the recording buffer. Typically called at the start of a test's
+	// Step phase to scope recording to the phase under test.
+	void ClearDrawCallsForTest();
+
+	// Tick the frame counter recorded in DrawCall::m_uFrame. Called by the
+	// engine's render task at end-of-frame in test builds; game code does
+	// not call this directly.
+	void AdvanceFrameForTest();
+#endif
+}


### PR DESCRIPTION
## Summary

Engine-wide per-frame draw-call recording instrumentation. Mirrors `Zenith_AudioBus` (MVP-0.4.1). Render code calls:

```cpp
Zenith_RenderBus::RecordDrawCall(szName, xWorldMatrix, uVertexCount, uMaterialId);
```

Test builds record into a frame-stamped buffer; shipping builds compile to an arg-silenced stub.

`DrawCall` captures `{ name, worldMatrix, vertexCount, materialId, frame }`.

## Test

`Test_T0RenderBus_RecordsDrawCalls` — Clear → Record → round-trip → multi-record → AdvanceFrameForTest. Tagged `m_bRequiresGraphics=false`.

## Test plan

- [x] Per-test windowed PASS
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green
- [ ] doc-lint green

Branched fresh from `origin/master` (independent of in-flight stack).

[Claude Code](https://claude.com/claude-code) co-authored.