### PR TITLE
docs(dp): MVP-1.2.2 attempt-2 deferred -- real navmesh exposes disconnected regions

### DIFF
--- a/Games/DevilsPlayground/Docs/DecisionLog.md
+++ b/Games/DevilsPlayground/Docs/DecisionLog.md
@@ -8,6 +8,28 @@
 
 ---
 
+## 2026-05-13 — MVP-1.2.2 attempt-2 deferred: real navmesh exposes disconnected regions, `PriestPursuit_Test` fails (Q-2026-05-13-NM03).
+
+**Decision:** Do NOT wire `DP_AI::GetOrBuildLevelNavMesh` to `Zenith_NavMeshGenerator::GenerateFromScene` yet. The engine perf fix (PR #33) makes the generation step fast enough (~850ms on GameLevel + cache amortises across batched tests), but the resulting navmesh accurately reflects GameLevel's collider geometry -- which has rooms walled-off with no doorway gaps. `PriestPursuit_Test` puts the priest at (62.4, 1.0, 56.5) and villager at (65.2, 2.0, 53.1) -- 4.4m apart but in different navmesh regions. `FindPath` returns `hasPath=0` and the priest doesn't move.
+
+**What I tried (and reverted):**
+1. Wire `GetOrBuildLevelNavMesh` to call `GenerateFromScene` first, fall back to the synthetic flat quad on null/empty result.
+2. Cache by `Zenith_SceneData::GetBuildIndex()` so the test harness's force-load + load-next pattern between tests doesn't trigger a fresh rebuild each time. (Cache key was correct -- the issue was the navmesh itself, not the cache.)
+3. Ran full DP suite: 49/50 pass + 1 fail (`PriestPursuit_Test`) + 1 batch-process crash. Reverted the wiring.
+
+**Why this is a "real-fix-needed" not "test-needs-loosening":** the test isn't asserting unreachable AI behaviour; it asserts that the priest closes distance on a nearby villager over 120 frames. With the synthetic mesh the priest could walk through walls (incorrect, but worked for the test). With the real mesh the priest stays put because every navmesh polygon adjacent to its spawn is sealed off from the villager's polygon. The right answer is the navmesh learning to thread through doorways, not the test relaxing its assertion.
+
+**Next-step option that I'd take if asked:** add `Zenith_NavMesh::PunchOpening(xPoint, fRadius)` engine API. `DPDoor_Behaviour` calls it at OnStart for every authored door, carving a connector through the wall-induced region boundary in the navmesh. Or implement off-mesh-connections (Recast standard) -- bigger surface, more complete. Either way, requires engine work + a new DPDoor wiring pass before MVP-1.2.2 can land.
+
+**Trade-offs considered:**
+- *Land MVP-1.2.2 + accept the `PriestPursuit_Test` regression.* Rejected -- the regression is genuine (priest is stuck), not a test artifact.
+- *Adjust `PriestPursuit_Test` to spawn priest + villager in the same room.* Possible but fragile -- the level's room layout shifts as we extend GameLevel. Better to fix the navmesh.
+- *Ship MVP-1.2.2 with an opt-in flag* (real navmesh for some tests, synthetic for others). Considered but adds production complexity for short-term test convenience.
+
+**Reversibility:** trivial -- no code committed. Documented in Q-2026-05-13-NM03.
+
+---
+
 ## 2026-05-13 — MVP-1.2.0 spike result: navmesh generator's top-face-only collector blocks the roadmap path. Filed as Q-2026-05-13-NM01.
 
 **Decision:** Do NOT commit a `Test_P1NavMesh_PathRespectsWalls` that fails to actually verify wall-respecting paths. The spike (described in the roadmap as "Author a single static test scene with 4 cube walls forming a room with a doorway. Call `Zenith_NavMeshGenerator::GenerateFromScene` on it. Assert the returned `Zenith_NavMesh*` is non-null and `FindPath(start, end)` routes around the wall") was implemented and run. The generator returns non-null and `FindPath` succeeds -- but the path is a straight line through where the wall should be. Cause documented in Q-2026-05-13-NM01.

--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -10,6 +10,34 @@
 
 ## Open
 
+### ⚠️ Q-2026-05-13-NM03 — MVP-1.2.2 (real navmesh in DP_AI) reveals disconnected regions; `PriestPursuit_Test` breaks because priest + closest villager land in different regions.
+
+**Context:** With PR #32 (walls block paths) + PR #33 (O(N) adjacency, 850ms generate) both landed, the production path of wiring `DP_AI::GetOrBuildLevelNavMesh` to call `Zenith_NavMeshGenerator::GenerateFromScene` is technically feasible. I wired it with a build-index-keyed cache and ran the DP suite -- 49/50 pass, but `PriestPursuit_Test` fails:
+
+```
+[AI] DP_AI: built real navmesh for build-index=1 (136784 verts, 131983 polys)
+[AI] PriestPursuit: navAgent=... target=(231/2) priestPos=(62.4,1.0,56.5)
+     villagerPos=(65.2,2.0,53.1) hasPath=0 vel=(0.00,0.00,0.00) patrol=(62.9,1.9,56.4)
+[AI] PriestPursuit_Test: initial=4.40 final=4.40 progress=0.00
+```
+
+`hasPath=0` over 4.4m of separation -- the priest's polygon and the closest villager's polygon are in **different connected components** of the navmesh. GameLevel's authored colliders (walls of every individual building) fully enclose rooms with no doorway-shaped gaps in the navmesh, so flood-filled regions are isolated.
+
+**This is the navmesh accurately representing the level geometry.** It's correct, just not what the existing test expects. The old synthetic 200m × 200m flat quad let the priest path to any villager.
+
+**Implication:** MVP-1.2.2 needs more than just the wiring + cache. The roadmap's MVP-1.2.3 (`DPDoor::SyncNavMeshBlock` portal wiring) is the natural next step BUT it doesn't help here -- doors *unblock* portals between rooms, but the navmesh has no portals between rooms today because the underlying geometry has no doorway openings. Either:
+  a) The collider authoring needs explicit doorway gaps (re-export from UE source map -- blocked on the asset pipeline).
+  b) The generator needs an explicit "connector cell" mechanism where DPDoor entities punch a hole in the navmesh at their footprint.
+  c) The Recast pipeline needs an "off-mesh connection" API (Zenith doesn't currently have this).
+
+**My best guess if you don't reply:** keep MVP-1.2.2 reverted. PR #33 lands the perf fix on its own value (unblocks `Test_P1NavMesh_PathRespectsWalls` which now uses real navmesh on a tiny scratch scene). Sketch MVP-1.2.3 as "DPDoor punches a navmesh hole at runtime" -- needs an engine API `Zenith_NavMesh::PunchOpening(point, radius)`. Track as a separate engine PR. Once that lands, MVP-1.2.2 can wire DP_AI to real navmesh AND PriestPursuit_Test still passes.
+
+**Cost of getting it wrong:** moderate. Sticking with the synthetic flat quad means doors don't gate AI navigation -- the priest patrols through walls. The roadmap acknowledges this; MVP-1.2 was always going to be a multi-PR effort.
+
+**Status:** asked 2026-05-13.
+
+---
+
 ### ⚠️ Q-2026-05-13-NM01 — NavMesh generator's geometry collector only voxelises box-collider TOP faces; walls never block the floor below.
 
 **Context:** During MVP-1.2.0 spike (real navmesh integration) I built a tiny test scene with a 12x12m floor + a 5m wide / 1m tall box-collider wall, called `Zenith_NavMeshGenerator::GenerateFromScene`, and tried to verify that `Zenith_Pathfinding::FindPath((0, 0.1, -3), (0, 0.1, +3))` routed around the wall. It didn't -- the returned path is a 2-waypoint straight line right through where the wall should be (length 6.0, `|x|max` 0.0).


### PR DESCRIPTION
## Summary

Docs-only PR. With PRs #32 (walls block paths) + #33 (O(N) adjacency, 850ms generation) both in flight, MVP-1.2.2's wiring step *should* have been clean. It isn't.

## What I tried

Wired `DP_AI::GetOrBuildLevelNavMesh` to call `Zenith_NavMeshGenerator::GenerateFromScene` on the active scene with a build-index-keyed cache (so batched tests don't re-generate per scene boundary). Built clean. Ran the full DP suite.

```
[run_dp_tests] Summary: 49 passed, 2 failed
Failed tests:
    <batch:exit=1>
    PriestPursuit_Test
```

## Why `PriestPursuit_Test` fails

```
[AI] DP_AI: built real navmesh for build-index=1 (136784 verts, 131983 polys)
[AI] PriestPursuit: priestPos=(62.4,1.0,56.5) villagerPos=(65.2,2.0,53.1)
     hasPath=0 vel=(0.00,0.00,0.00)
```

4.4m of separation but `hasPath=0` -- priest and villager are in **different connected components** of the navmesh. GameLevel's authored colliders fully enclose every room, so flood-filled regions are isolated. This is the navmesh *correctly* modelling the level geometry. The old synthetic flat quad let the priest walk through walls, which the test depended on.

## Why I'm not landing the wiring

The fix is not "loosen the test" -- the test is asserting genuine AI behaviour (priest closes distance on nearby villager). The fix is the navmesh needs to thread through doorways. That requires either:

  a) Re-export GameLevel colliders from the UE source with doorway gaps (blocked on asset pipeline).
  b) An engine API `Zenith_NavMesh::PunchOpening(xPoint, fRadius)` so `DPDoor_Behaviour::OnStart` can carve a connector through the wall-induced region boundary at runtime.
  c) Off-mesh-connection support (Recast standard).

That's MVP-1.2.3 territory + more engine work. Documenting now so the next session has the breadcrumb.

## What this PR contains

- `Games/DevilsPlayground/Docs/Questions.md` -- new entry `Q-2026-05-13-NM03` with the empirical evidence + trade-off analysis.
- `Games/DevilsPlayground/Docs/DecisionLog.md` -- a DecisionLog entry recording the rejected approaches (land-with-regression / loosen-the-test / opt-in-flag) and why each was rejected.

## What's NOT in this PR

The actual wiring code -- it was reverted before commit, since landing it would have shipped a real `PriestPursuit_Test` regression for no production value (the priest already-walks-through-walls behaviour is at least playable).

## Test plan

- [x] doc_lint green locally.
- [ ] CI: `complexity-gate` + `doc-lint` pass (no code changes, dp-build/dp-tests are no-ops here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)