### PR TITLE
fix(engine): NavMesh walls now block paths -- generator carves + smoother rejects across-gap shortcuts

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="..\Tests\Test_LifeTimer.cpp" />
     <ClCompile Include="..\Tests\Test_Materials.cpp" />
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_InputSimDuringPause.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_PriestStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Pause_InputSimDuringPause.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -508,6 +508,7 @@
     <ClCompile Include="..\Tests\Test_LifeTimer.cpp" />
     <ClCompile Include="..\Tests\Test_Materials.cpp" />
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_InputSimDuringPause.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_PriestStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Pause_InputSimDuringPause.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_P1NavMesh_PathRespectsWalls.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1NavMesh_PathRespectsWalls.cpp
@@ -1,0 +1,214 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_Scene.h"
+#include "EntityComponent/Zenith_Entity.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_ColliderComponent.h"
+#include "AI/Navigation/Zenith_NavMesh.h"
+#include "AI/Navigation/Zenith_NavMeshGenerator.h"
+#include "AI/Navigation/Zenith_Pathfinding.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1NavMesh_PathRespectsWalls (MVP-1.2.0 / 1.2.1)
+//
+// Builds a tiny scene with a floor + a single wall box collider, calls
+// Zenith_NavMeshGenerator::GenerateFromScene, and asserts that
+// Zenith_Pathfinding::FindPath routes a path AROUND the wall (not through).
+//
+// Layout (top-down, y up, +x right, +z forward):
+//
+//   z =  +4 .... Goal at (0, 0.1, +3)
+//        .
+//   z =   0 ............[--Wall--]............ Wall along x in [-2.5, +2.5],
+//        .                                     z in [-0.3, +0.3], top y=1.0.
+//   z =  -4 .... Start at (0, 0.1, -3)
+//
+// The fix that makes this test pass landed in the same commit:
+//   1. NavMeshGenerator now emits all 6 faces of each box collider, not
+//      just the top face. Non-walkable faces (sides + bottom) get marked
+//      as OBSTRUCTION spans -- which trip the clearance check above any
+//      walkable span beneath them, carving the floor under wall footprints.
+//   2. Pathfinding's SmoothPath now checks `SegmentExitsNavMesh` in
+//      addition to the existing geometric Raycast + IsBlocked probes.
+//      The Raycast misses the carved-out region (it's a ray-vs-polygon-
+//      plane test that finds nothing in the gap); the new sample-based
+//      probe catches the hole.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kNW_Start, kNW_BuildScene, kNW_Generate, kNW_FindPath,
+	                   kNW_Verify, kNW_Done };
+
+	int                   g_iPhase = kNW_Start;
+	Zenith_Scene          g_xScene;
+	Zenith_NavMesh*       g_pxNavMesh = nullptr;
+	Zenith_PathResult     g_xPath;
+	float                 g_fPathLength = 0.0f;
+	float                 g_fMaxLateralAbsX = 0.0f;
+	bool                  g_bGenerateSucceeded = false;
+	bool                  g_bPathSucceeded = false;
+	bool                  g_bPassed = false;
+
+	constexpr float kWALL_HALF_X      = 2.5f;
+	constexpr float kSTRAIGHT_LINE_M  = 6.0f;  // (0,0.1,-3) -> (0,0.1,+3)
+
+	void CreateStaticBox(Zenith_SceneData* pxScene, const char* szName,
+	                     const Zenith_Maths::Vector3& xPos,
+	                     const Zenith_Maths::Vector3& xScale)
+	{
+		Zenith_Entity xEnt(pxScene, szName);
+		Zenith_TransformComponent& xT = xEnt.GetComponent<Zenith_TransformComponent>();
+		xT.SetPosition(xPos);
+		xT.SetScale(xScale);
+		Zenith_ColliderComponent& xCol = xEnt.AddComponent<Zenith_ColliderComponent>();
+		xCol.AddCollider(COLLISION_VOLUME_TYPE_OBB, RIGIDBODY_TYPE_STATIC);
+	}
+}
+
+static void Setup_P1NavMeshPathRespectsWalls()
+{
+	g_iPhase = kNW_Start;
+	g_xScene = Zenith_Scene();
+	g_pxNavMesh = nullptr;
+	g_xPath = Zenith_PathResult();
+	g_fPathLength = 0.0f;
+	g_fMaxLateralAbsX = 0.0f;
+	g_bGenerateSucceeded = false;
+	g_bPathSucceeded = false;
+	g_bPassed = false;
+}
+
+static bool Step_P1NavMeshPathRespectsWalls(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kNW_Start:
+		g_xScene = Zenith_SceneManager::CreateEmptyScene("NavMeshWallSpike");
+		Zenith_SceneManager::SetActiveScene(g_xScene);
+		g_iPhase = kNW_BuildScene;
+		return true;
+
+	case kNW_BuildScene:
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(g_xScene);
+		if (pxScene == nullptr) { g_iPhase = kNW_Done; return false; }
+
+		// Scale = full box size (half-extents = scale * 0.5).
+		// Floor: 12m x 12m, top surface y=0.1.
+		CreateStaticBox(pxScene, "Floor",
+		                Zenith_Maths::Vector3(0.0f, 0.0f, 0.0f),
+		                Zenith_Maths::Vector3(12.0f, 0.2f, 12.0f));
+		// Wall: 5m wide along x, 1m tall, 0.6m thick in z. Top y=1.0 sits
+		// inside the agent's 1.8m clearance zone above the floor at y=0.1
+		// -- the wall's interior obstruction spans block the clearance
+		// check and the floor cells under the wall become non-walkable.
+		CreateStaticBox(pxScene, "Wall",
+		                Zenith_Maths::Vector3(0.0f, 0.5f, 0.0f),
+		                Zenith_Maths::Vector3(2.0f * kWALL_HALF_X, 1.0f, 0.6f));
+		g_iPhase = kNW_Generate;
+		return true;
+	}
+
+	case kNW_Generate:
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(g_xScene);
+		if (pxScene == nullptr) { g_iPhase = kNW_Done; return false; }
+		NavMeshGenerationConfig xConfig{}; // engine defaults
+		g_pxNavMesh = Zenith_NavMeshGenerator::GenerateFromScene(*pxScene, xConfig);
+		g_bGenerateSucceeded = (g_pxNavMesh != nullptr);
+		std::printf("[P1NavMeshWalls] GenerateFromScene returned %s (frame %d)\n",
+			g_bGenerateSucceeded ? "non-null" : "NULL", iFrame);
+		std::fflush(stdout);
+		g_iPhase = g_bGenerateSucceeded ? kNW_FindPath : kNW_Verify;
+		return true;
+	}
+
+	case kNW_FindPath:
+	{
+		const Zenith_Maths::Vector3 xStart(0.0f, 0.0f, -3.0f);
+		const Zenith_Maths::Vector3 xEnd  (0.0f, 0.0f, +3.0f);
+		g_xPath = Zenith_Pathfinding::FindPath(*g_pxNavMesh, xStart, xEnd);
+		g_bPathSucceeded = (g_xPath.m_eStatus == Zenith_PathResult::Status::SUCCESS);
+
+		g_fPathLength = 0.0f;
+		g_fMaxLateralAbsX = 0.0f;
+		const uint32_t uWp = g_xPath.m_axWaypoints.GetSize();
+		for (uint32_t u = 0; u < uWp; ++u)
+		{
+			const Zenith_Maths::Vector3& xWp = g_xPath.m_axWaypoints.Get(u);
+			if (std::fabs(xWp.x) > g_fMaxLateralAbsX) g_fMaxLateralAbsX = std::fabs(xWp.x);
+			if (u > 0)
+			{
+				const Zenith_Maths::Vector3& xPrev = g_xPath.m_axWaypoints.Get(u - 1);
+				const float fDx = xWp.x - xPrev.x;
+				const float fDy = xWp.y - xPrev.y;
+				const float fDz = xWp.z - xPrev.z;
+				g_fPathLength += std::sqrt(fDx * fDx + fDy * fDy + fDz * fDz);
+			}
+		}
+		std::printf("[P1NavMeshWalls] FindPath: status=%d waypoints=%u length=%.3f maxAbsX=%.3f\n",
+			(int)g_xPath.m_eStatus, uWp, g_fPathLength, g_fMaxLateralAbsX);
+		for (uint32_t u = 0; u < uWp; ++u)
+		{
+			const Zenith_Maths::Vector3& xWp = g_xPath.m_axWaypoints.Get(u);
+			std::printf("[P1NavMeshWalls]   waypoint[%u] = (%.3f, %.3f, %.3f)\n",
+				u, xWp.x, xWp.y, xWp.z);
+		}
+		std::fflush(stdout);
+		g_iPhase = kNW_Verify;
+		return true;
+	}
+
+	case kNW_Verify:
+	{
+		// Required lateral detour: at least wall_half_width - agent_radius - slack
+		// = 2.5 - 0.4 - 0.5 = 1.6m.
+		const float kREQUIRED_LATERAL = kWALL_HALF_X - 0.4f - 0.5f;
+		const bool bDetours       = g_fMaxLateralAbsX >= kREQUIRED_LATERAL;
+		// "Not straight" = path length exceeded the direct line.
+		const bool bNotStraight   = g_fPathLength > kSTRAIGHT_LINE_M + 0.5f;
+
+		g_bPassed = g_bGenerateSucceeded && g_bPathSucceeded && bDetours && bNotStraight;
+		std::printf("[P1NavMeshWalls] verify: gen=%d path=%d detours=%d notStraight=%d "
+		            "(maxAbsX=%.3f needed>=%.3f, length=%.3f needed>=%.3f) passed=%d\n",
+			(int)g_bGenerateSucceeded, (int)g_bPathSucceeded,
+			(int)bDetours, (int)bNotStraight,
+			g_fMaxLateralAbsX, kREQUIRED_LATERAL,
+			g_fPathLength, kSTRAIGHT_LINE_M + 0.5f, (int)g_bPassed);
+		std::fflush(stdout);
+
+		if (g_pxNavMesh != nullptr) { delete g_pxNavMesh; g_pxNavMesh = nullptr; }
+		g_iPhase = kNW_Done;
+		return false;
+	}
+
+	case kNW_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1NavMeshPathRespectsWalls()
+{
+	return g_bPassed;
+}
+
+static const Zenith_AutomatedTest g_xP1NavMeshWallsTest = {
+	"Test_P1NavMesh_PathRespectsWalls",
+	&Setup_P1NavMeshPathRespectsWalls,
+	&Step_P1NavMeshPathRespectsWalls,
+	&Verify_P1NavMeshPathRespectsWalls,
+	60,
+	false // m_bRequiresGraphics: pure collider-geometry + navmesh
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1NavMeshWallsTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp
+++ b/Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp
@@ -190,15 +190,40 @@ bool Zenith_NavMeshGenerator::CollectGeometryFromScene(Zenith_SceneData& xScene,
 			axVerticesOut.PushBack(axBoxVerts[i]);
 		}
 
-		// Only add TOP face - this creates walkable surfaces
-		// Vertex indices: 0-3 = bottom face corners, 4-7 = top face corners
-		// Top face (Y+) - CCW when viewed from above
-		axIndicesOut.PushBack(uBaseVertex + 4);
-		axIndicesOut.PushBack(uBaseVertex + 7);
-		axIndicesOut.PushBack(uBaseVertex + 6);
-		axIndicesOut.PushBack(uBaseVertex + 4);
-		axIndicesOut.PushBack(uBaseVertex + 6);
-		axIndicesOut.PushBack(uBaseVertex + 5);
+		// Emit all six faces of the box. The top face's normal points up
+		// and the slope check (in RasterizeTriangle) marks it walkable;
+		// the four sides and the bottom face have normals that fail the
+		// slope check and are marked as OBSTRUCTION spans (area type 0).
+		// Obstruction spans block the clearance check above any walkable
+		// span beneath them, so a 1m-tall wall sitting on the floor carves
+		// a hole in the floor's walkable surface directly under its
+		// footprint -- which is what the navmesh needs to route AI around
+		// walls instead of through them.
+		//
+		// Vertex layout (matches the axBoxVerts initialiser above):
+		//   0-3 = bottom face corners, 4-7 = top face corners.
+		//   0=(-x,-y,-z), 1=(+x,-y,-z), 2=(+x,-y,+z), 3=(-x,-y,+z),
+		//   4=(-x,+y,-z), 5=(+x,+y,-z), 6=(+x,+y,+z), 7=(-x,+y,+z).
+		// Each face wound CCW when viewed from OUTSIDE so the computed
+		// triangle normal points outward (away from the box centre).
+		auto EmitTri = [&](uint32_t a, uint32_t b, uint32_t c)
+		{
+			axIndicesOut.PushBack(uBaseVertex + a);
+			axIndicesOut.PushBack(uBaseVertex + b);
+			axIndicesOut.PushBack(uBaseVertex + c);
+		};
+		// Top face (normal +Y, walkable).
+		EmitTri(4, 7, 6); EmitTri(4, 6, 5);
+		// Bottom face (normal -Y, obstruction).
+		EmitTri(0, 1, 2); EmitTri(0, 2, 3);
+		// Front face Z- (normal -Z, obstruction).
+		EmitTri(0, 4, 5); EmitTri(0, 5, 1);
+		// Back face Z+ (normal +Z, obstruction).
+		EmitTri(3, 2, 6); EmitTri(3, 6, 7);
+		// Left face X- (normal -X, obstruction).
+		EmitTri(0, 3, 7); EmitTri(0, 7, 4);
+		// Right face X+ (normal +X, obstruction).
+		EmitTri(1, 5, 6); EmitTri(1, 6, 2);
 	}
 
 	Zenith_Log(LOG_CATEGORY_AI, "CollectGeometryFromScene: %u entities with colliders, %u with valid bodies, generated %u vertices",
@@ -319,11 +344,16 @@ void Zenith_NavMeshGenerator::RasterizeTriangle(
 	Zenith_Maths::Vector3 xEdge2 = xV2 - xV0;
 	Zenith_Maths::Vector3 xNormal = Zenith_Maths::Normalize(Zenith_Maths::Cross(xEdge1, xEdge2));
 
-	// Only voxelize walkable slopes (we only include top faces now)
-	if (!IsWalkableSlope(xNormal, xContext.m_xConfig.m_fMaxSlope))
-	{
-		return;
-	}
+	// Triangles whose normals point sufficiently up are walkable surfaces
+	// (area type 1) -- they emit voxel spans the agent can stand on.
+	// Everything else (vertical walls, ceilings, undersides) emits an
+	// OBSTRUCTION span (area type 0). Obstruction spans don't appear in
+	// the polygon mesh, but they DO trip the clearance check above any
+	// walkable span beneath them in the same column -- which is how a
+	// wall sitting on a floor carves a hole in the floor's walkable area.
+	const bool bWalkable = IsWalkableSlope(xNormal, xContext.m_xConfig.m_fMaxSlope);
+	const uint8_t uAreaType = bWalkable ? static_cast<uint8_t>(1)
+	                                    : static_cast<uint8_t>(0);
 
 	// Compute triangle bounding box in grid coords
 	float fMinX = std::min({xV0.x, xV1.x, xV2.x});
@@ -353,7 +383,7 @@ void Zenith_NavMeshGenerator::RasterizeTriangle(
 		for (int32_t iX = iMinX; iX <= iMaxX; ++iX)
 		{
 			int32_t iColIndex = GetColumnIndex(iX, iZ, xContext.m_iWidth);
-			AddSpan(xContext.m_axColumns.Get(iColIndex), uMinY, uMaxY, 1);  // All voxelized surfaces are walkable
+			AddSpan(xContext.m_axColumns.Get(iColIndex), uMinY, uMaxY, uAreaType);
 		}
 	}
 }

--- a/Zenith/AI/Navigation/Zenith_Pathfinding.Tests.inl
+++ b/Zenith/AI/Navigation/Zenith_Pathfinding.Tests.inl
@@ -300,3 +300,126 @@ void Zenith_UnitTests::TestPathfindingPartialPath(){
 
 }
 
+
+// ============================================================================
+// Smoother regression: shortcut must NOT cross a carved-out region of the
+// navmesh (e.g., the area beneath a wall on the floor mesh). Geometric
+// Raycast on a flat navmesh trivially "passes through" the gap because no
+// polygon plane sits in the gap to intersect. The SegmentExitsNavMesh
+// probe in SmoothPath catches this by sampling the line and asserting
+// every sample lands on a polygon at roughly the same Y as the endpoints.
+//
+// Setup:
+//   Two adjacent floor polygons at y=0.0, separated horizontally by a
+//   1m gap (no polygon between them). Both polygons are flagged as
+//   neighbours via `SetNeighbor` (matching the real-world bug where
+//   shared vertex indices in the grid-stamped polygon mesh make two
+//   floor polygons across a carved-out wall footprint claim adjacency).
+//
+//   A separate "wall-top" polygon at y=1.0 sits ABOVE the gap. Without
+//   the height-aware probe, FindPolygonContaining would find this
+//   wall-top polygon for samples at y=0.0 in the gap and report "still
+//   on the navmesh" -- masking the hole. The probe's vertical tolerance
+//   (0.5m) excludes the wall-top from the y=0.0 sample's match.
+// ============================================================================
+ZENITH_TEST(AI, PathfindingSmootherRejectsCarvedShortcut) { Zenith_UnitTests::TestPathfindingSmootherRejectsCarvedShortcut(); }
+
+void Zenith_UnitTests::TestPathfindingSmootherRejectsCarvedShortcut(){
+	Zenith_NavMesh xNavMesh;
+
+	// Two floor polygons at y=0, both 2m x 2m, separated by a 1m gap in z.
+	// West polygon: x in [0,2], z in [0,2]
+	// East polygon: x in [0,2], z in [3,5]
+	// Gap: z in [2,3]
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 0.0f, 0.0f));  // 0
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 0.0f, 0.0f));  // 1
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 0.0f, 2.0f));  // 2
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 0.0f, 2.0f));  // 3
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 0.0f, 3.0f));  // 4
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 0.0f, 3.0f));  // 5
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 0.0f, 5.0f));  // 6
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 0.0f, 5.0f));  // 7
+
+	// Wall-top polygon at y=1.0 spanning the gap (z in [2,3]).
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 1.0f, 2.0f));  // 8
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 1.0f, 2.0f));  // 9
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 1.0f, 3.0f));  // 10
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 1.0f, 3.0f));  // 11
+
+	Zenith_Vector<uint32_t> axWest, axEast, axWallTop;
+	axWest.PushBack(0); axWest.PushBack(1); axWest.PushBack(2); axWest.PushBack(3);
+	axEast.PushBack(4); axEast.PushBack(5); axEast.PushBack(6); axEast.PushBack(7);
+	axWallTop.PushBack(8); axWallTop.PushBack(9); axWallTop.PushBack(10); axWallTop.PushBack(11);
+
+	xNavMesh.AddPolygon(axWest);     // poly 0
+	xNavMesh.AddPolygon(axEast);     // poly 1
+	xNavMesh.AddPolygon(axWallTop);  // poly 2
+	xNavMesh.BuildSpatialGrid();
+
+	// Force-claim that poly 0 and poly 1 are neighbours (the bug-state).
+	// In production this happens via the grid-vertex-matching adjacency
+	// pass when a wall carves cells out -- adjacent floor polygons on
+	// opposite sides claim adjacency via shared vertex indices despite
+	// no real connection.
+	xNavMesh.SetNeighbor(0, /*edge=*/2, 1);
+	xNavMesh.SetNeighbor(1, /*edge=*/0, 0);
+
+	// Build a 2-waypoint candidate path from west to east. The smoother
+	// will try to shortcut start->end directly across the gap. With the
+	// fix, that shortcut is rejected because samples at y=0 in z in [2,3]
+	// find no polygon at the floor level (the wall-top at y=1.0 is too
+	// far away vertically given the 0.5m probe tolerance).
+	Zenith_Vector<Zenith_Maths::Vector3> axPath;
+	axPath.PushBack(Zenith_Maths::Vector3(1.0f, 0.0f, 1.0f));   // west centre
+	axPath.PushBack(Zenith_Maths::Vector3(1.0f, 0.0f, 2.5f));   // gap midpoint -- intermediate
+	axPath.PushBack(Zenith_Maths::Vector3(1.0f, 0.0f, 4.0f));   // east centre
+
+	Zenith_Pathfinding::SmoothPath(axPath, xNavMesh);
+
+	// After smoothing the intermediate waypoint must REMAIN because the
+	// start->end shortcut crosses the gap. If smoothing reduced to 2
+	// waypoints, the regression has come back.
+	ZENITH_ASSERT_GE(axPath.GetSize(), 3,
+		"SmoothPath must NOT shortcut across the carved-out region");
+}
+
+// ============================================================================
+// Companion test: verify the smoother still smooths valid shortcuts that
+// don't cross gaps. Without this counter-check, an over-aggressive
+// SegmentExitsNavMesh probe (e.g., too-tight vertical tolerance) would
+// silently break smoothing for all paths.
+// ============================================================================
+ZENITH_TEST(AI, PathfindingSmootherAcceptsValidShortcut) { Zenith_UnitTests::TestPathfindingSmootherAcceptsValidShortcut(); }
+
+void Zenith_UnitTests::TestPathfindingSmootherAcceptsValidShortcut(){
+	Zenith_NavMesh xNavMesh;
+
+	// Two adjacent floor polygons forming a 4m x 2m rectangle.
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 0.0f, 0.0f));  // 0
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 0.0f, 0.0f));  // 1 shared
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(2.0f, 0.0f, 2.0f));  // 2 shared
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(0.0f, 0.0f, 2.0f));  // 3
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(4.0f, 0.0f, 0.0f));  // 4
+	xNavMesh.AddVertex(Zenith_Maths::Vector3(4.0f, 0.0f, 2.0f));  // 5
+
+	Zenith_Vector<uint32_t> axLeft, axRight;
+	axLeft.PushBack(0);  axLeft.PushBack(1);  axLeft.PushBack(2);  axLeft.PushBack(3);
+	axRight.PushBack(1); axRight.PushBack(4); axRight.PushBack(5); axRight.PushBack(2);
+
+	xNavMesh.AddPolygon(axLeft);
+	xNavMesh.AddPolygon(axRight);
+	xNavMesh.ComputeAdjacency();
+	xNavMesh.BuildSpatialGrid();
+
+	// Build a 3-waypoint path with a redundant intermediate. The smoother
+	// should reduce it to 2 waypoints because nothing is in the way.
+	Zenith_Vector<Zenith_Maths::Vector3> axPath;
+	axPath.PushBack(Zenith_Maths::Vector3(0.5f, 0.0f, 1.0f));
+	axPath.PushBack(Zenith_Maths::Vector3(2.0f, 0.0f, 1.0f));  // portal midpoint -- redundant
+	axPath.PushBack(Zenith_Maths::Vector3(3.5f, 0.0f, 1.0f));
+
+	Zenith_Pathfinding::SmoothPath(axPath, xNavMesh);
+
+	ZENITH_ASSERT_EQ(axPath.GetSize(), 2,
+		"SmoothPath must collapse a redundant intermediate when the line is clear");
+}

--- a/Zenith/AI/Navigation/Zenith_Pathfinding.cpp
+++ b/Zenith/AI/Navigation/Zenith_Pathfinding.cpp
@@ -311,6 +311,49 @@ namespace
 		}
 		return false;
 	}
+
+	// Walks a line segment in `kSamples` steps and returns true if any
+	// sampled point is NOT on the navmesh at roughly the same height as
+	// the endpoints -- i.e., the line passes through a carved-out region
+	// (e.g., under a wall) where no floor polygon exists at the agent's
+	// current vertical level. The existing `Zenith_NavMesh::Raycast` is a
+	// ray-vs-polygon-plane test that misses these gaps because the ray
+	// runs parallel to the navmesh polygons and finds no plane to hit; A*
+	// can return a "neighbour" between two floor polygons on opposite
+	// sides of a wall because adjacency is computed from shared vertex
+	// indices and the grid keeps vertex indices stable across the carve.
+	//
+	// Why the tight vertical tolerance: with the default 1.5m tolerance
+	// (matching SegmentCrossesBlockedPolygon), a sample at floor height
+	// y=0.1 inside the wall's carved-out footprint would still "find" the
+	// wall-top polygon at y=1.0 (0.9m above) and return false (not a
+	// hole). We need a tolerance closer to the agent's max step height
+	// (0.3m) so polygons at the WRONG vertical level don't mask the gap.
+	//
+	// Tuning notes:
+	//   * 24 samples gives ~0.25m spacing for a 6m shortcut. The wall test
+	//     needs at least one sample inside the 0.6m-thick wall footprint;
+	//     0.25m spacing leaves ~0.35m of slack either side of the wall.
+	//   * Vertical tolerance = mean of endpoint Y ± kVERT_SLACK. Picking
+	//     against the actual segment endpoints (vs a fixed 0.3m) lets the
+	//     probe work for ramps + multi-level scenes where the line itself
+	//     crosses a Y delta.
+	//   * Sample indices 1..N-1 only (skip endpoints) -- endpoints are by
+	//     construction on the navmesh (A* placed them there).
+	bool SegmentExitsNavMesh(const Zenith_NavMesh& xNavMesh,
+		const Zenith_Maths::Vector3& xA, const Zenith_Maths::Vector3& xB)
+	{
+		constexpr int   kSamples    = 24;
+		constexpr float kVERT_SLACK = 0.5f;  // half the default 1.0m floor-to-ceiling envelope
+		for (int i = 1; i < kSamples; ++i)
+		{
+			const float fT = static_cast<float>(i) / static_cast<float>(kSamples);
+			const Zenith_Maths::Vector3 xP = xA + (xB - xA) * fT;
+			const uint32_t uPoly = xNavMesh.FindPolygonContaining(xP, kVERT_SLACK);
+			if (uPoly == UINT32_MAX) return true;
+		}
+		return false;
+	}
 }
 
 void Zenith_Pathfinding::SmoothPath(Zenith_Vector<Zenith_Maths::Vector3>& axPath,
@@ -347,17 +390,25 @@ void Zenith_Pathfinding::SmoothPath(Zenith_Vector<Zenith_Maths::Vector3>& axPath
 			const bool bBlockedByObstacle =
 				SegmentCrossesBlockedPolygon(xNavMesh,
 					axPath.Get(uCurrent), axPath.Get(u));
-			if (!bRaycastBlocked && !bBlockedByObstacle)
+			// Static-geometry gate — see SegmentExitsNavMesh above. The
+			// geometric Raycast also misses HOLES in the navmesh (carved
+			// cells under a wall), so without this check the smoother
+			// shortcuts across walls.
+			const bool bExitsNavMesh =
+				SegmentExitsNavMesh(xNavMesh,
+					axPath.Get(uCurrent), axPath.Get(u));
+			if (!bRaycastBlocked && !bBlockedByObstacle && !bExitsNavMesh)
 			{
-				// Path is geometrically clear AND doesn't cross a blocked
-				// polygon — safe to extend the shortcut.
+				// Path is geometrically clear, doesn't cross a blocked
+				// polygon, AND stays on the navmesh — safe to extend.
 				uFurthest = u;
 			}
 			else
 			{
-				// Either we'd leave the navmesh or cross a blocked
-				// polygon. Subsequent waypoints would also be unreachable
-				// from uCurrent by the same line, so stop searching.
+				// Either we'd leave the navmesh, cross a blocked polygon,
+				// or pass through a carved-out region. Subsequent waypoints
+				// would also be unreachable from uCurrent by the same line,
+				// so stop searching.
 				break;
 			}
 		}

--- a/Zenith/UnitTests/Zenith_UnitTests.h
+++ b/Zenith/UnitTests/Zenith_UnitTests.h
@@ -303,6 +303,8 @@ public:
 	static void TestPathfindingNoDuplicateWaypoints();
 	static void TestPathfindingBatchProcessing();
 	static void TestPathfindingPartialPath();
+	static void TestPathfindingSmootherRejectsCarvedShortcut();
+	static void TestPathfindingSmootherAcceptsValidShortcut();
 
 	// NavMesh Generator helper tests
 	static void TestCountWalkableSpans();


### PR DESCRIPTION
## Summary

Fixes the long-standing engine bug where AI pathfinding walked straight through walls. Discovered during MVP-1.2.0 spike (DP roadmap) -- see PR #31 / `Q-2026-05-13-NM01` for the full investigation.

## What was broken

Three independent bugs combined to silently swallow walls:

1. **`NavMeshGenerator::CollectGeometryFromScene`** emitted only the top face of each box collider. The voxelizer never saw the wall body.
2. **`NavMeshGenerator::RasterizeTriangle`** bailed early for non-walkable slopes, so even if all six faces were emitted, the vertical sides never made it into the voxel grid.
3. **`Pathfinding::SmoothPath`** used `Zenith_NavMesh::Raycast` (ray-vs-polygon-plane) which finds nothing in a navmesh "hole" -- so even with the carve, the smoother straight-lined paths back through the gap.

The combined effect: a wall placed on a floor was completely invisible to AI agents.

## What's fixed

**Generator** now emits all 6 box faces and marks non-walkable triangles (sides + bottom) as OBSTRUCTION spans (area type 0). Those spans don't appear in the polygon mesh, but they trip `HasInsufficientClearance` above any walkable span beneath them. With a 1m-tall wall + 1.8m agent height, the floor span at the wall's footprint has only 0.9m clearance -- correctly flagged non-walkable. Logged: `"FilterWalkableSpans: Filtered 51 spans, 1681 remaining"` matching the wall's 5m x 0.6m / 0.3m-cell footprint exactly.

**Smoother** now also runs a third probe, `SegmentExitsNavMesh`, that samples the proposed shortcut and asserts every sample lands on a polygon at roughly the same height as the endpoints (0.5m vertical tolerance -- tight enough to exclude wall-top polygons 1m above floor samples).

## Tests

**Engine unit tests** (`Zenith_Pathfinding.Tests.inl`):
- `PathfindingSmootherRejectsCarvedShortcut` -- reproduces the production bug-state (two floor polygons claiming adjacency across a gap, wall-top polygon spanning the gap above); asserts the smoother does NOT collapse a 3-waypoint candidate to 2.
- `PathfindingSmootherAcceptsValidShortcut` -- counter-check that a redundant intermediate on a continuous floor DOES still smooth out.

**DP integration test** (`Test_P1NavMesh_PathRespectsWalls`):
- Builds a real 12x12m floor + 5m wide / 1m tall wall scene using `Zenith_ColliderComponent`.
- Calls `Zenith_NavMeshGenerator::GenerateFromScene` then `Zenith_Pathfinding::FindPath((0,0.1,-3),(0,0.1,+3))`.
- Asserts the path detours past the wall (`length > 6.5m`, `maxAbsX >= 1.6m`).

## Verification

- [x] 1153/1153 engine unit tests pass locally (`--list-automated-tests` boot includes unit-tests run; the two new tests are part of those 1153).
- [x] `Test_P1NavMesh_PathRespectsWalls`: length=8.350m, maxAbsX=2.750m, passed=1.
- [x] Full DP suite headless: 48/48 pass (no regressions on existing tests).

## Roadmap impact

Unblocks MVP-1.2.1 -- this PR IS the production-ready Test_P1NavMesh_PathRespectsWalls. Once this lands, MVP-1.2.2 (wire `DP_AI::GetOrBuildLevelNavMesh` to call `GenerateFromScene`) is straightforward; MVP-1.2.3 (door portals) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)