### PR TITLE
perf(engine): NavMesh adjacency O(N²) → O(N) -- GameLevel went from >5min to 855ms

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -235,6 +235,7 @@
     <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp" />
     <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp" />
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
+    <ClCompile Include="..\Tests\Test_T1NavMesh_GeneratorPerf.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T1NavMesh_GeneratorPerf.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -529,6 +529,7 @@
     <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp" />
     <ClCompile Include="..\Tests\Test_T0RenderBus_RecordsDrawCalls.cpp" />
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp" />
+    <ClCompile Include="..\Tests\Test_T1NavMesh_GeneratorPerf.cpp" />
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClCompile Include="..\Tests\Test_T0SaveData_TestHooks.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_T1NavMesh_GeneratorPerf.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_VisualWiring.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_T1NavMesh_GeneratorPerf.cpp
+++ b/Games/DevilsPlayground/Tests/Test_T1NavMesh_GeneratorPerf.cpp
@@ -1,0 +1,176 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_Entity.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_ColliderComponent.h"
+#include "AI/Navigation/Zenith_NavMeshGenerator.h"
+#include "Profiling/Zenith_Profiling.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cmath>
+
+// ============================================================================
+// Test_T1NavMesh_GeneratorPerfOnGameLevel (diagnostic)
+//
+// Loads GameLevel, scans every static collider for its world-space AABB,
+// then calls Zenith_NavMeshGenerator::GenerateFromScene under the
+// profiling system and dumps a per-stage report.
+//
+// Surfaces:
+//   * The outlier collider(s) stretching the navmesh bounding box.
+//   * Which pipeline stage (voxelize / filter / regions / contours /
+//     poly mesh / final assembly) dominates the wall-clock budget.
+//
+// Pass criterion: GenerateFromScene returns a non-null navmesh. The
+// timing data is for triage, not yet for enforcing a perf budget.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kGP_Start, kGP_WaitScene, kGP_Dump, kGP_Generate, kGP_Done };
+
+	int   g_iPhase = kGP_Start;
+	bool  g_bPassed = false;
+}
+
+static void Setup_T1NavMeshGeneratorPerf()
+{
+	g_iPhase = kGP_Start;
+	g_bPassed = false;
+	Zenith_Profiling::ClearEvents();
+}
+
+static bool Step_T1NavMeshGeneratorPerf(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kGP_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kGP_WaitScene;
+		return true;
+
+	case kGP_WaitScene:
+		if (iFrame < 10) return true;
+		g_iPhase = kGP_Dump;
+		return true;
+
+	case kGP_Dump:
+	{
+		// Scan every entity with a static collider, log its AABB. The goal
+		// is to find outliers that stretch the navmesh bounding box.
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene == nullptr) { g_iPhase = kGP_Done; return false; }
+
+		const Zenith_Vector<Zenith_EntityID>& axIds = pxScene->GetActiveEntities();
+		uint32_t uColliderCount = 0;
+		float fMinX = 1e30f, fMinY = 1e30f, fMinZ = 1e30f;
+		float fMaxX = -1e30f, fMaxY = -1e30f, fMaxZ = -1e30f;
+
+		std::printf("[T1NavMeshPerf] Scanning %u entities for static colliders...\n",
+			axIds.GetSize());
+
+		for (uint32_t u = 0; u < axIds.GetSize(); ++u)
+		{
+			Zenith_Entity xEnt = pxScene->TryGetEntity(axIds.Get(u));
+			if (!xEnt.IsValid()) continue;
+			if (!xEnt.HasComponent<Zenith_ColliderComponent>()) continue;
+			Zenith_ColliderComponent& xCol = xEnt.GetComponent<Zenith_ColliderComponent>();
+			if (xCol.GetRigidBodyType() != RIGIDBODY_TYPE_STATIC) continue;
+			if (!xEnt.HasComponent<Zenith_TransformComponent>()) continue;
+
+			++uColliderCount;
+			Zenith_TransformComponent& xT = xEnt.GetComponent<Zenith_TransformComponent>();
+			Zenith_Maths::Vector3 xPos, xScl;
+			xT.GetPosition(xPos);
+			xT.GetScale(xScl);
+
+			const float fHalfX = std::fabs(xScl.x) * 0.5f;
+			const float fHalfY = std::fabs(xScl.y) * 0.5f;
+			const float fHalfZ = std::fabs(xScl.z) * 0.5f;
+			const float fEntMinX = xPos.x - fHalfX, fEntMaxX = xPos.x + fHalfX;
+			const float fEntMinY = xPos.y - fHalfY, fEntMaxY = xPos.y + fHalfY;
+			const float fEntMinZ = xPos.z - fHalfZ, fEntMaxZ = xPos.z + fHalfZ;
+
+			fMinX = std::min(fMinX, fEntMinX); fMaxX = std::max(fMaxX, fEntMaxX);
+			fMinY = std::min(fMinY, fEntMinY); fMaxY = std::max(fMaxY, fEntMaxY);
+			fMinZ = std::min(fMinZ, fEntMinZ); fMaxZ = std::max(fMaxZ, fEntMaxZ);
+
+			// Print colliders with extreme bounds (likely outliers).
+			const bool bExtremeXorZ = std::fabs(xPos.x) > 200.0f || std::fabs(xPos.z) > 200.0f;
+			const bool bExtremeY    = std::fabs(xPos.y) > 50.0f;
+			const bool bExtremeSize = fHalfX > 50.0f || fHalfY > 50.0f || fHalfZ > 50.0f;
+			if (bExtremeXorZ || bExtremeY || bExtremeSize)
+			{
+				const std::string& strName = xEnt.GetName();
+				std::printf("[T1NavMeshPerf] OUTLIER name='%s' pos=(%.1f, %.1f, %.1f) "
+				            "halfExt=(%.1f, %.1f, %.1f)\n",
+					strName.c_str(), xPos.x, xPos.y, xPos.z, fHalfX, fHalfY, fHalfZ);
+			}
+		}
+
+		std::printf("[T1NavMeshPerf] %u static colliders. Scene AABB: "
+		            "x=[%.1f, %.1f] y=[%.1f, %.1f] z=[%.1f, %.1f] -> %.1fm x %.1fm x %.1fm\n",
+			uColliderCount,
+			fMinX, fMaxX, fMinY, fMaxY, fMinZ, fMaxZ,
+			fMaxX - fMinX, fMaxY - fMinY, fMaxZ - fMinZ);
+		std::fflush(stdout);
+		g_iPhase = kGP_Generate;
+		return true;
+	}
+
+	case kGP_Generate:
+	{
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene == nullptr) { g_iPhase = kGP_Done; return false; }
+
+		NavMeshGenerationConfig xCfg{};
+		const auto xStart = std::chrono::high_resolution_clock::now();
+		Zenith_NavMesh* pxNavMesh = Zenith_NavMeshGenerator::GenerateFromScene(*pxScene, xCfg);
+		const auto xEnd = std::chrono::high_resolution_clock::now();
+
+		const std::chrono::duration<float, std::milli> xMs = xEnd - xStart;
+		const uint32_t uPolyCount = (pxNavMesh != nullptr) ? pxNavMesh->GetPolygonCount() : 0;
+
+		std::printf("[T1NavMeshPerf] GenerateFromScene on GameLevel: %.2f ms, %u polygons\n",
+			xMs.count(), uPolyCount);
+		std::printf("[T1NavMeshPerf] ---- profiling report ----\n");
+		std::fflush(stdout);
+		Zenith_Profiling::WriteTextReport(stdout);
+		std::printf("[T1NavMeshPerf] ---- end profiling ----\n");
+		std::fflush(stdout);
+
+		g_bPassed = (pxNavMesh != nullptr);
+		delete pxNavMesh;
+		g_iPhase = kGP_Done;
+		return false;
+	}
+
+	case kGP_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_T1NavMeshGeneratorPerf()
+{
+	return g_bPassed;
+}
+
+static const Zenith_AutomatedTest g_xT1NavMeshGeneratorPerfTest = {
+	"Test_T1NavMesh_GeneratorPerfOnGameLevel",
+	&Setup_T1NavMeshGeneratorPerf,
+	&Step_T1NavMeshGeneratorPerf,
+	&Verify_T1NavMeshGeneratorPerf,
+	600,
+	false
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xT1NavMeshGeneratorPerfTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp
+++ b/Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp
@@ -2,6 +2,7 @@
 #include "AI/Navigation/Zenith_NavMeshGenerator.h"
 #include "EntityComponent/Zenith_Scene.h"
 #include "EntityComponent/Components/Zenith_ColliderComponent.h"
+#include "Profiling/Zenith_Profiling.h"
 #include <algorithm>
 #include <queue>
 
@@ -20,10 +21,13 @@ Zenith_NavMesh* Zenith_NavMeshGenerator::GenerateFromScene(Zenith_SceneData& xSc
 	Zenith_Vector<Zenith_Maths::Vector3> axVertices;
 	Zenith_Vector<uint32_t> axIndices;
 
-	if (!CollectGeometryFromScene(xScene, axVertices, axIndices))
 	{
-		Zenith_Log(LOG_CATEGORY_AI, "Failed to collect geometry from scene");
-		return nullptr;
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_COLLECT_GEOMETRY);
+		if (!CollectGeometryFromScene(xScene, axVertices, axIndices))
+		{
+			Zenith_Log(LOG_CATEGORY_AI, "Failed to collect geometry from scene");
+			return nullptr;
+		}
 	}
 
 	Zenith_Log(LOG_CATEGORY_AI, "Collected %u vertices, %u triangles",
@@ -37,6 +41,12 @@ Zenith_NavMesh* Zenith_NavMeshGenerator::GenerateFromGeometry(
 	const Zenith_Vector<uint32_t>& axIndices,
 	const NavMeshGenerationConfig& xConfig)
 {
+	// Top-level scope covers the entire generation pipeline. Sub-stage
+	// scopes below let WriteTextReport pinpoint which Recast-style phase
+	// dominates the total (collect / voxelize / filter / regions / contours
+	// / polygon mesh / final navmesh assembly).
+	Zenith_Profiling::Scope xGenerateScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE);
+
 	if (axVertices.GetSize() == 0 || axIndices.GetSize() < 3)
 	{
 		Zenith_Log(LOG_CATEGORY_AI, "No geometry to generate NavMesh from");
@@ -49,49 +59,74 @@ Zenith_NavMesh* Zenith_NavMeshGenerator::GenerateFromGeometry(
 	xContext.m_xConfig = xConfig;
 
 	// Compute bounds
-	if (!ComputeBounds(axVertices, xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_COMPUTE_BOUNDS);
+		if (!ComputeBounds(axVertices, xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Voxelize
-	if (!VoxelizeTriangles(axVertices, axIndices, xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_VOXELIZE);
+		if (!VoxelizeTriangles(axVertices, axIndices, xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Filter walkable
-	if (!FilterWalkableSpans(xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_FILTER_WALKABLE);
+		if (!FilterWalkableSpans(xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Build compact heightfield
-	if (!BuildCompactHeightfield(xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_COMPACT_HF);
+		if (!BuildCompactHeightfield(xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Build regions
-	if (!BuildRegions(xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_REGIONS);
+		if (!BuildRegions(xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Trace contours
-	if (!TraceContours(xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_TRACE_CONTOURS);
+		if (!TraceContours(xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Build polygon mesh
-	if (!BuildPolygonMesh(xContext))
 	{
-		return nullptr;  // RAII: xContext destructor cleans up
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_POLY_MESH);
+		if (!BuildPolygonMesh(xContext))
+		{
+			return nullptr;  // RAII: xContext destructor cleans up
+		}
 	}
 
 	// Build final NavMesh
-	Zenith_NavMesh* pxNavMesh = BuildNavMesh(xContext);
+	Zenith_NavMesh* pxNavMesh = nullptr;
+	{
+		Zenith_Profiling::Scope xScope(ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_NAVMESH);
+		pxNavMesh = BuildNavMesh(xContext);
+	}
 
 	// RAII: xContext destructor cleans up heightfield when function returns
 
@@ -846,32 +881,63 @@ Zenith_NavMesh* Zenith_NavMeshGenerator::BuildNavMesh(GenerationContext& xContex
 	// Compute spatial data
 	pxNavMesh->ComputeSpatialData();
 
-	// Build adjacency (find shared edges)
-	for (uint32_t uPoly1 = 0; uPoly1 < pxNavMesh->GetPolygonCount(); ++uPoly1)
+	// Build adjacency by finding shared edges.
+	//
+	// Previously this was an O(N^2 * E^2) double loop -- for a navmesh with
+	// 131,983 polygons (DP GameLevel scale) that's ~1.4e11 operations and
+	// the generator took >5 minutes on a single scene load. Replaced with an
+	// O(N * E) hash-map pass: each edge is normalised to (min(v1,v2),
+	// max(v1,v2)) and looked up; the first polygon to claim an edge inserts
+	// itself, the second finds it and the pair are stitched as neighbours.
+	// Each edge is shared by at most two polygons in a valid manifold mesh
+	// (which Recast-style polygon meshes are by construction), so the hash
+	// map yields exact-pair matches in linear time.
+	//
+	// Verified DP GameLevel: 131,983 polygons, adjacency went from
+	// > 5 minutes (timeout) to milliseconds.
 	{
-		const Zenith_NavMeshPolygon& xPoly1 = pxNavMesh->GetPolygon(uPoly1);
-
-		for (uint32_t uPoly2 = uPoly1 + 1; uPoly2 < pxNavMesh->GetPolygonCount(); ++uPoly2)
+		struct EdgeOwner
 		{
-			const Zenith_NavMeshPolygon& xPoly2 = pxNavMesh->GetPolygon(uPoly2);
+			uint32_t m_uPoly = UINT32_MAX;
+			uint32_t m_uEdge = UINT32_MAX;
+		};
+		const auto MakeKey = [](uint32_t uA, uint32_t uB) -> uint64_t
+		{
+			const uint32_t uLo = uA < uB ? uA : uB;
+			const uint32_t uHi = uA < uB ? uB : uA;
+			return (static_cast<uint64_t>(uHi) << 32) | static_cast<uint64_t>(uLo);
+		};
 
-			// Check each edge of poly1 against each edge of poly2
-			for (uint32_t uEdge1 = 0; uEdge1 < xPoly1.m_axVertexIndices.GetSize(); ++uEdge1)
+		Zenith_HashMap<uint64_t, EdgeOwner> xEdgeOwners;
+		const uint32_t uPolyCount = pxNavMesh->GetPolygonCount();
+		for (uint32_t uPoly = 0; uPoly < uPolyCount; ++uPoly)
+		{
+			const Zenith_NavMeshPolygon& xPoly = pxNavMesh->GetPolygon(uPoly);
+			const uint32_t uEdgeCount = xPoly.m_axVertexIndices.GetSize();
+			for (uint32_t uEdge = 0; uEdge < uEdgeCount; ++uEdge)
 			{
-				uint32_t uV1a = xPoly1.m_axVertexIndices.Get(uEdge1);
-				uint32_t uV1b = xPoly1.m_axVertexIndices.Get((uEdge1 + 1) % xPoly1.m_axVertexIndices.GetSize());
+				const uint32_t uVa = xPoly.m_axVertexIndices.Get(uEdge);
+				const uint32_t uVb = xPoly.m_axVertexIndices.Get((uEdge + 1) % uEdgeCount);
+				const uint64_t uKey = MakeKey(uVa, uVb);
 
-				for (uint32_t uEdge2 = 0; uEdge2 < xPoly2.m_axVertexIndices.GetSize(); ++uEdge2)
+				if (EdgeOwner* pxExisting = xEdgeOwners.TryGet(uKey))
 				{
-					uint32_t uV2a = xPoly2.m_axVertexIndices.Get(uEdge2);
-					uint32_t uV2b = xPoly2.m_axVertexIndices.Get((uEdge2 + 1) % xPoly2.m_axVertexIndices.GetSize());
-
-					// Check if edges share vertices (in opposite order for adjacency)
-					if ((uV1a == uV2b && uV1b == uV2a) || (uV1a == uV2a && uV1b == uV2b))
-					{
-						pxNavMesh->SetNeighbor(uPoly1, uEdge1, uPoly2);
-						pxNavMesh->SetNeighbor(uPoly2, uEdge2, uPoly1);
-					}
+					// Found a polygon that already owns this edge -- stitch
+					// both directions. A truly degenerate mesh could in
+					// principle map three polygons to the same edge; we'd
+					// only stitch the first two found here. That's
+					// acceptable: production-mesh generation produces
+					// manifold geometry, and stitching extras would require
+					// edge->multi-polygon storage.
+					pxNavMesh->SetNeighbor(uPoly, uEdge, pxExisting->m_uPoly);
+					pxNavMesh->SetNeighbor(pxExisting->m_uPoly, pxExisting->m_uEdge, uPoly);
+				}
+				else
+				{
+					EdgeOwner xOwner;
+					xOwner.m_uPoly = uPoly;
+					xOwner.m_uEdge = uEdge;
+					xEdgeOwners.Insert(uKey, xOwner);
 				}
 			}
 		}

--- a/Zenith/Profiling/Zenith_Profiling.h
+++ b/Zenith/Profiling/Zenith_Profiling.h
@@ -80,6 +80,17 @@ enum Zenith_ProfileIndex
 	ZENITH_PROFILE_INDEX__AI_PATHFINDING,
 	ZENITH_PROFILE_INDEX__AI_AGENT_UPDATE,
 	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE,
+	// Sub-stages of AI_NAVMESH_GENERATE -- each wrapped individually so the
+	// profile report shows which Recast-style phase dominates the total.
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_COLLECT_GEOMETRY,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_COMPUTE_BOUNDS,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_VOXELIZE,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_FILTER_WALKABLE,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_COMPACT_HF,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_REGIONS,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_TRACE_CONTOURS,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_POLY_MESH,
+	ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_BUILD_NAVMESH,
 	ZENITH_PROFILE_INDEX__AI_DEBUG_DRAW,
 
 	// TilePuzzle Level Generation
@@ -169,6 +180,15 @@ static const char* g_aszProfileNames[]
 	"AI Pathfinding",
 	"AI Agent Update",
 	"AI NavMesh Generate",
+	"AI NavMesh Generate / Collect Geometry",
+	"AI NavMesh Generate / Compute Bounds",
+	"AI NavMesh Generate / Voxelize",
+	"AI NavMesh Generate / Filter Walkable",
+	"AI NavMesh Generate / Build Compact HF",
+	"AI NavMesh Generate / Build Regions",
+	"AI NavMesh Generate / Trace Contours",
+	"AI NavMesh Generate / Build Poly Mesh",
+	"AI NavMesh Generate / Build NavMesh",
 	"AI Debug Draw",
 
 	// TilePuzzle Level Generation


### PR DESCRIPTION
## Summary

When I tried to wire `DP_AI::GetOrBuildLevelNavMesh` to call `Zenith_NavMeshGenerator::GenerateFromScene` (MVP-1.2.2), the DP test suite hung -- a single generation on `GameLevel` (177 static colliders, 132K polygons) took longer than the 5-minute test timeout. Bisected the pipeline with `Zenith_Profiling` + per-stage scopes and pinned it on `BuildNavMesh`'s adjacency loop.

## The bug

`Zenith_NavMeshGenerator::BuildNavMesh` (Zenith_NavMeshGenerator.cpp ~line 885) does a four-nested loop:

```cpp
for poly1 in polygons:
  for poly2 > poly1:
    for edge1 in poly1:
      for edge2 in poly2:
        if edges match: stitch
```

For 131,983 polygons that's `~1.4×10¹¹` operations.

## The fix

Replace the polygon-pair loop with an edge-keyed hash map. Each undirected edge hashes as `(min(va, vb), max(va, vb))`. The first polygon to insert an edge becomes the owner; the second polygon to look up the same edge finds the owner and stitches both sides. In a manifold polygon mesh (which Recast-style polygon emit produces by construction) each edge appears in at most two polygons, so the hash map converges in `O(N × E)` time.

## Measurements (post-fix, via `Zenith_Profiling::WriteTextReport`)

GameLevel: 177 static colliders, 131,983 polygons, navmesh grid 505 × 670 × 189 cells.

```
Stage                                              Total ms
------------------------------------------------   --------
AI NavMesh Generate                                  842.3
  Trace Contours                                     446.6
  Build NavMesh (now contains the O(N) adjacency)    238.4
  Voxelize                                            48.1
  Build Poly Mesh                                     42.8
  Collect Geometry                                    12.9
  Build Regions                                       12.4
  Filter Walkable                                     10.8
  Build Compact HF                                     9.4
  Compute Bounds                                       1.1
```

`BuildNavMesh` alone was the >5-minute timeout. After the fix it's 238ms -- a >1200× speedup of that stage, ~350× of the whole pipeline (likely much more; the pre-fix number is a lower bound).

## Other changes

- **Profile instrumentation:** added per-stage indices under `ZENITH_PROFILE_INDEX__AI_NAVMESH_GENERATE_*` so future regressions are bisectable without re-instrumenting. The dispatch loop in `Zenith_NavMeshGenerator::GenerateFromGeometry` wraps each Recast-style phase in a `Zenith_Profiling::Scope`.
- **Diagnostic test** `Test_T1NavMesh_GeneratorPerfOnGameLevel`: scans every static collider, logs the scene AABB + outliers (entities stretching the bounds), times `GenerateFromScene`, dumps the profile report via `Zenith_Profiling::WriteTextReport(stdout)`. Currently passes as long as the generator returns non-null -- not yet a perf-budget gate.

## Verification

- [x] `Test_T1NavMesh_GeneratorPerfOnGameLevel` passed in 13 frames (~850ms generate + I/O).
- [x] `Test_P1NavMesh_PathRespectsWalls` (from PR #32) still passes — same path detour numbers as before (8.35m length, 2.75m max-X).
- [x] Full DP suite: 50/50 pass headless (`run_dp_tests.ps1 -Headless`).

## Roadmap impact

Unblocks MVP-1.2.2 (wire `DP_AI::GetOrBuildLevelNavMesh` to `GenerateFromScene`). With one-time generation at ~850ms + a scene-keyed cache, the production path becomes feasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)