### PR TITLE
feat(dp,test): MVP-1.3.{3,4} -- apprehend switch-breaks + out-of-range regression guards

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -214,7 +214,9 @@
     <ClCompile Include="..\Tests\Test_LifeTimer.cpp" />
     <ClCompile Include="..\Tests\Test_Materials.cpp" />
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Apprehend_OutOfRangeIgnored.cpp" />
     <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -68,7 +68,13 @@
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Apprehend_OutOfRangeIgnored.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -508,7 +508,9 @@
     <ClCompile Include="..\Tests\Test_LifeTimer.cpp" />
     <ClCompile Include="..\Tests\Test_Materials.cpp" />
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Apprehend_OutOfRangeIgnored.cpp" />
     <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -68,7 +68,13 @@
     <ClCompile Include="..\Tests\Test_MouseWheel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Apprehend_OutOfRangeIgnored.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_OutOfRangeIgnored.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_OutOfRangeIgnored.cpp
@@ -1,0 +1,246 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/Priest_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P1Apprehend_OutOfRangeIgnored (MVP-1.3.4)
+//
+// Regression guard for the Apprehend BT branch: when the priest is FAR
+// from the possessed villager (outside priest.apprehend_range_m), the
+// Apprehend node MUST return FAILURE on the first Execute and let the
+// Selector fall through to Pursue. The priest then walks toward the
+// villager via the regular pathfinding flow; no DP_OnRunLost is
+// dispatched while the priest is still en-route.
+//
+// Without the range gate (or with a broken distance computation) the
+// channel would start the instant the BT bridge wrote
+// BB_KEY_TARGET_WITH_DEVIL, ending the run before the player could
+// react -- the original PriestPursuit_Test on GameLevel starts the
+// priest ~4.4m from the villager, so a stuck-range gate would fail
+// every pursuit run-up.
+//
+// Procedure:
+//   1. Load GameLevel + subscribe to DP_OnRunLost.
+//   2. Pick the priest + the closest villager (~4.4m away in stock
+//      GameLevel data -- well outside the 2.0m apprehend_range).
+//   3. Possess the villager. Do NOT teleport the priest -- leave it
+//      at its authored ~4.4m starting separation.
+//   4. Run 120 frames (~2 seconds; shorter than the smallest possible
+//      "pursue-then-channel" path. At pursue_speed_mps = 7, closing the
+//      4.4m -> 1.5m gap takes ~0.4s, so Apprehend's 3s channel completes
+//      no earlier than frame ~205. 120 frames keeps the test inside
+//      the pre-channel window even under perfect pursuit.)
+//   5. Assert DP_OnRunLost did NOT fire during this window.
+//
+// What the test allows: the priest can pursue + close the distance.
+// What it forbids: Apprehend channel firing FROM the authored start
+// distance (which would only happen if the range gate was broken).
+//
+// To keep the test deterministic the priest's authored start is the
+// only thing the priest sees; the test does NOT teleport. If the priest
+// ever appears to apprehend "for free" from authoring distance, this
+// test fails noisily.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kOR_Start, kOR_WaitScene, kOR_Possess,
+	                   kOR_RunFrames, kOR_Verify, kOR_Done };
+
+	int                     g_iPhase = kOR_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xVillager;
+	Zenith_EventHandle      g_xRunLostHandle = INVALID_EVENT_HANDLE;
+	bool                    g_bRunLostFired = false;
+	int                     g_iRunFrames = 0;
+	float                   g_fInitialSeparation = 0.0f;
+
+	constexpr int kFRAMES_TO_RUN = 120;  // ~2s @ 60Hz (pre-channel window)
+
+	void OnRunLost(const DP_OnRunLost& /*xEvt*/)
+	{
+		g_bRunLostFired = true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+}
+
+static void Setup_P1ApprehendOutOfRange()
+{
+	g_iPhase = kOR_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_bRunLostFired = false;
+	g_iRunFrames = 0;
+	g_fInitialSeparation = 0.0f;
+	g_xRunLostHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P1ApprehendOutOfRange(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kOR_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kOR_WaitScene;
+		return true;
+
+	case kOR_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		Zenith_EntityID xClosest;
+		float fClosestDist = 1e30f;
+		Zenith_Maths::Vector3 xPriestPos(0.0f);
+		bool bGotPriestPos = false;
+
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest, &xPriestPos, &bGotPriestPos]
+			(Zenith_EntityID xId, Priest_Behaviour&)
+			{
+				xFoundPriest = xId;
+				bGotPriestPos = TryGetEntityPos(xId, xPriestPos);
+			});
+		if (xFoundPriest.IsValid() && bGotPriestPos)
+		{
+			DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+				[&xClosest, &fClosestDist, &xPriestPos]
+				(Zenith_EntityID xId, DPVillager_Behaviour&)
+				{
+					Zenith_Maths::Vector3 xVPos;
+					if (!TryGetEntityPos(xId, xVPos)) return;
+					const float fD = HorizontalDistance(xPriestPos, xVPos);
+					if (fD < fClosestDist) { fClosestDist = fD; xClosest = xId; }
+				});
+		}
+
+		if (xFoundPriest.IsValid() && xClosest.IsValid())
+		{
+			g_xPriest   = xFoundPriest;
+			g_xVillager = xClosest;
+			g_fInitialSeparation = fClosestDist;
+			g_iPhase    = kOR_Possess;
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P1ApprehendOOR: priest=(%.1f,%.1f,%.1f) closest_villager@%.2fm",
+				xPriestPos.x, xPriestPos.y, xPriestPos.z, fClosestDist);
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kOR_Done;
+		}
+		return true;
+	}
+
+	case kOR_Possess:
+		// Do NOT teleport the priest -- leave it at authored separation
+		// (~4.4m). The whole point of the test is that Apprehend stays
+		// quiet until the priest physically closes that gap via Pursue.
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iRunFrames = 0;
+		g_iPhase = kOR_RunFrames;
+		return true;
+
+	case kOR_RunFrames:
+		++g_iRunFrames;
+		if (g_bRunLostFired)
+		{
+			// Fail-fast: there's no point running another N frames after
+			// the spurious dispatch.
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P1ApprehendOOR: DP_OnRunLost fired at frame %d (initial sep %.2fm) -- spurious",
+				g_iRunFrames, g_fInitialSeparation);
+			g_iPhase = kOR_Verify;
+			return true;
+		}
+		if (g_iRunFrames >= kFRAMES_TO_RUN)
+		{
+			g_iPhase = kOR_Verify;
+		}
+		return true;
+
+	case kOR_Verify:
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ApprehendOOR: runLost=%d initialSep=%.2fm (expect runLost=0)",
+			(int)g_bRunLostFired, g_fInitialSeparation);
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+		g_iPhase = kOR_Done;
+		return false;
+
+	case kOR_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1ApprehendOutOfRange()
+{
+	if (!g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ApprehendOOR: priest not found");
+		return false;
+	}
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ApprehendOOR: villager not found");
+		return false;
+	}
+	if (g_fInitialSeparation < 3.0f)
+	{
+		// Sanity guard -- the test assumes the priest starts well outside
+		// the 2m apprehend_range. If GameLevel authoring ever moves the
+		// priest closer than 3m from any villager, the assertion below
+		// stops meaning anything useful. Fail with a clear message so we
+		// notice and re-tune the test setup.
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ApprehendOOR: initial separation %.2fm is too small -- test design assumes priest authored OUTSIDE apprehend_range (2m)",
+			g_fInitialSeparation);
+		return false;
+	}
+	if (g_bRunLostFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ApprehendOOR: DP_OnRunLost fired -- Apprehend channel ran from out-of-range");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1ApprehendOORTest = {
+	"Test_P1Apprehend_OutOfRangeIgnored",
+	&Setup_P1ApprehendOutOfRange,
+	&Step_P1ApprehendOutOfRange,
+	&Verify_P1ApprehendOutOfRange,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1ApprehendOORTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_SwitchBreaksChannel.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_SwitchBreaksChannel.cpp
@@ -1,0 +1,280 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/Priest_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P1Apprehend_SwitchBreaksChannel (MVP-1.3.3)
+//
+// The Apprehend BT branch channels for priest.apprehend_channel_s seconds
+// before dispatching DP_OnRunLost. The contract is that the channel
+// MUST break if the player switches to a different villager mid-channel
+// (Tuning.json: priest.apprehend_interruptible_by_switch = true).
+//
+// Procedure:
+//   1. Load GameLevel + subscribe to DP_OnRunLost.
+//   2. Pick the priest + the CLOSEST villager (villager A; the one
+//      Test_P1Apprehend_PriestCatchesPlayer uses).
+//   3. Pick a SECOND villager far from the priest (villager B). 67m+ in
+//      practice -- the GameLevel-data Pleb12 placement at (5.8, _, 21.6).
+//      Far enough that the priest can't pursue + re-channel within the
+//      remaining frame budget.
+//   4. Possess A, teleport the priest to 1.5m east of A (inside
+//      apprehend_range = 2m). Start the channel.
+//   5. Run ~50 frames (~0.8s into the 3s channel).
+//   6. Switch possession to villager B.
+//   7. Run another ~200 frames (~3.3s -- enough that the ORIGINAL
+//      channel would have completed had the switch not broken it).
+//   8. Assert DP_OnRunLost did NOT fire during this window. (Eventually
+//      the priest will reach B and re-channel, dispatching the event --
+//      but the 200-frame budget is well short of priest-traverse-67m
+//      + 3s-channel, so no spurious dispatch is expected.)
+//
+// What this proves:
+//   * Mid-channel target switch DOES interrupt the channel.
+//   * Apprehend doesn't "remember" the old target and complete the
+//     channel anyway after a switch (would have been a bug given how
+//     m_xChannelTarget is locked in OnEnter and never refreshed inside
+//     a single channel window).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kSB_Start, kSB_WaitScene, kSB_Possess, kSB_TeleportPriest,
+	                   kSB_RunInitialChannel, kSB_SwitchTarget, kSB_RunPostSwitch,
+	                   kSB_Verify, kSB_Done };
+
+	int                     g_iPhase = kSB_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xVillagerA;
+	Zenith_EntityID         g_xVillagerB;
+	Zenith_EventHandle      g_xRunLostHandle = INVALID_EVENT_HANDLE;
+	bool                    g_bRunLostFired = false;
+	int                     g_iRunFrames = 0;
+
+	constexpr int kFRAMES_BEFORE_SWITCH = 50;   // ~0.83s @ 60Hz
+	constexpr int kFRAMES_AFTER_SWITCH  = 200;  // ~3.33s @ 60Hz
+
+	void OnRunLost(const DP_OnRunLost& /*xEvt*/)
+	{
+		g_bRunLostFired = true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	bool TrySetEntityPos(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+		return true;
+	}
+}
+
+static void Setup_P1ApprehendSwitch()
+{
+	g_iPhase = kSB_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xVillagerA = INVALID_ENTITY_ID;
+	g_xVillagerB = INVALID_ENTITY_ID;
+	g_bRunLostFired = false;
+	g_iRunFrames = 0;
+	g_xRunLostHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P1ApprehendSwitch(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kSB_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kSB_WaitScene;
+		return true;
+
+	case kSB_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		Zenith_EntityID xClosest;
+		Zenith_EntityID xFarthest;
+		float fClosestDist = 1e30f;
+		float fFarthestDist = 0.0f;
+
+		Zenith_Maths::Vector3 xPriestPos(0.0f);
+		bool bGotPriestPos = false;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest, &xPriestPos, &bGotPriestPos]
+			(Zenith_EntityID xId, Priest_Behaviour&)
+			{
+				xFoundPriest = xId;
+				bGotPriestPos = TryGetEntityPos(xId, xPriestPos);
+			});
+
+		if (xFoundPriest.IsValid() && bGotPriestPos)
+		{
+			DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+				[&xClosest, &xFarthest, &fClosestDist, &fFarthestDist, &xPriestPos]
+				(Zenith_EntityID xId, DPVillager_Behaviour&)
+				{
+					Zenith_Maths::Vector3 xVPos;
+					if (!TryGetEntityPos(xId, xVPos)) return;
+					const float fD = HorizontalDistance(xPriestPos, xVPos);
+					if (fD < fClosestDist) { fClosestDist = fD; xClosest = xId; }
+					if (fD > fFarthestDist) { fFarthestDist = fD; xFarthest = xId; }
+				});
+		}
+
+		if (xFoundPriest.IsValid() && xClosest.IsValid() && xFarthest.IsValid()
+			&& xClosest.m_uIndex != xFarthest.m_uIndex)
+		{
+			g_xPriest    = xFoundPriest;
+			g_xVillagerA = xClosest;
+			g_xVillagerB = xFarthest;
+			g_iPhase     = kSB_Possess;
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P1ApprehendSwitch: priest=(%.1f,%.1f,%.1f) closest@%.1fm farthest@%.1fm",
+				xPriestPos.x, xPriestPos.y, xPriestPos.z,
+				fClosestDist, fFarthestDist);
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kSB_Done;
+		}
+		return true;
+	}
+
+	case kSB_Possess:
+		DP_Player::SetPossessedVillager(g_xVillagerA);
+		g_iPhase = kSB_TeleportPriest;
+		return true;
+
+	case kSB_TeleportPriest:
+	{
+		Zenith_Maths::Vector3 xVPos;
+		if (!TryGetEntityPos(g_xVillagerA, xVPos)) { g_iPhase = kSB_Done; return false; }
+		TrySetEntityPos(g_xPriest,
+			Zenith_Maths::Vector3(xVPos.x + 1.5f, xVPos.y, xVPos.z));
+		g_iRunFrames = 0;
+		g_iPhase = kSB_RunInitialChannel;
+		return true;
+	}
+
+	case kSB_RunInitialChannel:
+		++g_iRunFrames;
+		if (g_bRunLostFired)
+		{
+			// Channel completed BEFORE we got to switch -- the channel
+			// duration is shorter than the test assumed, or the priest
+			// is way closer than expected. Either way it's a test
+			// configuration bug, not the system-under-test failing.
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P1ApprehendSwitch: DP_OnRunLost fired during initial channel (frame=%d) -- switch wasn't tested",
+				g_iRunFrames);
+			g_iPhase = kSB_Verify;
+			return true;
+		}
+		if (g_iRunFrames >= kFRAMES_BEFORE_SWITCH)
+		{
+			g_iPhase = kSB_SwitchTarget;
+		}
+		return true;
+
+	case kSB_SwitchTarget:
+		// Switch to the far villager. The previous channel should now
+		// terminate (Apprehend's target-mismatch check returns FAILURE);
+		// the Selector falls to Pursue and the priest starts walking
+		// toward villager_B. Whether the priest can re-engage Apprehend
+		// before kFRAMES_AFTER_SWITCH elapses depends on the priest's
+		// pursue speed (~5 m/s) and the priest-to-B distance (~67m for
+		// the FAR pick). At 5 m/s the priest covers ~17m in 3.3s --
+		// nowhere near 67m -- so no DP_OnRunLost should fire in this
+		// window.
+		DP_Player::SetPossessedVillager(g_xVillagerB);
+		g_iRunFrames = 0;
+		g_iPhase = kSB_RunPostSwitch;
+		return true;
+
+	case kSB_RunPostSwitch:
+		++g_iRunFrames;
+		if (g_iRunFrames >= kFRAMES_AFTER_SWITCH)
+		{
+			g_iPhase = kSB_Verify;
+		}
+		return true;
+
+	case kSB_Verify:
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ApprehendSwitch: runLost=%d (expect 0 -- channel broken)",
+			(int)g_bRunLostFired);
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+		g_iPhase = kSB_Done;
+		return false;
+
+	case kSB_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1ApprehendSwitch()
+{
+	if (!g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ApprehendSwitch: priest not found");
+		return false;
+	}
+	if (!g_xVillagerA.IsValid() || !g_xVillagerB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ApprehendSwitch: villager A or B not found");
+		return false;
+	}
+	if (g_bRunLostFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ApprehendSwitch: DP_OnRunLost fired -- channel was NOT broken by switch");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1ApprehendSwitchTest = {
+	"Test_P1Apprehend_SwitchBreaksChannel",
+	&Setup_P1ApprehendSwitch,
+	&Step_P1ApprehendSwitch,
+	&Verify_P1ApprehendSwitch,
+	500
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1ApprehendSwitchTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Two regression-guard tests rounding out the Apprehend BT branch contract from PR #41.

### MVP-1.3.3 — `Test_P1Apprehend_SwitchBreaksChannel`

Verifies `priest.apprehend_interruptible_by_switch=true`: mid-channel target switches MUST break the channel rather than finishing it on the original target.

Possess closest villager, teleport priest into apprehend range, run 50 frames (channel starts), switch possession to the farthest villager (~66m away), run 200 more frames, assert DP_OnRunLost did NOT fire. The switch triggers Apprehend's target-mismatch check → FAILURE → Selector falls to Pursue → priest can't traverse 66m + complete a fresh channel in 3.3s.

### MVP-1.3.4 — `Test_P1Apprehend_OutOfRangeIgnored`

Range-gate regression guard. Possess closest villager WITHOUT teleporting the priest (authored separation ~4.4m, outside 2m apprehend_range), run 120 frames (~2s — shorter than the smallest possible pursue+channel path, which is ~3.4s), assert DP_OnRunLost did NOT fire.

Both tests query villagers via DP_Query so they survive future GameLevel authoring shuffles.

## Test plan

- [x] `Test_P1Apprehend_SwitchBreaksChannel` passes in 258 frames
- [x] `Test_P1Apprehend_OutOfRangeIgnored` passes in 126 frames
- [x] PriestPursuit_Test + Test_P1Apprehend_PriestCatchesPlayer still pass
- [x] Full DP suite: **41 PASSED, 0 FAILED, 15 SKIPPED-headless**
- [x] Build clean (`vs2022_Debug_Win64_True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)