### PR TITLE
docs(dp): MVP-1.2.0 spike findings -- navmesh generator top-face-only blocks wall blocking

### DIFF
--- a/Games/DevilsPlayground/Docs/DecisionLog.md
+++ b/Games/DevilsPlayground/Docs/DecisionLog.md
@@ -8,6 +8,25 @@
 
 ---
 
+## 2026-05-13 — MVP-1.2.0 spike result: navmesh generator's top-face-only collector blocks the roadmap path. Filed as Q-2026-05-13-NM01.
+
+**Decision:** Do NOT commit a `Test_P1NavMesh_PathRespectsWalls` that fails to actually verify wall-respecting paths. The spike (described in the roadmap as "Author a single static test scene with 4 cube walls forming a room with a doorway. Call `Zenith_NavMeshGenerator::GenerateFromScene` on it. Assert the returned `Zenith_NavMesh*` is non-null and `FindPath(start, end)` routes around the wall") was implemented and run. The generator returns non-null and `FindPath` succeeds -- but the path is a straight line through where the wall should be. Cause documented in Q-2026-05-13-NM01.
+
+**What I tried:** Built `Games/DevilsPlayground/Tests/Test_P1NavMesh_PathRespectsWalls.cpp` with a 12x12m floor + 5m wide / 1m tall box-collider wall. Path from (0, 0.1, -3) to (0, 0.1, +3) routes straight at `|x|=0.0`. Read the generator. Tried emitting all 6 box faces (vs the existing top-face-only emit) -- polygon count unchanged, path still straight. Concluded the generator needs a column solid-fill post-pass (Recast-style) the engine doesn't currently have. Test deleted, findings filed in Questions.md.
+
+**Why not commit a loose "spike-only" test:** a test named `Test_P1NavMesh_PathRespectsWalls` whose Verify returns true regardless of whether the path detours is dishonest -- a future agent or reviewer would see it green and assume the wall-blocking is verified. A misleading green test is worse than no test.
+
+**Why not commit the engine fix in this same session:** Q-2026-05-13-NM01's preferred path is to fix the generator's solid-fill step, but it's an engine change to a non-trivial algorithm and warrants a dedicated PR with its own engine tests + design review (per OrchestratorPlaybook §5.4 "Mandatory Reviewer subagent on every engine PR"). Bundling it with a DP-side game-test PR would dilute review.
+
+**Trade-offs considered:**
+- *Commit the loose test anyway with a `m_bRequiresGraphics=true` to skip it on CI.* Rejected -- skipping is for genuine graphics dependence, not for "this test doesn't actually work yet". Repurposing the skip flag muddies the contract.
+- *Implement the generator fix in this session and bundle.* Rejected per the dilute-review concern above.
+- *Switch to MVP-1.2.alt (hand-authored `.znavmesh`).* Rejected for the same reasons captured in Q-2026-05-13-NM01: more work than fixing the generator + a manually-managed asset to maintain.
+
+**Reversibility:** filing as a Question is fully reversible. Implementing the generator fix would require a follow-up engine PR with its own DecisionLog entry.
+
+---
+
 ## 2026-05-13 — MVP-1.1: Pause controller migrates to persistent scene (singleton); dedicated `PauseManager` entity.
 
 **Decision:** `DPPauseMenuController_Behaviour::OnStart` captures the current active scene as `m_xGameplayScene`, then calls `Zenith_SceneManager::MarkEntityPersistent(m_xParentEntity)`. On Esc it toggles overlay visibility AND calls `Zenith_SceneManager::SetScenePaused(m_xGameplayScene, m_bShown)`. Subsequent scene loads create a new `PauseManager` entity whose OnStart detects an existing persistent singleton, hands it the new gameplay-scene handle, force-unpauses, and lets itself be destroyed with the scene rather than re-migrating.

--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -10,6 +10,26 @@
 
 ## Open
 
+### ⚠️ Q-2026-05-13-NM01 — NavMesh generator's geometry collector only voxelises box-collider TOP faces; walls never block the floor below.
+
+**Context:** During MVP-1.2.0 spike (real navmesh integration) I built a tiny test scene with a 12x12m floor + a 5m wide / 1m tall box-collider wall, called `Zenith_NavMeshGenerator::GenerateFromScene`, and tried to verify that `Zenith_Pathfinding::FindPath((0, 0.1, -3), (0, 0.1, +3))` routed around the wall. It didn't -- the returned path is a 2-waypoint straight line right through where the wall should be (length 6.0, `|x|max` 0.0).
+
+Root cause traced to `Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp::CollectGeometryFromScene` (around line 193, comment "Only add TOP face - this creates walkable surfaces"). The collector emits **only the top face** of each box collider as input triangles. The voxelizer thus sees a thin lid at the floor's top y AND another thin lid at the wall's top y -- but nothing between them. The clearance check above the floor span doesn't trip on the wall's interior because the wall has no interior in the heightfield. Floor cells under the wall stay walkable; path-finder cuts straight through.
+
+I tried emitting all six box faces. Polygon count was unchanged (1681 polygons, floor: 1630, mid: 51, high: 0). The voxelizer's triangle rasteriser hits cells the triangles cover but doesn't *fill* between disjoint top + bottom + side triangles into a closed solid region. Recast does this via a "solid span fill" post-pass per column; Zenith's generator currently omits that step.
+
+**Implication:** MVP-1.2.0 spike as the roadmap originally described it (4 walls forming a room with a doorway, FindPath detours through doorway) CANNOT pass against the current generator. Production DP needs either:
+  a) the generator to gain the column solid-fill step (~30 lines of post-processing in the rasterizer), OR
+  b) the MVP-1.2.alt fallback (hand-authored `.znavmesh` from collider geometry, no runtime generation).
+
+**My best guess if you don't reply:** spend ~half a day on option (a) -- fix the generator's column solid-fill step, then revive the spike test as the strict MVP-1.2.1 assertion. The fix is well-bounded (per-column scan of min/max-y triangle hits → mark intermediate voxels solid). Falling back to MVP-1.2.alt means authoring a tool to bake `.znavmesh` from collider geometry, which is more work than fixing the generator and produces a manually-managed asset.
+
+**Cost of getting it wrong:** Phase 1.2 slips by a couple of days either way. Going with option (a) and discovering it's harder than expected costs the same as going straight to (b). Going with (b) when (a) would have worked means we ship a hand-authored navmesh that needs re-baking every time level geometry changes.
+
+**Status:** asked 2026-05-13. The spike findings are documented but I did NOT commit the failing test -- a test named `Test_P1NavMesh_PathRespectsWalls` that doesn't actually assert wall-respecting paths would be misleading. The test will be re-introduced once the generator fix lands.
+
+---
+
 ### ⚠️ Q-2026-05-12-001 — No CI gate for DP. Auto-merge merges immediately without running DP tests.
 
 **Context:** [.github/workflows/complexity.yml](../../../.github/workflows/complexity.yml) (renamed from msbuild.yml in MVP-0.0.2) runs a complexity gate but did not originally build DP or run `Tools/run_dp_tests.ps1` -- those checks landed in MVP-0.0.2 (`dp-build`) and MVP-0.0.3 (`dp-tests`) workflows. [AgentBriefing.md §3.5](AgentBriefing.md) describes required checks (`build-debug-tools`, `tests-headless`) but they're aspirational, not implemented yet — they're MVP-0.3 territory.


### PR DESCRIPTION
## Summary

MVP-1.2.0 spike result captured in two places (no code changes -- the test file I drafted was deleted to avoid checking in a misleading test).

## What I tried

Built `Test_P1NavMesh_PathRespectsWalls` per the roadmap: 12x12m floor + 5m wide / 1m tall box-collider wall, ran `Zenith_NavMeshGenerator::GenerateFromScene`, called `FindPath((0, 0.1, -3), (0, 0.1, +3))`, expected the path to detour around the wall.

It didn't. Path is a 2-waypoint straight line through where the wall should be (length 6.0, `|x|max` 0.0).

## What's wrong

`Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp::CollectGeometryFromScene` (~line 193) emits **only the top face** of each box collider as input geometry. The voxelizer sees a thin lid at the floor's top y AND another at the wall's top y -- but nothing in between. Floor cells under the wall stay walkable because the wall has no body in the heightfield.

I tried emitting all six box faces. Polygon count was unchanged. The voxelizer rasterises each triangle to cells it covers but doesn't fill between disjoint top + bottom + side triangles into a closed solid region. Recast does this via a per-column "solid span fill" post-pass; Zenith's generator omits that step.

## Why no code

Two reasons:
1. **No misleading test:** a test named `Test_P1NavMesh_PathRespectsWalls` whose Verify silently passes regardless of whether the path actually detours would be dishonest. The test was deleted rather than committed in that state.
2. **Engine fix wants its own PR:** the fix is well-bounded (~30 lines of solid-span fill) but it's a non-trivial engine algorithm change. Per OrchestratorPlaybook S5.4 it needs a Mandatory Reviewer subagent + its own design review. Bundling here would dilute that.

## Roadmap impact

MVP-1.2.0 / 1.2.1 (the spike + its promoted test) are **blocked** on the engine fix. MVP-1.2.2 onwards (the DP-side integration of GenerateFromScene into DP_AI) is also blocked until the generator is actually producing usable navmeshes for collider geometry.

See `Games/DevilsPlayground/Docs/Questions.md` Q-2026-05-13-NM01 for the full bug write-up and `Games/DevilsPlayground/Docs/DecisionLog.md` for the no-code reasoning.

## Test plan

- [x] doc_lint green locally.
- [ ] CI: complexity-gate + doc-lint pass (dp-build and dp-tests are no-ops here since no code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)