### PR TITLE
feat(engine,dp): ColliderComponent::SetIncludeInNavMesh -- runtime-blockable obstacles opt out of navmesh geometry

### DIFF
--- a/Games/DevilsPlayground/Components/DPDoor_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPDoor_Behaviour.h
@@ -12,6 +12,7 @@
 
 #include "Components/DPInteractable_Behaviour.h"
 #include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_ColliderComponent.h"
 #include "Maths/Zenith_Maths.h"
 #include "AI/Navigation/Zenith_NavMesh.h"
 #include "Source/PublicInterfaces.h"
@@ -36,6 +37,20 @@ public:
 		m_fOpenDuration = DP_Tuning::Get<float>("interactables.door_open_duration_s");
 		m_bIsOpen = false;
 		m_fOpenT = 0.0f;
+
+		// Doors are runtime-blockable obstacles. The wall colliders surrounding
+		// each room have authored doorway GAPS that are exactly door-width;
+		// the door entity itself sits IN that gap with its own collider. If
+		// the door's collider participated in the navmesh, the gap would be
+		// sealed and AI couldn't path between rooms even when the door is
+		// open. Mark the collider as nav-mesh-excluded so the generator emits
+		// walkable polygons through the doorway; SyncNavMeshBlock then toggles
+		// those polygons' BLOCKED flag at runtime based on open/closed state.
+		// See Zenith_ColliderComponent::SetIncludeInNavMesh for the contract.
+		if (m_xParentEntity.HasComponent<Zenith_ColliderComponent>())
+		{
+			m_xParentEntity.GetComponent<Zenith_ColliderComponent>().SetIncludeInNavMesh(false);
+		}
 	}
 
 	void OnStart() ZENITH_FINAL override

--- a/Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp
+++ b/Zenith/AI/Navigation/Zenith_NavMeshGenerator.cpp
@@ -178,6 +178,19 @@ bool Zenith_NavMeshGenerator::CollectGeometryFromScene(Zenith_SceneData& xScene,
 		{
 			continue;
 		}
+
+		// Opt-out: callers can mark a static collider as "not navmesh geometry"
+		// when the obstacle is meant to be runtime-blockable (doors, gates,
+		// lift barriers). Skipping these here lets the generator emit
+		// walkable polygons across the doorway gap; the gameplay layer then
+		// calls Zenith_NavMesh::SetBlockedAtPoint at runtime to mark those
+		// polygons blocked when the door is closed. See
+		// Zenith_ColliderComponent::SetIncludeInNavMesh for the contract.
+		if (!xCollider.GetIncludeInNavMesh())
+		{
+			continue;
+		}
+
 		++uEntitiesWithValidBodies;
 
 		if (!xEntity.HasComponent<Zenith_TransformComponent>())

--- a/Zenith/EntityComponent/Components/Zenith_ColliderComponent.h
+++ b/Zenith/EntityComponent/Components/Zenith_ColliderComponent.h
@@ -50,6 +50,17 @@ public:
 	void SetDebugDrawPhysicsMesh(bool bEnable) { m_bDebugDrawPhysicsMesh = bEnable; }
 	bool GetDebugDrawPhysicsMesh() const { return m_bDebugDrawPhysicsMesh; }
 
+	// NavMesh-input flag: when false, Zenith_NavMeshGenerator skips this
+	// collider during geometry collection. The collider still participates
+	// in physics. Use this for static obstacles that AI should be ABLE to
+	// path through dynamically (doors, breakable barriers, lift gates) --
+	// pathfinding then uses Zenith_NavMesh::SetPolygonBlocked / SetBlockedAtPoint
+	// at runtime to mark the corresponding polygons as blocked when the
+	// obstacle is in its "closed" state. Defaults to true (existing
+	// behaviour: every static collider becomes navmesh geometry).
+	void SetIncludeInNavMesh(bool bInclude) { m_bIncludeInNavMesh = bInclude; }
+	bool GetIncludeInNavMesh() const { return m_bIncludeInNavMesh; }
+
 	void AddCollider(CollisionVolumeType eVolumeType, RigidBodyType eRigidBodyType);
 	void AddCapsuleCollider(float fRadius, float fHalfHeight, RigidBodyType eRigidBodyType);
 	void RebuildCollider(); // Rebuild collider with current transform (e.g., after scale change)
@@ -103,6 +114,11 @@ private:
 	float m_fExplicitCapsuleHalfHeight = 0.0f;
 	bool m_bUseExplicitCapsuleDimensions = false;
 	bool m_bDebugDrawPhysicsMesh = false;
+	// See SetIncludeInNavMesh comment. Defaults to true so existing colliders
+	// (floors, walls, props) continue to contribute navmesh geometry without
+	// requiring an opt-in change. Callers that author runtime-blockable
+	// obstacles (doors, gates) opt OUT via SetIncludeInNavMesh(false).
+	bool m_bIncludeInNavMesh = true;
 
 	struct TerrainMeshData
 	{


### PR DESCRIPTION
## Summary

Fixes one of the issues the navmesh exposed (per session work): static obstacles meant to be **runtime-blockable** (doors, gates, breakable barriers) shouldn't seal off rooms in the navmesh -- the gameplay layer needs to dynamically block/unblock those polygons at runtime via `Zenith_NavMesh::SetBlockedAtPoint`.

## What broke

When I wired `DP_AI::GetOrBuildLevelNavMesh` to the real generator (PR #34's deferred MVP-1.2.2), `PriestPursuit_Test` failed because the priest's polygon and the nearest villager's polygon were in **different connected components**. Tracing the cause: every DPDoor authored a static box collider that participated in navmesh generation, sealing the doorway gaps that wall placement deliberately leaves between buildings.

A diagnostic run with `m_fAgentRadius = 0.0f` (zero erosion) confirmed the disconnection: with no agent shrinking, the doors still seal every room because they're solid box colliders sitting *in* the doorway.

## What changed

**Engine (`Zenith_ColliderComponent`):** new `SetIncludeInNavMesh(bool)` / `GetIncludeInNavMesh()`. Defaults to true so existing colliders (floors, walls, props) continue to contribute navmesh geometry without an opt-in change. The generator's `CollectGeometryFromScene` now skips static colliders flagged as nav-excluded -- their geometry still participates in physics, but the navmesh emits walkable polygons AROUND them as if they didn't exist.

**DP (`DPDoor_Behaviour`):** `OnAwake` now calls `m_xParentEntity.GetComponent<Zenith_ColliderComponent>().SetIncludeInNavMesh(false)`. Doors keep their physics collider (still block raycasts, still trigger proximity events) but no longer obstruct navmesh generation. `SyncNavMeshBlock` continues to toggle door-footprint polygons at runtime, which is what it was always meant to do once the underlying navmesh had polygons there to block.

## What this PR does NOT do

Does **not** wire `DP_AI::GetOrBuildLevelNavMesh` to call `GenerateFromScene`. With the engine change in place, real navmesh generation now produces walkable polygons through doorways -- but on GameLevel the priest still can't reach any villager. Diagnostic with `m_fAgentRadius = 0.0f` confirms it: even with zero erosion, no reachability exists. The underlying collider authoring's wall endpoints don't actually leave doorway-shaped gaps in the floor plane at navmesh-friendly widths. That's a level-data problem; filed as `Q-2026-05-13-NM03` in PR #34.

So this PR is engine + DP infrastructure ONLY. The pieces are in place for the eventual MVP-1.2.2 attempt; nothing here ships a behavioural change today.

## Verification

- [x] DP suite: 50/50 passing in 17s headless.
- [x] `Test_P1NavMesh_PathRespectsWalls` still passes (uses CreateEmptyScene with a tiny floor+wall fixture, not GameLevel).
- [x] Engine builds clean.

## Stack

Stacked on `engine/navmesh-adjacency-perf` (PR #33). Will rebase onto master once #33 lands. The engine API touch in this PR (new public methods + the generator filter) does not conflict with PR #34 (docs-only deferral note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)