### PR TITLE
feat(engine): MVP-0.4.4 -- Zenith_NavMesh::GetQueryCountForTest

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -231,6 +231,7 @@
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp" />
+    <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp" />
     <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp" />
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -525,6 +525,7 @@
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp" />
+    <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp" />
     <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp" />
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_T0NavMesh_QueryCountIncrements.cpp
+++ b/Games/DevilsPlayground/Tests/Test_T0NavMesh_QueryCountIncrements.cpp
@@ -1,0 +1,98 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "AI/Navigation/Zenith_NavMesh.h"
+#include "AI/Navigation/Zenith_Pathfinding.h"
+#include "Maths/Zenith_Maths.h"
+
+// ============================================================================
+// Test_T0NavMesh_QueryCountIncrements (MVP-0.4.4)
+//
+// Tier-0 smoke for Zenith_NavMesh::GetQueryCountForTest:
+//   1. ResetQueryCountForTest() zeroes the counter.
+//   2. Each Zenith_Pathfinding::FindPath call increments by exactly 1.
+//   3. FindPath calls against an empty navmesh still increment (the counter
+//      is per-call, not per-success).
+//
+// Pure engine-API exercise -- no scene, no entity, no graphics. Builds a
+// trivial empty NavMesh and runs FindPath against it (which will return
+// FAILED since there are no polygons; the counter still ticks).
+// ============================================================================
+
+namespace
+{
+	int g_iFailures = 0;
+}
+
+static void Setup_T0NavMesh_QueryCountIncrements()
+{
+	g_iFailures = 0;
+	Zenith_NavMesh::ResetQueryCountForTest();
+}
+
+static bool Step_T0NavMesh_QueryCountIncrements(int iFrame)
+{
+	(void)iFrame;
+	return false;
+}
+
+static bool Verify_T0NavMesh_QueryCountIncrements()
+{
+	g_iFailures = 0;
+
+	// 1) Reset leaves the counter at 0.
+	if (Zenith_NavMesh::GetQueryCountForTest() != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0NavMesh: counter not zero after Reset (got %u)",
+			Zenith_NavMesh::GetQueryCountForTest());
+		++g_iFailures;
+	}
+
+	// 2) Build a minimal empty navmesh and issue 3 path queries. The counter
+	//    should land at 3 regardless of pathfinding result. Empty navmesh =>
+	//    Zenith_Pathfinding::FindPath returns FAILED; we don't care about
+	//    the result, only that the counter ticked.
+	Zenith_NavMesh xEmptyMesh;
+	const Zenith_Maths::Vector3 xStart(0.0f, 0.0f, 0.0f);
+	const Zenith_Maths::Vector3 xEnd(10.0f, 0.0f, 10.0f);
+
+	(void)Zenith_Pathfinding::FindPath(xEmptyMesh, xStart, xEnd);
+	(void)Zenith_Pathfinding::FindPath(xEmptyMesh, xStart, xEnd);
+	(void)Zenith_Pathfinding::FindPath(xEmptyMesh, xStart, xEnd);
+
+	const u_int uAfterThree = Zenith_NavMesh::GetQueryCountForTest();
+	if (uAfterThree != 3)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0NavMesh: expected counter=3 after 3 FindPath calls, got %u",
+			uAfterThree);
+		++g_iFailures;
+	}
+
+	// 3) ResetQueryCountForTest puts it back at zero.
+	Zenith_NavMesh::ResetQueryCountForTest();
+	if (Zenith_NavMesh::GetQueryCountForTest() != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0NavMesh: Reset didn't clear (counter=%u)",
+			Zenith_NavMesh::GetQueryCountForTest());
+		++g_iFailures;
+	}
+
+	return g_iFailures == 0;
+}
+
+static const Zenith_AutomatedTest g_xNavMeshQueryCountTest = {
+	"Test_T0NavMesh_QueryCountIncrements",
+	&Setup_T0NavMesh_QueryCountIncrements,
+	&Step_T0NavMesh_QueryCountIncrements,
+	&Verify_T0NavMesh_QueryCountIncrements,
+	10,
+	false // m_bRequiresGraphics: false -- pure pathfinding-API exercise
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xNavMeshQueryCountTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Zenith/AI/Navigation/Zenith_NavMesh.cpp
+++ b/Zenith/AI/Navigation/Zenith_NavMesh.cpp
@@ -219,6 +219,31 @@ void Zenith_NavMeshPolygon::ReadFromDataStream(Zenith_DataStream& xStream)
 
 // ========== Zenith_NavMesh ==========
 
+#ifdef ZENITH_INPUT_SIMULATOR
+namespace
+{
+	// MVP-0.4.4: per-process FindPath query counter. Lives in the anonymous
+	// namespace so it stays a TU-local static; the three accessors below
+	// expose it through the class API.
+	u_int s_uFindPathQueryCount = 0;
+}
+
+u_int Zenith_NavMesh::GetQueryCountForTest()
+{
+	return s_uFindPathQueryCount;
+}
+
+void Zenith_NavMesh::ResetQueryCountForTest()
+{
+	s_uFindPathQueryCount = 0;
+}
+
+void Zenith_NavMesh::IncrementQueryCountForTest_Internal()
+{
+	++s_uFindPathQueryCount;
+}
+#endif
+
 void Zenith_NavMesh::Clear()
 {
 	m_axVertices.Clear();

--- a/Zenith/AI/Navigation/Zenith_NavMesh.h
+++ b/Zenith/AI/Navigation/Zenith_NavMesh.h
@@ -249,6 +249,26 @@ public:
 	const Zenith_Maths::Vector3& GetBoundsMin() const { return m_xBoundsMin; }
 	const Zenith_Maths::Vector3& GetBoundsMax() const { return m_xBoundsMax; }
 
+#ifdef ZENITH_INPUT_SIMULATOR
+	// ========== Test instrumentation (MVP-0.4.4) ==========
+	//
+	// Per-process counter incremented every time Zenith_Pathfinding::FindPath
+	// is called. Used by tests asserting "the priest issued at most N path
+	// queries during the test window" without needing to instrument
+	// Priest_Behaviour or the AI agent. Owned by the navmesh namespace
+	// because the counter is a property of the navigation system as a whole
+	// rather than any single NavMesh instance.
+	//
+	// API:
+	//   GetQueryCountForTest() -- returns the live counter.
+	//   ResetQueryCountForTest() -- zero the counter (call at test setup).
+	//   IncrementQueryCountForTest_Internal() -- called by FindPath. Not
+	//       intended for direct use; the suffix flags it as engine-internal.
+	static u_int GetQueryCountForTest();
+	static void  ResetQueryCountForTest();
+	static void  IncrementQueryCountForTest_Internal();
+#endif
+
 	// ========== Serialization ==========
 
 	void WriteToDataStream(Zenith_DataStream& xStream) const;

--- a/Zenith/AI/Navigation/Zenith_Pathfinding.cpp
+++ b/Zenith/AI/Navigation/Zenith_Pathfinding.cpp
@@ -130,6 +130,14 @@ Zenith_PathResult Zenith_Pathfinding::FindPath(const Zenith_NavMesh& xNavMesh,
 	const Zenith_Maths::Vector3& xEnd)
 {
 	Zenith_Profiling::Scope xProfileScope(ZENITH_PROFILE_INDEX__AI_PATHFINDING);
+#ifdef ZENITH_INPUT_SIMULATOR
+	// MVP-0.4.4: count every public FindPath call so tests can assert
+	// query-volume contracts (e.g. "priest issued <= N path queries
+	// during the test window"). FindPathInternal is called from
+	// AsyncWorker too; we only count the public-facing call so the
+	// async-internal recompute path doesn't double-count.
+	Zenith_NavMesh::IncrementQueryCountForTest_Internal();
+#endif
 	return FindPathInternal(xNavMesh, xStart, xEnd);
 }
 


### PR DESCRIPTION
## Summary

Per-process FindPath query counter. Final Phase 0.4 instrumentation item — with MVP-0.4.1/.4.2/.4.3/.4.4 all merged, the TestPlan §0.4 instrumentation surface is complete.

```cpp
u_int Zenith_NavMesh::GetQueryCountForTest();
void  Zenith_NavMesh::ResetQueryCountForTest();
```

Wired into `Zenith_Pathfinding::FindPath` (public entry), not `FindPathInternal` — async-worker recompute path doesn't double-count.

## Test

`Test_T0NavMesh_QueryCountIncrements` — Reset → issues 3 `FindPath` calls against an empty navmesh (each FAILS but counter ticks) → asserts counter == 3 → Reset → asserts counter == 0. Tagged `m_bRequiresGraphics=false`.

## Test plan

- [x] Per-test windowed PASS
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green
- [ ] doc-lint green

Branched fresh from `origin/master`.

[Claude Code](https://claude.com/claude-code) co-authored.