### PR TITLE
docs(dp): Q-2026-05-14-NM01 -- engine MVP-1.2 stack complete; PriestPursuit_Test exposes a BT issue

### DIFF
--- a/Games/DevilsPlayground/Docs/DecisionLog.md
+++ b/Games/DevilsPlayground/Docs/DecisionLog.md
@@ -8,6 +8,33 @@
 
 ---
 
+## 2026-05-14 — MVP-1.2.2 attempt-3 finding: with the full engine stack landed (#32, #33, #35, #36, #37), reachability is fixed but `PriestPursuit_Test` exposes a SEPARATE BT-behaviour issue.
+
+**Context:** With all engine pieces landed -- walls block paths (PR #32), O(N) adjacency (PR #33), collider-can-opt-out-of-navmesh (PR #35), per-door portal stitching (PR #36), region-keyed vertex dedup (PR #37) -- I tried wiring `DP_AI::GetOrBuildLevelNavMesh` to `Zenith_NavMeshGenerator::GenerateFromScene` locally. `PriestPursuit_Test` no longer fails on `hasPath=0`; the navmesh-connectivity diagnosis from Q-2026-05-13-NM03 is fully resolved by the engine stack.
+
+**New failure mode:** with the priest relocated to villager + 0.5m offset (guaranteed-same-polygon reachability), the priest's BT runs for 120 frames and the priest MOVES AWAY from the villager (initial 0.59m → final 0.98m). hasPath might be 1 at some point but the priest's actual trajectory diverges from the villager. The pursue BT branch should fire when `BB.TargetWithDevil` is set (the test does set the possessed villager); either the BT picks a sub-branch other than pursue, or the path the agent follows wanders before the target is reached.
+
+**Hypotheses (not yet investigated):**
+  a) Pursue branch isn't firing because the perception bridge's `EmitSoundStimulus` (or sight check) hasn't yet detected the villager at distance < 1m -- the priest's awareness ramp may take frames to reach the threshold. With the synthetic 200m flat navmesh the priest would walk the long initial distance toward the villager via patrol, which had the side-effect of also building awareness; with the priest pre-positioned right next to the villager, that distance-walking step is skipped.
+  b) The BT's Selector picks patrol before pursue because the awareness isn't above threshold yet -- the patrol target picker (`GetRandomReachablePointInRadius`) returns a point in the wrong direction.
+  c) Path smoothing / navmesh quirk produces an unexpected first-waypoint direction.
+
+**Decision:** Don't ship the DP_AI wiring change in this session. The PriestPursuit regression is real (the metric goes UP, not down). The fix is BT-side -- investigate which branch fires, why pursue isn't triggering, what the perception ramp is doing -- not engine-side. Filed as Q-2026-05-14-NM01.
+
+What DOES ship this session: every engine surface MVP-1.2.2 needs to actually work. The PR-by-PR investment is intact:
+  * MVP-1.2.0 / 1.2.1 (walls block paths) -- PR #32, merged.
+  * MVP-1.2.5 (`GetPathWaypoints`) + 1.2.9 (`Zenith_NavMeshTestPathfinder`) -- PR #36, in CI.
+  * Generator-quality fixes (perf, collider opt-out, portal stitch, region keys) -- PRs #33, #35, #36, #37, all merged or in CI.
+
+**Trade-offs considered:**
+- *Land the wiring with a known regression on PriestPursuit_Test.* Rejected -- the metric goes the wrong way; that's not "behaviour is preserved", it's "a previously-passing test now reports the priest is broken".
+- *Land the wiring + the test relocation (0.5m offset).* Rejected -- the test now describes a different scenario than it claims to test (BT pursue under controlled spawn vs the original "find closest villager and pursue"), AND the test still fails.
+- *Skip the test gracefully when the priest can't reach any villager.* Rejected -- hides the BT bug that this PR exposed.
+
+**Reversibility:** trivial -- the wiring isn't on master.
+
+---
+
 ## 2026-05-13 — MVP-1.2.2 attempt-2 deferred: real navmesh exposes disconnected regions, `PriestPursuit_Test` fails (Q-2026-05-13-NM03).
 
 **Decision:** Do NOT wire `DP_AI::GetOrBuildLevelNavMesh` to `Zenith_NavMeshGenerator::GenerateFromScene` yet. The engine perf fix (PR #33) makes the generation step fast enough (~850ms on GameLevel + cache amortises across batched tests), but the resulting navmesh accurately reflects GameLevel's collider geometry -- which has rooms walled-off with no doorway gaps. `PriestPursuit_Test` puts the priest at (62.4, 1.0, 56.5) and villager at (65.2, 2.0, 53.1) -- 4.4m apart but in different navmesh regions. `FindPath` returns `hasPath=0` and the priest doesn't move.

--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -10,6 +10,27 @@
 
 ## Open
 
+### ⚠️ Q-2026-05-14-NM01 — With the full engine MVP-1.2 stack, `PriestPursuit_Test` exposes a BT-behaviour issue, not a navmesh issue.
+
+**Context:** With PRs #32 (walls block) + #33 (perf) + #35 (collider opt-out) + #36 (portal stitch + 1.2.5 + 1.2.9) + #37 (region-keyed verts) all landed, the navmesh connectivity issue Q-2026-05-13-NM03 was filed about is fully resolved. Wiring `DP_AI::GetOrBuildLevelNavMesh` to `GenerateFromScene` no longer produces `hasPath=0`. But `PriestPursuit_Test` still fails -- now because the priest's BT moves the priest AWAY from the relocated villager (initial distance 0.59m → final 0.98m over 120 frames).
+
+The priest is now spawning 0.5m east of the closest villager (a test-side relocation to guarantee same-polygon reachability), `BB.TargetWithDevil` should be set by the perception bridge once `DP_Player::SetPossessedVillager` is called, and the BT's pursue branch should fire. Something between the BT's branch selection and the agent's velocity output is going wrong; the priest steers in the wrong direction.
+
+**Hypotheses I'd investigate first:**
+  * Perception awareness ramp -- with the priest spawned right next to the villager, the awareness ramp may not have reached the threshold to flip BB into pursue mode within the first 60 frames. The synthetic-flat-quad version of this test had the priest WALK to the villager from a few meters away, which gave the awareness time to ramp up before pursue fired. Need to check `Zenith_PerceptionSystem::GetAwarenessOf` for the villager over those 120 frames.
+  * Patrol target picker -- if pursue ISN'T firing, the Selector's fallback is patrol. The patrol target picker (`GetRandomReachablePointInRadius`) might return a point in the wrong direction. The diagnostic log showed `patrol=(67.5,1.5,51.9)` while priest is at (67.7,1.9,53.1) -- patrol target is 1.2m southwest, which would explain the priest moving in that direction.
+  * BT lifecycle -- BT only ticks at 10Hz (per AI/CLAUDE.md), so 120 frames at 60Hz = 20 BT ticks. If the BT picks patrol on tick 1 and the run-to-completion semantics of the patrol leaf keep it running for several ticks, the priest commits to patrol even after pursue would otherwise fire.
+
+**Implication:** Phase 1 (priest pursuit) is "done" from an engine-surface perspective but might have a real gameplay bug. With the synthetic flat navmesh the bug was masked by the long initial pursuit distance.
+
+**My best guess if you don't reply:** look at the perception awareness ramp first -- if it's the cause, raise `awareness_gain` or set BB.TargetWithDevil unconditionally when DP_Player::SetPossessedVillager is called (don't wait for the perception ramp).
+
+**Cost of getting it wrong:** moderate. The priest does pursue villagers in actual gameplay (with the synthetic navmesh) -- this test failure surfaces only on the controlled-relocation scenario. Production gameplay starts the priest several meters from any villager.
+
+**Status:** asked 2026-05-14.
+
+---
+
 ### ⚠️ Q-2026-05-13-NM03 — MVP-1.2.2 (real navmesh in DP_AI) reveals disconnected regions; `PriestPursuit_Test` breaks because priest + closest villager land in different regions.
 
 **Context:** With PR #32 (walls block paths) + PR #33 (O(N) adjacency, 850ms generate) both landed, the production path of wiring `DP_AI::GetOrBuildLevelNavMesh` to call `Zenith_NavMeshGenerator::GenerateFromScene` is technically feasible. I wired it with a build-index-keyed cache and ran the DP suite -- 49/50 pass, but `PriestPursuit_Test` fails:


### PR DESCRIPTION
## Summary

Final finding-doc for this session's MVP-1.2.2 work.

With PRs #32 (walls block) + #33 (perf O(N)) + #35 (collider opt-out) + #36 (portal stitch + 1.2.5 + 1.2.9) + #37 (region-keyed vertex dedup) all merged or in CI, the navmesh-connectivity issue Q-2026-05-13-NM03 was filed about is fully resolved. A local test with `DP_AI::GetOrBuildLevelNavMesh` wired to `GenerateFromScene` no longer produces `hasPath=0`.

But `PriestPursuit_Test` still fails -- now because the priest's BT moves the priest **away** from the relocated villager (initial 0.59m → final 0.98m). This is a BT-side issue, not engine-side. Filed as `Q-2026-05-14-NM01` with three hypotheses to triage first.

## Why no DP_AI wiring change

The DP-side wiring (`DP_AI::GetOrBuildLevelNavMesh` calls `GenerateFromScene`) is the obvious next step but I deliberately held it back from this session. The remaining test failure has a different root cause (BT) and shipping the wiring without resolving the regression would land a "previously-passing test now reports the priest is broken" diff.

The engine deliverable from this session is the full surface MVP-1.2.2 needs to actually work; the BT investigation is a separate concern that probably resolves on perception/awareness ramp tuning, not a code fix.

## Verification

- [x] doc_lint green locally.
- [ ] CI: `complexity-gate` + `doc-lint` pass (no code changes, dp-build/dp-tests are no-ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)