### PR TITLE
feat(engine): MVP-0.4.3 -- Zenith_SaveSystem skeleton

### DIFF
--- a/Build/zenith_agde.vcxproj.filters
+++ b/Build/zenith_agde.vcxproj.filters
@@ -751,6 +751,9 @@
     <ClCompile Include="..\Zenith\FileAccess\Zenith_FileAccess.cpp">
       <Filter>FileAccess</Filter>
     </ClCompile>
+    <ClCompile Include="..\Zenith\FileAccess\Zenith_SaveSystem.cpp">
+      <Filter>FileAccess</Filter>
+    </ClCompile>
     <ClCompile Include="..\Zenith\Flux\AnimatedMeshes\Flux_AnimatedMeshes.cpp">
       <Filter>Flux\AnimatedMeshes</Filter>
     </ClCompile>
@@ -3490,6 +3493,9 @@
       <Filter>EntityComponent</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\FileAccess\Zenith_FileAccess.h">
+      <Filter>FileAccess</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Zenith\FileAccess\Zenith_SaveSystem.h">
       <Filter>FileAccess</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\Flux\AnimatedMeshes\Flux_AnimatedMeshes.h">

--- a/Build/zenith_win64.vcxproj
+++ b/Build/zenith_win64.vcxproj
@@ -1170,6 +1170,7 @@
     <ClInclude Include="..\Zenith\EntityComponent\Zenith_SceneManager_Internal.h" />
     <ClInclude Include="..\Zenith\EntityComponent\Zenith_SceneOperation.h" />
     <ClInclude Include="..\Zenith\FileAccess\Zenith_FileAccess.h" />
+    <ClInclude Include="..\Zenith\FileAccess\Zenith_SaveSystem.h" />
     <ClInclude Include="..\Zenith\Flux\AnimatedMeshes\Flux_AnimatedMeshes.h" />
     <ClInclude Include="..\Zenith\Flux\Backend\Concepts\Flux_Concept_CommandRecorder.h" />
     <ClInclude Include="..\Zenith\Flux\Backend\Concepts\Flux_Concept_Device.h" />
@@ -2435,6 +2436,7 @@
     <ClCompile Include="..\Zenith\EntityComponent\Zenith_SceneManager.cpp" />
     <ClCompile Include="..\Zenith\EntityComponent\Zenith_SceneOperation.cpp" />
     <ClCompile Include="..\Zenith\FileAccess\Zenith_FileAccess.cpp" />
+    <ClCompile Include="..\Zenith\FileAccess\Zenith_SaveSystem.cpp" />
     <ClCompile Include="..\Zenith\Flux\AnimatedMeshes\Flux_AnimatedMeshes.cpp" />
     <ClCompile Include="..\Zenith\Flux\Backend\Flux_BackendConformance.cpp" />
     <ClCompile Include="..\Zenith\Flux\Decals\Flux_Decals.cpp" />

--- a/Build/zenith_win64.vcxproj.filters
+++ b/Build/zenith_win64.vcxproj.filters
@@ -751,6 +751,9 @@
     <ClCompile Include="..\Zenith\FileAccess\Zenith_FileAccess.cpp">
       <Filter>FileAccess</Filter>
     </ClCompile>
+    <ClCompile Include="..\Zenith\FileAccess\Zenith_SaveSystem.cpp">
+      <Filter>FileAccess</Filter>
+    </ClCompile>
     <ClCompile Include="..\Zenith\Flux\AnimatedMeshes\Flux_AnimatedMeshes.cpp">
       <Filter>Flux\AnimatedMeshes</Filter>
     </ClCompile>
@@ -3490,6 +3493,9 @@
       <Filter>EntityComponent</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\FileAccess\Zenith_FileAccess.h">
+      <Filter>FileAccess</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Zenith\FileAccess\Zenith_SaveSystem.h">
       <Filter>FileAccess</Filter>
     </ClInclude>
     <ClInclude Include="..\Zenith\Flux\AnimatedMeshes\Flux_AnimatedMeshes.h">

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -226,6 +226,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
+    <ClCompile Include="..\Tests\Test_T0SaveSystem_WriteReadRoundTrip.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0SaveSystem_WriteReadRoundTrip.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -520,6 +520,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
+    <ClCompile Include="..\Tests\Test_T0SaveSystem_WriteReadRoundTrip.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0SaveSystem_WriteReadRoundTrip.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_T0SaveSystem_WriteReadRoundTrip.cpp
+++ b/Games/DevilsPlayground/Tests/Test_T0SaveSystem_WriteReadRoundTrip.cpp
@@ -1,0 +1,127 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "FileAccess/Zenith_SaveSystem.h"
+
+#include <cstring>
+
+// ============================================================================
+// Test_T0SaveSystem_WriteReadRoundTrip (MVP-0.4.3)
+//
+// Tier-0 smoke for Zenith_SaveSystem skeleton:
+//   1. ClearForTest() empties store + log + readback stash.
+//   2. WriteBlob -> ReadBlob round-trips key + payload.
+//   3. WriteBlob log records every write.
+//   4. SetReadbackBlob stages a payload that ReadBlob returns.
+//   5. Re-writing the same key OVERWRITES the in-memory store but
+//      APPENDS to the write log (both writes visible to test).
+// ============================================================================
+
+namespace
+{
+	int g_iFailures = 0;
+}
+
+static void Setup_T0SaveSystem_WriteReadRoundTrip()
+{
+	g_iFailures = 0;
+	Zenith_SaveSystem::ClearForTest();
+}
+
+static bool Step_T0SaveSystem_WriteReadRoundTrip(int iFrame)
+{
+	(void)iFrame;
+	return false;
+}
+
+static bool BlobMatches(const Zenith_SaveSystem::Blob* pxBlob, const char* szExpected)
+{
+	if (pxBlob == nullptr) return false;
+	const size_t uLen = std::strlen(szExpected);
+	if (pxBlob->m_xData.GetSize() != static_cast<u_int>(uLen)) return false;
+	for (size_t u = 0; u < uLen; ++u)
+	{
+		if (pxBlob->m_xData.Get(static_cast<u_int>(u)) != static_cast<uint8_t>(szExpected[u]))
+			return false;
+	}
+	return true;
+}
+
+static bool Verify_T0SaveSystem_WriteReadRoundTrip()
+{
+	g_iFailures = 0;
+
+	// 1) Empty after Clear.
+	if (Zenith_SaveSystem::GetWrittenBlobsForTest().GetSize() != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST, "Test_T0SaveSystem: write log not empty after Clear");
+		++g_iFailures;
+	}
+	if (Zenith_SaveSystem::ReadBlob("nonexistent") != nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST, "Test_T0SaveSystem: ReadBlob returned non-null for missing key");
+		++g_iFailures;
+	}
+
+	// 2) Write -> Read round-trip.
+	const char* szPayload = "hello-save";
+	Zenith_SaveSystem::WriteBlob("villager.position", szPayload, std::strlen(szPayload));
+	const Zenith_SaveSystem::Blob* pxRead = Zenith_SaveSystem::ReadBlob("villager.position");
+	if (!BlobMatches(pxRead, szPayload))
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveSystem: round-trip failed for key 'villager.position'");
+		++g_iFailures;
+	}
+
+	// 3) Write log records the write.
+	const auto& xLog = Zenith_SaveSystem::GetWrittenBlobsForTest();
+	if (xLog.GetSize() != 1)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveSystem: expected 1 log entry, got %u", xLog.GetSize());
+		++g_iFailures;
+	}
+
+	// 4) Stash takes precedence -- ReadBlob returns the stash payload even
+	//    when an in-memory store entry exists for the same key.
+	const char* szStash = "from-disk";
+	Zenith_SaveSystem::SetReadbackBlob("villager.position", szStash, std::strlen(szStash));
+	const Zenith_SaveSystem::Blob* pxAfterStash = Zenith_SaveSystem::ReadBlob("villager.position");
+	if (!BlobMatches(pxAfterStash, szStash))
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveSystem: readback stash didn't override store");
+		++g_iFailures;
+	}
+
+	// 5) Re-write APPENDS to the log even when key already present.
+	const char* szPayload2 = "updated-position";
+	Zenith_SaveSystem::WriteBlob("villager.position", szPayload2, std::strlen(szPayload2));
+	const auto& xLogAfter = Zenith_SaveSystem::GetWrittenBlobsForTest();
+	if (xLogAfter.GetSize() != 2)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveSystem: expected 2 log entries after re-write, got %u",
+			xLogAfter.GetSize());
+		++g_iFailures;
+	}
+
+	Zenith_SaveSystem::ClearForTest();
+
+	return g_iFailures == 0;
+}
+
+static const Zenith_AutomatedTest g_xSaveSystemRoundTripTest = {
+	"Test_T0SaveSystem_WriteReadRoundTrip",
+	&Setup_T0SaveSystem_WriteReadRoundTrip,
+	&Step_T0SaveSystem_WriteReadRoundTrip,
+	&Verify_T0SaveSystem_WriteReadRoundTrip,
+	10,
+	false
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xSaveSystemRoundTripTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Zenith/FileAccess/Zenith_SaveSystem.cpp
+++ b/Zenith/FileAccess/Zenith_SaveSystem.cpp
@@ -1,0 +1,144 @@
+#include "Zenith.h"
+
+#include "FileAccess/Zenith_SaveSystem.h"
+
+#include <cstring>
+#include <vector>
+
+namespace
+{
+	// In-memory store, write log, and readback stash. All live in the
+	// anonymous namespace so they aren't visible outside this TU. The
+	// store is keyed by string so ReadBlob(szKey) can find what
+	// WriteBlob(szKey, ...) put in.
+	//
+	// Active in BOTH shipping and test builds for the WriteBlob in-memory
+	// path -- the MVP skeleton doesn't touch disk yet, and game code
+	// reading-then-writing-and-reading-back during a session needs to
+	// round-trip via this in-memory map. The write log + readback stash
+	// (recording APIs) are test-build-only.
+	std::vector<Zenith_SaveSystem::Blob> s_xStore;
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	Zenith_Vector<Zenith_SaveSystem::Blob> s_xWriteLog;
+	std::vector<Zenith_SaveSystem::Blob>   s_xReadbackStash;
+	u_int                                  s_uCurrentFrame = 0;
+#endif
+
+	// Linear-search helper -- key counts are small for MVP gameplay (well
+	// under 100), no need for a hash map.
+	Zenith_SaveSystem::Blob* FindByKey(std::vector<Zenith_SaveSystem::Blob>& xStore,
+	                                    const char* szKey)
+	{
+		if (szKey == nullptr) return nullptr;
+		for (auto& xBlob : xStore)
+		{
+			if (xBlob.m_strKey == szKey) return &xBlob;
+		}
+		return nullptr;
+	}
+}
+
+namespace Zenith_SaveSystem
+{
+	void WriteBlob(const char* szKey, const void* pData, size_t ulSize)
+	{
+		if (szKey == nullptr) return;
+
+		// Update or insert in the in-memory store.
+		Blob* pxExisting = FindByKey(s_xStore, szKey);
+		Blob xNew;
+		xNew.m_strKey = szKey;
+		xNew.m_xData.Clear();
+		if (pData != nullptr && ulSize > 0)
+		{
+			xNew.m_xData.Reserve(static_cast<u_int>(ulSize));
+			const uint8_t* pxBytes = static_cast<const uint8_t*>(pData);
+			for (size_t u = 0; u < ulSize; ++u)
+			{
+				xNew.m_xData.PushBack(pxBytes[u]);
+			}
+		}
+#ifdef ZENITH_INPUT_SIMULATOR
+		xNew.m_uFrame = s_uCurrentFrame;
+#endif
+
+		if (pxExisting != nullptr)
+		{
+			*pxExisting = xNew;
+		}
+		else
+		{
+			s_xStore.push_back(xNew);
+		}
+
+#ifdef ZENITH_INPUT_SIMULATOR
+		// Always append to the write log so tests see every write, not just
+		// the final state of each key.
+		s_xWriteLog.PushBack(xNew);
+#endif
+	}
+
+	const Blob* ReadBlob(const char* szKey)
+	{
+		if (szKey == nullptr) return nullptr;
+
+#ifdef ZENITH_INPUT_SIMULATOR
+		// Readback stash takes precedence over the in-memory store -- it's
+		// how tests inject "what disk would have returned" without actually
+		// writing first.
+		Blob* pxStash = FindByKey(s_xReadbackStash, szKey);
+		if (pxStash != nullptr) return pxStash;
+#endif
+
+		Blob* pxFound = FindByKey(s_xStore, szKey);
+		return pxFound;
+	}
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	const Zenith_Vector<Blob>& GetWrittenBlobsForTest()
+	{
+		return s_xWriteLog;
+	}
+
+	void SetReadbackBlob(const char* szKey, const void* pData, size_t ulSize)
+	{
+		if (szKey == nullptr) return;
+		Blob xBlob;
+		xBlob.m_strKey = szKey;
+		if (pData != nullptr && ulSize > 0)
+		{
+			const uint8_t* pxBytes = static_cast<const uint8_t*>(pData);
+			xBlob.m_xData.Reserve(static_cast<u_int>(ulSize));
+			for (size_t u = 0; u < ulSize; ++u)
+			{
+				xBlob.m_xData.PushBack(pxBytes[u]);
+			}
+		}
+		xBlob.m_uFrame = s_uCurrentFrame;
+
+		// Update or insert in the readback stash.
+		Blob* pxExisting = FindByKey(s_xReadbackStash, szKey);
+		if (pxExisting != nullptr)
+		{
+			*pxExisting = xBlob;
+		}
+		else
+		{
+			s_xReadbackStash.push_back(xBlob);
+		}
+	}
+
+	void ClearForTest()
+	{
+		s_xStore.clear();
+		s_xWriteLog.Clear();
+		s_xReadbackStash.clear();
+	}
+
+	void AdvanceFrameForTest()
+	{
+		++s_uCurrentFrame;
+	}
+#endif
+}

--- a/Zenith/FileAccess/Zenith_SaveSystem.h
+++ b/Zenith/FileAccess/Zenith_SaveSystem.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "Collections/Zenith_Vector.h"
+
+#include <cstdint>
+#include <string>
+
+// ============================================================================
+// Zenith_SaveSystem -- MVP-0.4.3 skeleton
+//
+// Engine save/load surface. The MVP skeleton doesn't touch disk yet -- it
+// exposes write/read entry points and per-test recording so save-related
+// tests can assert what would be persisted without actually serialising to
+// the filesystem. The post-MVP implementation will route the same calls
+// through the real Zenith_FileAccess platform path.
+//
+// Caller pattern (game code):
+//   Zenith_SaveSystem::WriteBlob("villager.position", pData, ulSize);
+//   const Blob* pxBlob = Zenith_SaveSystem::ReadBlob("villager.position");
+//
+// Test pattern (ZENITH_INPUT_SIMULATOR builds only):
+//   Zenith_SaveSystem::ClearForTest();
+//   // Stage a readback so the next ReadBlob returns this payload.
+//   Zenith_SaveSystem::SetReadbackBlob("villager.position", payload, n);
+//   ... run gameplay that calls Write/Read ...
+//   const auto& xWrites = Zenith_SaveSystem::GetWrittenBlobsForTest();
+//   Zenith_Assert(xWrites.GetSize() > 0, "Expected a write");
+//
+// Threading: WriteBlob / ReadBlob are main-thread only by contract. Async
+// save lands post-MVP.
+// ============================================================================
+namespace Zenith_SaveSystem
+{
+	struct Blob
+	{
+		std::string m_strKey;
+		Zenith_Vector<uint8_t> m_xData;
+		u_int       m_uFrame = 0;
+	};
+
+	// Persist a payload under a key. MVP skeleton stores it in-memory keyed
+	// by key (overwriting any previous value at the same key) AND -- in
+	// test builds -- appends an entry to the per-frame write log so tests
+	// can audit what was written and when.
+	void WriteBlob(const char* szKey, const void* pData, size_t ulSize);
+
+	// Retrieve a payload by key. Returns nullptr if no payload exists for
+	// szKey. In test builds, SetReadbackBlob() stages a payload that
+	// ReadBlob will return for that key.
+	const Blob* ReadBlob(const char* szKey);
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// Returns the write log since the last ClearForTest. The reference is
+	// valid until the next Clear / WriteBlob (vector may reallocate).
+	const Zenith_Vector<Blob>& GetWrittenBlobsForTest();
+
+	// Stage a payload so ReadBlob(szKey) returns it. Multiple SetReadback
+	// calls for different keys are independent. The stash survives across
+	// WriteBlob calls -- only ClearForTest wipes it.
+	void SetReadbackBlob(const char* szKey, const void* pData, size_t ulSize);
+
+	// Wipe the in-memory store, the write log, and the readback stash.
+	void ClearForTest();
+
+	// Tick the frame counter recorded in Blob::m_uFrame. Engine frame loop
+	// calls this in test builds; game code does not.
+	void AdvanceFrameForTest();
+#endif
+}


### PR DESCRIPTION
## Summary

Engine save/load surface skeleton — no disk yet. MVP gameplay rounds-trips writes via an in-memory store; the post-MVP implementation will route the same calls through `Zenith_FileAccess`.

```cpp
Zenith_SaveSystem::WriteBlob("villager.position", pData, ulSize);
const Blob* pxBlob = Zenith_SaveSystem::ReadBlob("villager.position");
```

Test builds add `GetWrittenBlobsForTest()` / `SetReadbackBlob()` / `ClearForTest()` / `AdvanceFrameForTest()`. Readback stash takes precedence over the in-memory store so tests can inject 'what disk would have returned' without writing first.

## Test

`Test_T0SaveSystem_WriteReadRoundTrip` — Clear → Write+Read round-trip → log captures writes → stash overrides store → re-write appends to log. Tagged `m_bRequiresGraphics=false`.

## Test plan

- [x] Per-test windowed PASS
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green
- [ ] doc-lint green

Branched fresh from `origin/master`.

[Claude Code](https://claude.com/claude-code) co-authored.