### PR TITLE
feat(dp): MVP-1.3.{1,2} -- DP_OnRunLost event + Apprehend BT branch

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="..\Tests\Test_LifeTimer.cpp" />
     <ClCompile Include="..\Tests\Test_Materials.cpp" />
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -508,6 +508,7 @@
     <ClCompile Include="..\Tests\Test_LifeTimer.cpp" />
     <ClCompile Include="..\Tests\Test_Materials.cpp" />
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DP_BT_Nodes.h
+++ b/Games/DevilsPlayground/Components/DP_BT_Nodes.h
@@ -6,16 +6,24 @@
  *  - DP_BTCondition_HasInvestigatePos        (reads BB.HasInvestigatePos)
  *  - DP_BTAction_ClearInvestigatePos         (sets BB.HasInvestigatePos=false)
  *  - DP_BTDecorator_IsTargetValid            (gates child on BB.TargetWithDevil != INVALID)
+ *  - DP_BTAction_Apprehend                   (channels on possessed villager,
+ *                                             dispatches DP_OnRunLost{Apprehended})
  */
 
 #include "AI/BehaviorTree/Zenith_BTNode.h"
 #include "AI/BehaviorTree/Zenith_Blackboard.h"
+#include "AI/Components/Zenith_AIAgentComponent.h"
 #include "AI/Navigation/Zenith_NavMesh.h"
+#include "AI/Navigation/Zenith_NavMeshAgent.h"
 #include "EntityComponent/Zenith_Entity.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
 #include "EntityComponent/Components/Zenith_TransformComponent.h"
 #include "Maths/Zenith_Maths.h"
 
 #include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
 
 class DP_BTAction_FindPosInSuspicionSphere : public Zenith_BTLeaf
 {
@@ -82,4 +90,136 @@ public:
 		return m_pxChild->Execute(xAgent, xBB, fDt);
 	}
 	const char* GetTypeName() const override { return "DP_IsTargetValid"; }
+};
+
+// MVP-1.3.2: Apprehend BT action. Placed BEFORE pursue in the priest's
+// Selector so it intercepts the moment the priest gets within
+// priest.apprehend_range_m of the possessed villager. The priest stands
+// still and channels for priest.apprehend_channel_s seconds; if the
+// channel completes without interruption, it dispatches
+// DP_OnRunLost{Apprehended} and clears the player's possession.
+// Interruption sources:
+//   * Possessed-villager handle changes (player switched to another
+//     vessel) -- Priest_Behaviour::OnUpdate's m_xTree.Reset() on rising-
+//     edge of BB target tears the node down before this Execute runs.
+//   * Target leaves apprehend range (player ran) -- Execute returns
+//     FAILURE so the Selector falls back to pursue.
+//   * Target despawns (e.g., villager died) -- HasTarget check earlier
+//     in the same Selector turn would have failed; in this node the
+//     scene-data null check handles the same case defensively.
+class DP_BTAction_Apprehend : public Zenith_BTLeaf
+{
+public:
+	DP_BTAction_Apprehend() = default;
+
+	void OnEnter(Zenith_Entity& xAgent, Zenith_Blackboard& /*xBB*/) override
+	{
+		// Cache tuning per-run so DP_Tuning hot-reload during a play
+		// session (if ever wired) takes effect on the next apprehend
+		// window. m_fAppliedChannelSeconds is the actual duration this
+		// channel will run for; m_fChannelElapsed is the per-channel
+		// timer.
+		m_fAppliedChannelSeconds = DP_Tuning::Get<float>("priest.apprehend_channel_s");
+		m_fAppliedRangeMetres    = DP_Tuning::Get<float>("priest.apprehend_range_m");
+		m_fChannelElapsed        = 0.0f;
+		m_xChannelTarget         = INVALID_ENTITY_ID;
+
+		// Stop the navmesh agent so the priest plants and channels
+		// instead of continuing to drift along the path Pursue had
+		// requested. Pursue will re-request a path when Apprehend
+		// FAILS (target leaves range) and the Selector falls through.
+		if (xAgent.HasComponent<Zenith_AIAgentComponent>())
+		{
+			Zenith_AIAgentComponent& xAI = xAgent.GetComponent<Zenith_AIAgentComponent>();
+			if (Zenith_NavMeshAgent* pxNav = xAI.GetNavMeshAgent())
+			{
+				pxNav->Stop();
+			}
+		}
+	}
+
+	BTNodeStatus Execute(Zenith_Entity& xAgent, Zenith_Blackboard& xBB, float fDt) override
+	{
+		const Zenith_EntityID xTarget = xBB.GetEntityID(DP_AI::BB_KEY_TARGET_WITH_DEVIL);
+		if (!xTarget.IsValid()) { m_eLastStatus = BTNodeStatus::FAILURE; return m_eLastStatus; }
+
+		// Resolve target's scene + transform.
+		Zenith_SceneData* pxScene =
+			Zenith_SceneManager::GetSceneDataForEntity(xTarget);
+		if (pxScene == nullptr) { m_eLastStatus = BTNodeStatus::FAILURE; return m_eLastStatus; }
+		Zenith_Entity xTargetEnt = pxScene->TryGetEntity(xTarget);
+		if (!xTargetEnt.IsValid()) { m_eLastStatus = BTNodeStatus::FAILURE; return m_eLastStatus; }
+		if (!xTargetEnt.HasComponent<Zenith_TransformComponent>()) { m_eLastStatus = BTNodeStatus::FAILURE; return m_eLastStatus; }
+		if (!xAgent.HasComponent<Zenith_TransformComponent>()) { m_eLastStatus = BTNodeStatus::FAILURE; return m_eLastStatus; }
+
+		Zenith_Maths::Vector3 xTargetPos, xAgentPos;
+		xTargetEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xTargetPos);
+		xAgent.GetComponent<Zenith_TransformComponent>().GetPosition(xAgentPos);
+
+		// Horizontal distance only -- DP's gameplay plane is flat-ish and
+		// the priest/villager Y values are body-capsule-driven (settle at
+		// half-height above the floor), so a 3D distance would erroneously
+		// reject apprehend the moment one rests slightly lower than the
+		// other.
+		const float fDx = xTargetPos.x - xAgentPos.x;
+		const float fDz = xTargetPos.z - xAgentPos.z;
+		const float fDist = std::sqrt(fDx * fDx + fDz * fDz);
+
+		if (fDist > m_fAppliedRangeMetres)
+		{
+			// Out of range -- bail so the Selector falls back to pursue.
+			// OnEnter resets state when this branch is re-entered after
+			// the priest re-closes the gap.
+			m_eLastStatus = BTNodeStatus::FAILURE;
+			return m_eLastStatus;
+		}
+
+		// Lock onto target on first valid tick. If the BB target swaps
+		// mid-channel (player switched villager), m_xTree.Reset() in
+		// Priest_Behaviour::OnUpdate aborts this node -- but as a defence
+		// in depth, also bail here on mismatch.
+		if (!m_xChannelTarget.IsValid())
+		{
+			m_xChannelTarget = xTarget;
+		}
+		else if (m_xChannelTarget.m_uIndex != xTarget.m_uIndex
+		      || m_xChannelTarget.m_uGeneration != xTarget.m_uGeneration)
+		{
+			m_eLastStatus = BTNodeStatus::FAILURE;
+			return m_eLastStatus;
+		}
+
+		m_fChannelElapsed += fDt;
+		if (m_fChannelElapsed >= m_fAppliedChannelSeconds)
+		{
+			// Channel complete. Dispatch the run-loss event and clear
+			// the player's possession (the player gets bounced to the
+			// "run over" screen by whichever subscriber owns that).
+			Zenith_EventDispatcher::Get().Dispatch(
+				DP_OnRunLost{ DP_RunLostCause::Apprehended });
+			DP_Player::SetPossessedVillager(INVALID_ENTITY_ID);
+			m_eLastStatus = BTNodeStatus::SUCCESS;
+			return m_eLastStatus;
+		}
+
+		m_eLastStatus = BTNodeStatus::RUNNING;
+		return m_eLastStatus;
+	}
+
+	const char* GetTypeName() const override { return "DP_Apprehend"; }
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// Test-only accessors for inspecting channel progress without
+	// reaching into private state. Not used by production gameplay.
+	float           GetChannelElapsed() const  { return m_fChannelElapsed; }
+	float           GetAppliedChannelSeconds() const { return m_fAppliedChannelSeconds; }
+	float           GetAppliedRangeMetres() const    { return m_fAppliedRangeMetres; }
+	Zenith_EntityID GetChannelTarget() const    { return m_xChannelTarget; }
+#endif
+
+private:
+	float           m_fChannelElapsed        = 0.0f;
+	float           m_fAppliedChannelSeconds = 3.0f;
+	float           m_fAppliedRangeMetres    = 2.0f;
+	Zenith_EntityID m_xChannelTarget         = INVALID_ENTITY_ID;
 };

--- a/Games/DevilsPlayground/Components/Priest_Behaviour.h
+++ b/Games/DevilsPlayground/Components/Priest_Behaviour.h
@@ -188,8 +188,17 @@ public:
 			m_xParentEntity.GetEntityID().m_uIndex, m_xParentEntity.GetEntityID().m_uGeneration,
 			bHasAI ? 1 : 0, (void*)pxNavMesh);
 
-		// Build the BT root: Selector → Pursue / Investigate / Patrol.
+		// Build the BT root: Selector → Apprehend / Pursue / Investigate / Patrol.
 		auto* pxRoot = new Zenith_BTSelector();
+
+		// ---- Apprehend branch (MVP-1.3.2, highest priority) -----------------
+		// HasTarget(BB.TargetWithDevil) → Apprehend (channels in place)
+		// Apprehend internally checks range/channel-duration and dispatches
+		// DP_OnRunLost{Apprehended} when the channel completes.
+		auto* pxApprehend = new Zenith_BTSequence();
+		pxApprehend->AddChild(new Zenith_BTCondition_HasTarget(DP_AI::BB_KEY_TARGET_WITH_DEVIL));
+		pxApprehend->AddChild(new DP_BTAction_Apprehend());
+		pxRoot->AddChild(pxApprehend);
 
 		// ---- Pursue branch ---------------------------------------------------
 		// HasTarget(BB.TargetWithDevil) → MoveToEntity(BB.TargetWithDevil)

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -61,6 +61,35 @@ struct DP_OnVictory
 	uint32_t m_uPlaceholder = 0;
 };
 
+// MVP-1.3.1: run-loss cause enum. The dispatcher fires DP_OnRunLost{cause}
+// when the player's current possession ends in a way other than the
+// player voluntarily switching to another villager. Three causes:
+//   * Apprehended -- the priest got within priest.apprehend_range_m of
+//     the possessed villager and held the channel for
+//     priest.apprehend_channel_s seconds. MVP-1.3.2's Apprehend BT
+//     branch dispatches this.
+//   * Dawn -- the night timer ran out before the player delivered all
+//     5 objectives. MVP-1.3.5 / MVP-4.2.2 wires this.
+//   * NoVessels -- every villager in the level has died (life timer)
+//     and no fresh body is available for possession. MVP-1.3.5 /
+//     MVP-4.2.3 wires this from DPVillager_Behaviour::TickLife.
+//
+// Subscribers (DPHUDController, GameManager / state machine, future
+// "game over" overlay) treat all three as "run is over" and switch
+// the player to the run-over screen. The cause field lets the UI tell
+// the player WHY they lost (the GDD's three failure copy variants).
+enum class DP_RunLostCause : uint8_t
+{
+	Apprehended,
+	Dawn,
+	NoVessels
+};
+
+struct DP_OnRunLost
+{
+	DP_RunLostCause m_eCause;
+};
+
 // ============================================================================
 // DP_Player — published by B2 (player + camera + input).
 // ============================================================================

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_PriestCatchesPlayer.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_PriestCatchesPlayer.cpp
@@ -1,0 +1,265 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/Priest_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Source/DP_Tuning.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P1Apprehend_PriestCatchesPlayer (MVP-1.3.1 + 1.3.2)
+//
+// End-to-end apprehend flow on the real GameLevel scene:
+//   1. Load GameLevel (scene 1) -- spawns priest + 17 villagers.
+//   2. Subscribe to DP_OnRunLost so we can detect dispatch.
+//   3. Pick the priest + the closest villager (same logic as
+//      Test_PriestPursuit so the apprehend can fire from a known
+//      starting separation).
+//   4. Possess the chosen villager via DP_Player::SetPossessedVillager;
+//      Priest_Behaviour::BridgePerceptionToBlackboard observes the
+//      possession on the next frame and writes BB_KEY_TARGET_WITH_DEVIL.
+//   5. Teleport the priest to ~1.5 m horizontal from the villager --
+//      well inside priest.apprehend_range_m (2.0 m default) so the
+//      Apprehend BT branch is the highest-priority Selector child that
+//      can run.
+//   6. Run frames for priest.apprehend_channel_s + slack (~4 s at
+//      60 Hz = 240 frames; we use 360 for safety).
+//   7. Assert:
+//      a) DP_OnRunLost fired with cause = Apprehended.
+//      b) DP_Player::GetPossessedVillager() returns INVALID (the
+//         Apprehend action clears possession on channel complete).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kAP_Start, kAP_WaitScene, kAP_Possess, kAP_TeleportPriest,
+	                   kAP_RunChannel, kAP_Verify, kAP_Done };
+
+	int                     g_iPhase = kAP_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xVillager;
+	Zenith_EventHandle      g_xRunLostHandle = INVALID_EVENT_HANDLE;
+	bool                    g_bRunLostFired = false;
+	DP_RunLostCause         g_eRunLostCause = DP_RunLostCause::Apprehended;
+	int                     g_iRunFrames = 0;
+	bool                    g_bPossessionCleared = false;
+
+	void OnRunLost(const DP_OnRunLost& xEvt)
+	{
+		g_bRunLostFired = true;
+		g_eRunLostCause = xEvt.m_eCause;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	bool TrySetEntityPos(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+		return true;
+	}
+}
+
+static void Setup_P1Apprehend()
+{
+	g_iPhase = kAP_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_bRunLostFired = false;
+	g_eRunLostCause = DP_RunLostCause::Apprehended;
+	g_iRunFrames = 0;
+	g_bPossessionCleared = false;
+	// Subscribe in setup so we don't miss any early dispatch from the
+	// priest's first OnUpdate after possession (defensive; the channel
+	// time + slack means a single-frame race is unlikely, but it costs
+	// nothing to subscribe early).
+	g_xRunLostHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P1Apprehend(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kAP_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kAP_WaitScene;
+		return true;
+
+	case kAP_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		Zenith_EntityID xFoundVillager;
+		float fClosestDist = 1e30f;
+
+		Zenith_Maths::Vector3 xPriestPos(0.0f);
+		bool bGotPriestPos = false;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest, &xPriestPos, &bGotPriestPos]
+			(Zenith_EntityID xId, Priest_Behaviour&)
+			{
+				xFoundPriest = xId;
+				bGotPriestPos = TryGetEntityPos(xId, xPriestPos);
+			});
+
+		if (xFoundPriest.IsValid() && bGotPriestPos)
+		{
+			DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+				[&xFoundVillager, &fClosestDist, &xPriestPos]
+				(Zenith_EntityID xId, DPVillager_Behaviour&)
+				{
+					Zenith_Maths::Vector3 xVPos;
+					if (!TryGetEntityPos(xId, xVPos)) return;
+					const float fD = HorizontalDistance(xPriestPos, xVPos);
+					if (fD < fClosestDist)
+					{
+						fClosestDist = fD;
+						xFoundVillager = xId;
+					}
+				});
+		}
+
+		if (xFoundPriest.IsValid() && xFoundVillager.IsValid())
+		{
+			g_xPriest   = xFoundPriest;
+			g_xVillager = xFoundVillager;
+			g_iPhase    = kAP_Possess;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kAP_Done;
+		}
+		return true;
+	}
+
+	case kAP_Possess:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kAP_TeleportPriest;
+		return true;
+
+	case kAP_TeleportPriest:
+	{
+		// Wait one frame after Possess so DPVillager_Behaviour::OnUpdate
+		// has a chance to observe DP_Player's possession side-table and
+		// flip its IsPossessed() flag (the priest's bridge needs that).
+		// Then teleport the priest to ~1.5 m east of the villager --
+		// well inside the 2.0 m apprehend_range default.
+		Zenith_Maths::Vector3 xVillagerPos;
+		if (!TryGetEntityPos(g_xVillager, xVillagerPos)) { g_iPhase = kAP_Done; return false; }
+		const Zenith_Maths::Vector3 xPriestPos(
+			xVillagerPos.x + 1.5f, xVillagerPos.y, xVillagerPos.z);
+		TrySetEntityPos(g_xPriest, xPriestPos);
+		g_iRunFrames = 0;
+		g_iPhase = kAP_RunChannel;
+		return true;
+	}
+
+	case kAP_RunChannel:
+		++g_iRunFrames;
+		// 4 s at 60 Hz = ~240 frames. Channel default is 3 s. We allow
+		// 360 frames (~6 s) so the test still passes if the priest's
+		// BT reset latency or one-frame possession-propagation delay
+		// extends the elapsed window.
+		if (g_bRunLostFired || g_iRunFrames >= 360)
+		{
+			g_iPhase = kAP_Verify;
+		}
+		return true;
+
+	case kAP_Verify:
+	{
+		g_bPossessionCleared =
+			!DP_Player::GetPossessedVillager().IsValid();
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Apprehend: runLost=%d cause=%d possessionCleared=%d frames=%d",
+			(int)g_bRunLostFired, (int)g_eRunLostCause,
+			(int)g_bPossessionCleared, g_iRunFrames);
+		// Unsubscribe before kAP_Done so a follow-on batched test that
+		// dispatches DP_OnRunLost (none exist today, but future
+		// MVP-1.3.5 / 4.2.x tests will) doesn't accidentally re-fire
+		// our captured flag.
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+		g_iPhase = kAP_Done;
+		return false;
+	}
+
+	case kAP_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1Apprehend()
+{
+	if (!g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Apprehend: priest entity not found");
+		return false;
+	}
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Apprehend: villager entity not found");
+		return false;
+	}
+	if (!g_bRunLostFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Apprehend: DP_OnRunLost never fired (frames=%d)", g_iRunFrames);
+		return false;
+	}
+	if (g_eRunLostCause != DP_RunLostCause::Apprehended)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Apprehend: DP_OnRunLost fired with cause=%d (expected %d=Apprehended)",
+			(int)g_eRunLostCause, (int)DP_RunLostCause::Apprehended);
+		return false;
+	}
+	if (!g_bPossessionCleared)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Apprehend: possession not cleared after apprehend");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1ApprehendTest = {
+	"Test_P1Apprehend_PriestCatchesPlayer",
+	&Setup_P1Apprehend,
+	&Step_P1Apprehend,
+	&Verify_P1Apprehend,
+	500
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1ApprehendTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Two roadmap items landed together (the roadmap's split made sense only with a TDD-style red-then-green flow; auto-merge-on-green CI forces both into one PR).

### MVP-1.3.1 — DP_OnRunLost event + cause enum

Adds `DP_OnRunLost` event struct + `DP_RunLostCause` enum (Apprehended / Dawn / NoVessels) to `PublicInterfaces.h`. Only the Apprehended cause is wired by this PR; Dawn + NoVessels are declared up front so future MVP-1.3.5 / 4.2.2 / 4.2.3 work doesn't need to touch the header again.

### MVP-1.3.2 — Apprehend BT branch

New `DP_BTAction_Apprehend` leaf node inserted as the highest-priority Selector child in `Priest_Behaviour`'s tree, ahead of Pursue / Investigate / Patrol:

- **OnEnter**: reads `priest.apprehend_channel_s` and `priest.apprehend_range_m` from DP_Tuning, resets per-channel state, calls `Zenith_NavMeshAgent::Stop()` so the priest plants instead of drifting along Pursue's path.
- **Execute**: horizontal distance to `BB.TargetWithDevil`. Out of range → FAILURE (Selector falls back to Pursue). Target changed mid-channel → FAILURE (defence in depth; rising-edge `m_xTree.Reset()` in `Priest_Behaviour::OnUpdate` is the primary abort path).
- **Channel complete** → dispatch `DP_OnRunLost{Apprehended}`, clear DP_Player's possessed-villager handle, return SUCCESS.

### Test

`Test_P1Apprehend_PriestCatchesPlayer` (real GameLevel scene):
1. Subscribe to DP_OnRunLost
2. Possess closest villager, teleport priest to 1.5 m east (well inside 2.0 m apprehend range)
3. Run 360 frames (~6 s; channel is 3 s)
4. Assert event fired with cause=Apprehended AND `DP_Player::GetPossessedVillager()` returns INVALID

### Bug found + fixed

`Zenith_BTNode::m_eLastStatus` isn't auto-set by `Execute`'s return value — leaf nodes must assign to it manually. Without that, `ExecuteCompositeBody`'s `pxChild->GetLastStatus() != RUNNING` check thinks every leaf returned its construct-time default (FAILURE), and calls `OnEnter` on every tick — which reset `m_fChannelElapsed` to 0 every frame and meant Apprehend never completed its 3-second channel. The fix (`m_eLastStatus = X; return m_eLastStatus`) mirrors the engine's MoveTo / MoveToEntity pattern.

## Test plan

- [x] `Test_P1Apprehend_PriestCatchesPlayer` passes in 189 frames (channel completes at expected time)
- [x] `PriestPursuit_Test` continues to pass (Apprehend FAILS out of range → Pursue runs as before)
- [x] Full DP suite: **37 PASSED, 0 FAILED, 15 SKIPPED-headless**
- [x] Build clean (`vs2022_Debug_Win64_True`)

## Dependencies

Conflicts with PR #40 on the Zenith vcxproj entries for `Zenith_NavMeshTestPathfinder.h`. When PR #40 lands first, the conflict resolves trivially via rebase (both add the same line). Either ordering works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)