### PR TITLE
feat(engine): MVP-0.4.3 (replaces #27) -- Zenith_SaveData test hooks

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -226,6 +226,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
+    <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -520,6 +520,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
+    <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_T0SaveData_TestHooks.cpp
+++ b/Games/DevilsPlayground/Tests/Test_T0SaveData_TestHooks.cpp
@@ -1,0 +1,174 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "SaveData/Zenith_SaveData.h"
+
+#include <cstring>
+
+// ============================================================================
+// Test_T0SaveData_TestHooks (MVP-0.4.3, post-rework)
+//
+// Tier-0 smoke for the test-only hooks added to Zenith_SaveData. The hooks:
+//   - GetWrittenSlotsForTest() returns every Save() since last Clear.
+//   - SetReadbackForTest(slot, gameVer, data, size) stages a payload that
+//     the next Load(slot, ...) returns INSTEAD of reading from disk.
+//   - ClearForTest() wipes the recording log + readback stash.
+//
+// This replaces the closed PR #27's Zenith_SaveSystem skeleton, which
+// duplicated the existing Zenith_SaveData. The right design is to layer
+// test instrumentation onto the production system (which TilePuzzle already
+// uses) rather than parallel a new namespace.
+//
+// The test does NOT call Save() / Load() against real disk -- the
+// recording-log path is exercised entirely via the readback stash (which
+// bypasses disk by design) so the test stays hermetic and doesn't depend
+// on Zenith_SaveData::Initialise having been called.
+// ============================================================================
+
+namespace
+{
+	int g_iFailures = 0;
+
+	struct TestPayload
+	{
+		uint32_t m_uLevel = 0;
+		float    m_fScore = 0.0f;
+	};
+
+	void WriteCallback(Zenith_DataStream& xStream, void* pxUserData)
+	{
+		const TestPayload* pxData = static_cast<TestPayload*>(pxUserData);
+		xStream << pxData->m_uLevel;
+		xStream << pxData->m_fScore;
+	}
+
+	void ReadCallback(Zenith_DataStream& xStream, uint32_t /*uGameVersion*/, void* pxUserData)
+	{
+		TestPayload* pxData = static_cast<TestPayload*>(pxUserData);
+		xStream >> pxData->m_uLevel;
+		xStream >> pxData->m_fScore;
+	}
+}
+
+static void Setup_T0SaveData_TestHooks()
+{
+	g_iFailures = 0;
+	Zenith_SaveData::ClearForTest();
+}
+
+static bool Step_T0SaveData_TestHooks(int iFrame)
+{
+	(void)iFrame;
+	return false;
+}
+
+static bool Verify_T0SaveData_TestHooks()
+{
+	g_iFailures = 0;
+
+	// 1) ClearForTest leaves both buffers empty.
+	if (Zenith_SaveData::GetWrittenSlotsForTest().GetSize() != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: write log not empty after Clear");
+		++g_iFailures;
+	}
+
+	// 2) SetReadbackForTest then Load via the public Zenith_SaveData::Load
+	//    short-circuits to the stash. We must NOT call Save() because we
+	//    haven't Initialise()'d the save directory in this test.
+	//
+	//    Build the stash payload by running the write callback into a
+	//    DataStream, then handing the byte buffer to SetReadbackForTest.
+	TestPayload xExpected = { 42, 1234.5f };
+	Zenith_DataStream xStashStream;
+	WriteCallback(xStashStream, &xExpected);
+	const uint64_t ulStashSize = xStashStream.GetCursor();
+	Zenith_SaveData::SetReadbackForTest("autosave", /*uGameVersion=*/1,
+		xStashStream.GetData(), ulStashSize);
+
+	TestPayload xLoaded = { 0, 0.0f };
+	const bool bLoaded = Zenith_SaveData::Load("autosave", ReadCallback, &xLoaded);
+	if (!bLoaded)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: Load returned false on staged readback");
+		++g_iFailures;
+	}
+	if (xLoaded.m_uLevel != 42)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: level didn't round-trip (got %u, expected 42)",
+			xLoaded.m_uLevel);
+		++g_iFailures;
+	}
+	if (xLoaded.m_fScore < 1234.4f || xLoaded.m_fScore > 1234.6f)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: score didn't round-trip (got %f, expected 1234.5)",
+			xLoaded.m_fScore);
+		++g_iFailures;
+	}
+
+	// 3) SetReadbackForTest with a different payload for the same slot
+	//    REPLACES the stash (not appends).
+	TestPayload xExpected2 = { 99, 7777.0f };
+	Zenith_DataStream xStashStream2;
+	WriteCallback(xStashStream2, &xExpected2);
+	Zenith_SaveData::SetReadbackForTest("autosave", 1,
+		xStashStream2.GetData(), xStashStream2.GetCursor());
+
+	TestPayload xLoaded2 = { 0, 0.0f };
+	Zenith_SaveData::Load("autosave", ReadCallback, &xLoaded2);
+	if (xLoaded2.m_uLevel != 99)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: re-stage didn't replace (got level=%u, expected 99)",
+			xLoaded2.m_uLevel);
+		++g_iFailures;
+	}
+
+	// 4) ClearForTest wipes the stash. We verify by re-staging with a new
+	//    payload (which should completely replace, not merge with, any
+	//    previous stash state) -- if Clear didn't work then ANY load after
+	//    re-stage would still see the previous (wrong) values via the
+	//    stash entry that should have been cleared.
+	Zenith_SaveData::ClearForTest();
+	if (Zenith_SaveData::GetWrittenSlotsForTest().GetSize() != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: write log not empty after second Clear");
+		++g_iFailures;
+	}
+	TestPayload xExpected4 = { 7, 0.5f };
+	Zenith_DataStream xStashStream4;
+	WriteCallback(xStashStream4, &xExpected4);
+	Zenith_SaveData::SetReadbackForTest("autosave", 1,
+		xStashStream4.GetData(), xStashStream4.GetCursor());
+
+	TestPayload xLoaded4 = { 0, 0.0f };
+	Zenith_SaveData::Load("autosave", ReadCallback, &xLoaded4);
+	if (xLoaded4.m_uLevel != 7)
+	{
+		Zenith_Log(LOG_CATEGORY_UNITTEST,
+			"Test_T0SaveData_TestHooks: post-Clear restage broken (got level=%u, expected 7)",
+			xLoaded4.m_uLevel);
+		++g_iFailures;
+	}
+
+	return g_iFailures == 0;
+}
+
+static const Zenith_AutomatedTest g_xSaveDataTestHooksTest = {
+	"Test_T0SaveData_TestHooks",
+	&Setup_T0SaveData_TestHooks,
+	&Step_T0SaveData_TestHooks,
+	&Verify_T0SaveData_TestHooks,
+	10,
+	false // m_bRequiresGraphics: pure save-system-API exercise
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xSaveDataTestHooksTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Zenith/SaveData/Zenith_SaveData.cpp
+++ b/Zenith/SaveData/Zenith_SaveData.cpp
@@ -12,6 +12,27 @@
 
 namespace Zenith_SaveData
 {
+#ifdef ZENITH_INPUT_SIMULATOR
+	// ============================================================================
+	// MVP-0.4.3 test instrumentation -- recording log + readback stash. The
+	// recording log captures every Save() call; the stash lets tests inject
+	// "what disk would have returned" for a specific slot so a Load() short-
+	// circuits to it. Both wiped only by ClearForTest.
+	// ============================================================================
+	static Zenith_Vector<WrittenSlot>     s_xWrittenSlotsLog;
+	static std::vector<WrittenSlot>       s_xReadbackStash;
+
+	static WrittenSlot* FindReadbackSlot(const char* szSlotName)
+	{
+		if (szSlotName == nullptr) return nullptr;
+		for (auto& xSlot : s_xReadbackStash)
+		{
+			if (xSlot.m_strSlotName == szSlotName) return &xSlot;
+		}
+		return nullptr;
+	}
+#endif
+
 	// ============================================================================
 	// CRC32 Lookup Table (polynomial 0xEDB88320)
 	// ============================================================================
@@ -114,6 +135,27 @@ namespace Zenith_SaveData
 
 		uint64_t ulPayloadSize = xPayloadStream.GetCursor();
 
+#ifdef ZENITH_INPUT_SIMULATOR
+		// MVP-0.4.3: record the write so tests can audit what was persisted.
+		// We copy the payload bytes BEFORE the header is added so the log
+		// reflects the game-level data, not the file format scaffolding.
+		{
+			WrittenSlot xEntry;
+			xEntry.m_strSlotName  = szSlotName;
+			xEntry.m_uGameVersion = uGameVersion;
+			if (ulPayloadSize > 0)
+			{
+				xEntry.m_xPayload.Reserve(static_cast<u_int>(ulPayloadSize));
+				const uint8_t* pxBytes = static_cast<const uint8_t*>(xPayloadStream.GetData());
+				for (uint64_t u = 0; u < ulPayloadSize; ++u)
+				{
+					xEntry.m_xPayload.PushBack(pxBytes[u]);
+				}
+			}
+			s_xWrittenSlotsLog.PushBack(std::move(xEntry));
+		}
+#endif
+
 		// Compute checksum over payload bytes
 		uint32_t uChecksum = 0;
 		if (ulPayloadSize > 0)
@@ -155,6 +197,28 @@ namespace Zenith_SaveData
 	// ============================================================================
 	bool Load(const char* szSlotName, SaveReadCallback pfnReadPayload, void* pxUserData)
 	{
+#ifdef ZENITH_INPUT_SIMULATOR
+		// MVP-0.4.3: if a test staged a readback for this slot, short-circuit
+		// the disk path and feed the staged payload to the read callback.
+		// Runs BEFORE the Initialise / null-arg asserts so tests can exercise
+		// load semantics without having to first call Initialise (which sets
+		// up an APPDATA save directory we'd never use in a hermetic test).
+		if (szSlotName != nullptr && pfnReadPayload != nullptr)
+		{
+			if (WrittenSlot* pxStash = FindReadbackSlot(szSlotName))
+			{
+				Zenith_DataStream xStream;
+				if (pxStash->m_xPayload.GetSize() > 0)
+				{
+					xStream.WriteData(&pxStash->m_xPayload.Get(0), pxStash->m_xPayload.GetSize());
+					xStream.SetCursor(0);
+				}
+				pfnReadPayload(xStream, pxStash->m_uGameVersion, pxUserData);
+				return true;
+			}
+		}
+#endif
+
 		Zenith_Assert(s_bInitialised, "SaveData: Not initialised. Call Initialise() first");
 		Zenith_Assert(szSlotName != nullptr, "SaveData: Slot name cannot be null");
 		Zenith_Assert(pfnReadPayload != nullptr, "SaveData: Read callback cannot be null");
@@ -274,4 +338,49 @@ namespace Zenith_SaveData
 		Zenith_Log(LOG_CATEGORY_CORE, "SaveData: Deleted save slot '%s'", szPath);
 		return true;
 	}
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// ============================================================================
+	// MVP-0.4.3 test instrumentation -- public API
+	// ============================================================================
+	const Zenith_Vector<WrittenSlot>& GetWrittenSlotsForTest()
+	{
+		return s_xWrittenSlotsLog;
+	}
+
+	void SetReadbackForTest(const char* szSlotName, uint32_t uGameVersion,
+		const void* pData, uint64_t ulSize)
+	{
+		if (szSlotName == nullptr) return;
+
+		WrittenSlot xSlot;
+		xSlot.m_strSlotName  = szSlotName;
+		xSlot.m_uGameVersion = uGameVersion;
+		if (pData != nullptr && ulSize > 0)
+		{
+			xSlot.m_xPayload.Reserve(static_cast<u_int>(ulSize));
+			const uint8_t* pxBytes = static_cast<const uint8_t*>(pData);
+			for (uint64_t u = 0; u < ulSize; ++u)
+			{
+				xSlot.m_xPayload.PushBack(pxBytes[u]);
+			}
+		}
+
+		// Update or insert in the stash.
+		if (WrittenSlot* pxExisting = FindReadbackSlot(szSlotName))
+		{
+			*pxExisting = std::move(xSlot);
+		}
+		else
+		{
+			s_xReadbackStash.push_back(std::move(xSlot));
+		}
+	}
+
+	void ClearForTest()
+	{
+		s_xWrittenSlotsLog.Clear();
+		s_xReadbackStash.clear();
+	}
+#endif
 }

--- a/Zenith/SaveData/Zenith_SaveData.h
+++ b/Zenith/SaveData/Zenith_SaveData.h
@@ -2,6 +2,11 @@
 
 #include "DataStream/Zenith_DataStream.h"
 
+#ifdef ZENITH_INPUT_SIMULATOR
+#include "Collections/Zenith_Vector.h"
+#include <string>
+#endif
+
 // Magic number: "ZENS" = 0x5A454E53 (Zenith Save)
 static constexpr uint32_t uZENITH_SAVE_MAGIC = 0x5A454E53;
 
@@ -62,4 +67,44 @@ namespace Zenith_SaveData
 
 	// Compute CRC32 checksum of a data buffer
 	uint32_t ComputeCRC32(const void* pData, uint64_t ulSize);
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// ========================================================================
+	// Test instrumentation (MVP-0.4.3)
+	//
+	// Recording + readback hooks for headless save tests. Tests typically:
+	//   1. Call ClearForTest() at setup to wipe recorded state.
+	//   2. Use SetReadbackForTest(...) BEFORE the system-under-test calls
+	//      Load() -- the staged payload bypasses disk and is returned to
+	//      the read callback directly.
+	//   3. Run gameplay that calls Save() / Load() through the normal API.
+	//   4. Inspect GetWrittenSlotsForTest() to assert what was persisted
+	//      (slot name + raw payload bytes + game version).
+	//
+	// The recording lives behind ZENITH_INPUT_SIMULATOR so shipping builds
+	// stay clean. Save() / Load() still hit disk in test builds too unless
+	// SetReadbackForTest stages a payload for the requested slot (in which
+	// case Load() short-circuits to the stash without reading the file).
+	// ========================================================================
+	struct WrittenSlot
+	{
+		std::string m_strSlotName;
+		uint32_t    m_uGameVersion = 0;
+		Zenith_Vector<uint8_t> m_xPayload;
+	};
+
+	// Returns every Save() call since the last ClearForTest, in order. The
+	// payload bytes are exactly what was written between the header and
+	// EOF (no header, no CRC -- those live in the file on disk).
+	const Zenith_Vector<WrittenSlot>& GetWrittenSlotsForTest();
+
+	// Stage a payload that the next Load(szSlotName, ...) returns via its
+	// read callback instead of reading from disk. The stash persists across
+	// Save() / Load() calls; only ClearForTest wipes it.
+	void SetReadbackForTest(const char* szSlotName, uint32_t uGameVersion,
+		const void* pData, uint64_t ulSize);
+
+	// Wipe the recording log + readback stash. Disk files are NOT touched.
+	void ClearForTest();
+#endif
 }


### PR DESCRIPTION
## Summary

Replaces the closed PR #27, which authored a parallel `Zenith_SaveSystem` namespace that **duplicated the existing `Zenith_SaveData`** (Zenith/SaveData/). The existing system is production-quality — platform dirs, ZENS magic file format, CRC32 checksum, slot-based API, function-pointer callbacks per engine convention, **already used by TilePuzzle**.

The correct MVP-0.4.3 shape is to layer test instrumentation onto the production system rather than parallel it.

## Added (all behind `ZENITH_INPUT_SIMULATOR`)

```cpp
struct WrittenSlot { string slotName; uint32_t gameVersion; Zenith_Vector<uint8_t> payload; };

const Zenith_Vector<WrittenSlot>& GetWrittenSlotsForTest();
void SetReadbackForTest(slot, gameVer, data, size);
void ClearForTest();
```

## Integration with existing API

- **Save()** appends to the recording log after building the payload (raw payload bytes, before the header).
- **Load()** short-circuits to the stash BEFORE the Initialise / null-arg asserts when a stash entry exists for the requested slot. Tests can exercise load semantics without APPDATA setup.
- **ClearForTest()** wipes log + stash; disk files untouched.

Shipping builds: zero new code paths in Save/Load. `ZENITH_INPUT_SIMULATOR` guards keep the recording log + stash storage out of release binaries.

## Test

`Test_T0SaveData_TestHooks` — stage readback → Load via read callback → assert round-trip → re-stage replaces (not merges) → Clear + re-stage works. Tagged `m_bRequiresGraphics=false`.

## Test plan

- [x] Per-test windowed PASS
- [x] Full headless batch: 41 passed, 0 failed
- [ ] dp-build green
- [ ] complexity-gate green
- [ ] dp-tests green
- [ ] doc-lint green

## Lesson learned

Before authoring a new engine surface I should run `find Zenith/ -iname "*Foo*"` and `grep -rln 'class.*Foo' Zenith/` to check whether the engine already provides the capability. Closed PR #27 was the cost of skipping that check; this PR is the corrected version. (Filing as a DecisionLog note in the next docs PR.)

[Claude Code](https://claude.com/claude-code) co-authored.