### PR TITLE
feat(dp): MVP-1.5.{1,2,3} -- possession cooldown after voluntary switch

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -217,6 +217,8 @@
     <ClCompile Include="..\Tests\Test_P1Apprehend_OutOfRangeIgnored.cpp" />
     <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp" />
     <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Cooldown_CannotPossessFor1pt5s.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -77,6 +77,12 @@
     <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Cooldown_CannotPossessFor1pt5s.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -511,6 +511,8 @@
     <ClCompile Include="..\Tests\Test_P1Apprehend_OutOfRangeIgnored.cpp" />
     <ClCompile Include="..\Tests\Test_P1Apprehend_PriestCatchesPlayer.cpp" />
     <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Cooldown_CannotPossessFor1pt5s.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -77,6 +77,12 @@
     <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Cooldown_CannotPossessFor1pt5s.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
@@ -44,6 +44,12 @@ public:
 		// process sight/hearing/damage stimuli.
 		Zenith_PerceptionSystem::Update(fDt);
 
+		// MVP-1.5: drain the possession cooldown per frame. The cooldown is
+		// set by TryVoluntaryPossessSwitch on a successful voluntary switch
+		// and gates subsequent attempts until it reaches zero. Death + priest
+		// apprehend paths don't touch the cooldown.
+		DP_Player::TickPossessionCooldown(fDt);
+
 		HandleClickToPossess();
 	}
 
@@ -115,7 +121,11 @@ private:
 
 		if (xBest.IsValid())
 		{
-			DP_Player::SetPossessedVillager(xBest);
+			// Voluntary switch path -- triggers the cooldown gate. If the
+			// click lands within the cooldown window (1.5 s default) the
+			// possession refuses, silently. Cosmetic feedback (HUD flash /
+			// audio) is a future-MVP polish item.
+			DP_Player::TryVoluntaryPossessSwitch(xBest);
 		}
 	}
 };

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -10,6 +10,8 @@
 #include "AI/Navigation/Zenith_NavMesh.h"
 #include "AI/Navigation/Zenith_NavMeshGenerator.h"
 
+#include "DP_Tuning.h"
+
 #include <unordered_map>
 
 // ============================================================================
@@ -23,6 +25,15 @@ namespace
 {
 	// ---- DP_Player state (B2 fills in) ----
 	Zenith_EntityID g_xPossessedVillager = INVALID_ENTITY_ID;
+
+	// MVP-1.5: possession-cooldown timer. Decrements per frame via
+	// DP_Player::TickPossessionCooldown (called from
+	// DPPlayerController_Behaviour::OnUpdate). Set by
+	// TryVoluntaryPossessSwitch on a successful voluntary switch /
+	// release. Death + apprehend paths bypass this entirely (they
+	// call SetPossessedVillager directly), matching the Tuning.json
+	// canon: "cooldown_after_burnout_s = 0.0".
+	float g_fPossessionCooldownRemaining = 0.0f;
 
 	// Per-villager held-item record. Mutated by DP_Player::SetHeldItem /
 	// RemoveHeldItem, read by DP_Player::GetHeldItem*. EntityID hashes via
@@ -70,6 +81,46 @@ namespace DP_Player
 		g_xPossessedVillager = xId;
 	}
 
+	bool TryVoluntaryPossessSwitch(Zenith_EntityID xId)
+	{
+		// Idempotent re-click: clicking the same villager you're already
+		// possessing is a no-op (and doesn't waste the cooldown window).
+		if (xId.IsValid()
+			&& g_xPossessedVillager.IsValid()
+			&& xId.m_uIndex == g_xPossessedVillager.m_uIndex
+			&& xId.m_uGeneration == g_xPossessedVillager.m_uGeneration)
+		{
+			return true;
+		}
+
+		// Cooldown gate. Death/apprehend never set the cooldown, so a
+		// pending switch after a respawn always succeeds without delay.
+		if (g_fPossessionCooldownRemaining > 0.0f)
+		{
+			return false;
+		}
+
+		g_xPossessedVillager = xId;
+		g_fPossessionCooldownRemaining =
+			DP_Tuning::Get<float>("possession.cooldown_after_voluntary_switch_s");
+		return true;
+	}
+
+	void TickPossessionCooldown(float fDt)
+	{
+		if (g_fPossessionCooldownRemaining <= 0.0f) return;
+		g_fPossessionCooldownRemaining -= fDt;
+		if (g_fPossessionCooldownRemaining < 0.0f)
+		{
+			g_fPossessionCooldownRemaining = 0.0f;
+		}
+	}
+
+	float GetPossessionCooldownRemaining()
+	{
+		return g_fPossessionCooldownRemaining;
+	}
+
 	DP_ItemTag GetHeldItemTag(Zenith_EntityID xVillager)
 	{
 		auto it = g_xHeldItems.find(PackEntityID(xVillager));
@@ -105,6 +156,7 @@ namespace DP_Player
 	{
 		g_xPossessedVillager = INVALID_ENTITY_ID;
 		g_xHeldItems.clear();
+		g_fPossessionCooldownRemaining = 0.0f;
 	}
 }
 

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -98,13 +98,48 @@ namespace DP_Player
 	Zenith_EntityID GetPossessedVillager();
 	void SetPossessedVillager(Zenith_EntityID xId);
 
+	// MVP-1.5: voluntary-switch possession path. Player-driven possession
+	// (click-to-possess, future switch UI) goes through this entry point
+	// so the cooldown gate fires. System paths -- villager death, priest
+	// apprehend -- keep calling SetPossessedVillager directly so they
+	// don't trigger a cooldown the player can't see coming.
+	//
+	// Returns true if the possession actually changed; false when the
+	// call was rejected by the cooldown gate. Resolving to the SAME
+	// villager that's already possessed returns true and is a no-op
+	// (idempotent re-clicks don't waste the cooldown window).
+	//
+	// Cooldown rules:
+	//   * Switching to a different valid villager (incl. INVALID -> X
+	//     while a cooldown is already burning down from a prior switch):
+	//     refused if cooldown > 0; on success, cooldown = priest_tuning
+	//     "possession.cooldown_after_voluntary_switch_s" (default 1.5 s).
+	//   * Voluntarily releasing to INVALID while currently possessing
+	//     a valid villager: cooldown = same as above.
+	//   * Resetting cooldown is automatic on death / apprehend (those
+	//     paths use SetPossessedVillager and don't touch the cooldown
+	//     timer; "cooldown_after_burnout_s = 0" in tuning is the canon).
+	bool TryVoluntaryPossessSwitch(Zenith_EntityID xId);
+
+	// Per-frame cooldown decrement. DPPlayerController_Behaviour::OnUpdate
+	// calls this once per frame so the cooldown drains at wall-clock rate
+	// regardless of how many possession attempts are made. Safe to call
+	// when cooldown is already zero (clamps).
+	void TickPossessionCooldown(float fDt);
+
+	// Remaining cooldown in seconds. Zero when no cooldown is active.
+	// HUD / debug overlays can render this to show the player when their
+	// next switch will be available.
+	float GetPossessionCooldownRemaining();
+
 	DP_ItemTag GetHeldItemTag(Zenith_EntityID xVillager);
 	Zenith_EntityID GetHeldItemEntity(Zenith_EntityID xVillager);
 	void SetHeldItem(Zenith_EntityID xVillager, Zenith_EntityID xItem);
 	void RemoveHeldItem(Zenith_EntityID xVillager);
 
 	// Drop possessed-villager and held-item state. Used by the harness
-	// between batched automated tests; not part of game runtime.
+	// between batched automated tests; not part of game runtime. Also
+	// resets the possession cooldown so tests start with a clean slate.
 	void ResetForTest();
 }
 

--- a/Games/DevilsPlayground/Tests/Test_P1Cooldown_CannotPossessFor1pt5s.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Cooldown_CannotPossessFor1pt5s.cpp
@@ -1,0 +1,324 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P1Cooldown_CannotPossessFor1pt5s (MVP-1.5.1 + 1.5.2)
+//
+// Verifies the possession-cooldown gate added by MVP-1.5.2. After a
+// voluntary switch, `DP_Player::TryVoluntaryPossessSwitch(another_id)`
+// must REFUSE any further switches until the cooldown drains to zero.
+// Default cooldown is `possession.cooldown_after_voluntary_switch_s = 1.5`.
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Pick three distinct villagers (A = closest, B = mid-distance,
+//      C = farthest -- the actual choice doesn't matter; we just need
+//      three different EntityIDs).
+//   3. SetPossessedVillager(A) -- direct write, no cooldown. Initial
+//      possession.
+//   4. TryVoluntaryPossessSwitch(B) -- should SUCCEED. Cooldown now
+//      armed at ~1.5s.
+//   5. Immediately TryVoluntaryPossessSwitch(C) -- should REFUSE
+//      (cooldown active). Player remains possessing B.
+//   6. Run ~60 frames (~1.0s). Cooldown should still be active
+//      (~0.5s remaining).
+//   7. TryVoluntaryPossessSwitch(C) again -- still REFUSED.
+//   8. Run ~40 more frames (~0.7s additional, total ~1.7s -- past the
+//      1.5s cooldown). Cooldown should now be zero.
+//   9. TryVoluntaryPossessSwitch(C) -- should SUCCEED.
+//
+// What this proves end-to-end:
+//   * TryVoluntaryPossessSwitch returns false during the cooldown
+//     window.
+//   * DPPlayerController_Behaviour's per-frame TickPossessionCooldown
+//     drains the timer at wall-clock rate.
+//   * The possession state stays on the LAST successfully-set villager
+//     while the cooldown is active (the rejected attempts don't
+//     accidentally null out the handle).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kCD_Start, kCD_WaitScene, kCD_PossessA, kCD_SwitchToB,
+	                   kCD_TryEarlySwitchToC, kCD_TickFirstHalf,
+	                   kCD_TryMidSwitchToC, kCD_TickPastEnd,
+	                   kCD_TryLateSwitchToC, kCD_Done };
+
+	int                     g_iPhase = kCD_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	Zenith_EntityID         g_xC;
+
+	// Captured verdicts of each TryVoluntaryPossessSwitch attempt.
+	bool                    g_bSwitchToBOk = false;
+	bool                    g_bEarlySwitchToCOk = false;
+	bool                    g_bMidSwitchToCOk = false;
+	bool                    g_bLateSwitchToCOk = false;
+	Zenith_EntityID         g_xAfterEarlyAttempt;
+	Zenith_EntityID         g_xAfterMidAttempt;
+	Zenith_EntityID         g_xAfterLateAttempt;
+	int                     g_iTickFrames = 0;
+
+	// Frame budgets chosen against the 1.5s default cooldown:
+	//   * 60 frames ~= 1.0s. After this we should STILL be in cooldown.
+	//   * 40 more frames ~= 0.67s additional, total ~1.67s. Past the
+	//     1.5s mark, cooldown should have drained.
+	constexpr int kFRAMES_FIRST_TICK_BLOCK  = 60;
+	constexpr int kFRAMES_SECOND_TICK_BLOCK = 40;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA, const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	// Pick three distinct villagers: closest, mid (≈median), farthest from
+	// the priest. The exact ordering doesn't matter for this test --
+	// we just need three different EntityIDs to switch between -- but
+	// using distance-from-priest gives a stable, reproducible pick if
+	// GameLevel ever shuffles villager order in DP_LevelData.
+	void PickThreeVillagers(Zenith_EntityID& xClosest,
+	                        Zenith_EntityID& xMid,
+	                        Zenith_EntityID& xFarthest)
+	{
+		// Anchor pick: use the active scene's first DPVillager-by-iteration
+		// as a reference. The DP_Query iteration order matches insertion
+		// order which matches DP_LevelData::kVillager order, so this is
+		// deterministic.
+		Zenith_Maths::Vector3 xAnchor(0.0f);
+		bool bGotAnchor = false;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xAnchor, &bGotAnchor]
+			(Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (bGotAnchor) return;
+				bGotAnchor = TryGetEntityPos(xId, xAnchor);
+			});
+		if (!bGotAnchor) return;
+
+		struct Cand { Zenith_EntityID xId; float fDist; };
+		Zenith_Vector<Cand> axCands;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xAnchor, &axCands]
+			(Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				Zenith_Maths::Vector3 xPos;
+				if (!TryGetEntityPos(xId, xPos)) return;
+				Cand xC;
+				xC.xId = xId;
+				xC.fDist = HorizontalDistance(xPos, xAnchor);
+				axCands.PushBack(xC);
+			});
+		if (axCands.GetSize() < 3) return;
+
+		// Cheap "sort by distance" -- bubble for the 17-villager scene.
+		for (uint32_t i = 0; i < axCands.GetSize(); ++i)
+		{
+			for (uint32_t j = i + 1; j < axCands.GetSize(); ++j)
+			{
+				if (axCands.Get(j).fDist < axCands.Get(i).fDist)
+				{
+					const Cand xTmp = axCands.Get(i);
+					axCands.Get(i) = axCands.Get(j);
+					axCands.Get(j) = xTmp;
+				}
+			}
+		}
+
+		xClosest  = axCands.Get(0).xId;
+		xMid      = axCands.Get(axCands.GetSize() / 2).xId;
+		xFarthest = axCands.Get(axCands.GetSize() - 1).xId;
+	}
+}
+
+static void Setup_P1Cooldown()
+{
+	g_iPhase = kCD_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_xC = INVALID_ENTITY_ID;
+	g_bSwitchToBOk = false;
+	g_bEarlySwitchToCOk = false;
+	g_bMidSwitchToCOk = false;
+	g_bLateSwitchToCOk = false;
+	g_xAfterEarlyAttempt = INVALID_ENTITY_ID;
+	g_xAfterMidAttempt = INVALID_ENTITY_ID;
+	g_xAfterLateAttempt = INVALID_ENTITY_ID;
+	g_iTickFrames = 0;
+}
+
+static bool Step_P1Cooldown(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kCD_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kCD_WaitScene;
+		return true;
+
+	case kCD_WaitScene:
+	{
+		PickThreeVillagers(g_xA, g_xB, g_xC);
+		if (g_xA.IsValid() && g_xB.IsValid() && g_xC.IsValid()
+			&& g_xA.m_uIndex != g_xB.m_uIndex
+			&& g_xB.m_uIndex != g_xC.m_uIndex
+			&& g_xA.m_uIndex != g_xC.m_uIndex)
+		{
+			g_iPhase = kCD_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kCD_Done;
+		}
+		return true;
+	}
+
+	case kCD_PossessA:
+		// Direct write -- baseline state, no cooldown.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kCD_SwitchToB;
+		return true;
+
+	case kCD_SwitchToB:
+		// Voluntary switch -- arms the cooldown on success.
+		g_bSwitchToBOk = DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kCD_TryEarlySwitchToC;
+		return true;
+
+	case kCD_TryEarlySwitchToC:
+		// Immediately attempt another switch -- must be REFUSED.
+		g_bEarlySwitchToCOk = DP_Player::TryVoluntaryPossessSwitch(g_xC);
+		g_xAfterEarlyAttempt = DP_Player::GetPossessedVillager();
+		g_iTickFrames = 0;
+		g_iPhase = kCD_TickFirstHalf;
+		return true;
+
+	case kCD_TickFirstHalf:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kFRAMES_FIRST_TICK_BLOCK)
+		{
+			g_iPhase = kCD_TryMidSwitchToC;
+		}
+		return true;
+
+	case kCD_TryMidSwitchToC:
+		// Still within the 1.5s window (~1.0s elapsed) -- still REFUSED.
+		g_bMidSwitchToCOk = DP_Player::TryVoluntaryPossessSwitch(g_xC);
+		g_xAfterMidAttempt = DP_Player::GetPossessedVillager();
+		g_iTickFrames = 0;
+		g_iPhase = kCD_TickPastEnd;
+		return true;
+
+	case kCD_TickPastEnd:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kFRAMES_SECOND_TICK_BLOCK)
+		{
+			g_iPhase = kCD_TryLateSwitchToC;
+		}
+		return true;
+
+	case kCD_TryLateSwitchToC:
+		// Past the 1.5s window (~1.67s elapsed total) -- now SUCCEEDS.
+		g_bLateSwitchToCOk = DP_Player::TryVoluntaryPossessSwitch(g_xC);
+		g_xAfterLateAttempt = DP_Player::GetPossessedVillager();
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Cooldown: switchToB=%d earlyToC=%d midToC=%d lateToC=%d (expect 1 0 0 1) postLate=%u/%u (expect %u/%u)",
+			(int)g_bSwitchToBOk, (int)g_bEarlySwitchToCOk,
+			(int)g_bMidSwitchToCOk, (int)g_bLateSwitchToCOk,
+			g_xAfterLateAttempt.m_uIndex, g_xAfterLateAttempt.m_uGeneration,
+			g_xC.m_uIndex, g_xC.m_uGeneration);
+		g_iPhase = kCD_Done;
+		return false;
+
+	case kCD_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1Cooldown()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid() || !g_xC.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: failed to pick 3 distinct villagers");
+		return false;
+	}
+	if (!g_bSwitchToBOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: initial switch A->B should have succeeded (no prior cooldown)");
+		return false;
+	}
+	if (g_bEarlySwitchToCOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: immediate switch B->C was allowed -- cooldown gate didn't fire");
+		return false;
+	}
+	if (g_xAfterEarlyAttempt.m_uIndex != g_xB.m_uIndex
+		|| g_xAfterEarlyAttempt.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Cooldown: rejected switch should have left possession on B, but got %u/%u (B=%u/%u)",
+			g_xAfterEarlyAttempt.m_uIndex, g_xAfterEarlyAttempt.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		return false;
+	}
+	if (g_bMidSwitchToCOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: mid-window switch B->C was allowed -- cooldown drained too fast");
+		return false;
+	}
+	if (g_xAfterMidAttempt.m_uIndex != g_xB.m_uIndex
+		|| g_xAfterMidAttempt.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: rejected mid switch should have left possession on B");
+		return false;
+	}
+	if (!g_bLateSwitchToCOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: late switch B->C past the 1.5s window was refused -- cooldown didn't drain");
+		return false;
+	}
+	if (g_xAfterLateAttempt.m_uIndex != g_xC.m_uIndex
+		|| g_xAfterLateAttempt.m_uGeneration != g_xC.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Cooldown: late switch did not change possession to C");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1CooldownTest = {
+	"Test_P1Cooldown_CannotPossessFor1pt5s",
+	&Setup_P1Cooldown,
+	&Step_P1Cooldown,
+	&Verify_P1Cooldown,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1CooldownTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Cooldown_NotAffectedByDeath.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Cooldown_NotAffectedByDeath.cpp
@@ -1,0 +1,243 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+
+// ============================================================================
+// Test_P1Cooldown_NotAffectedByDeath (MVP-1.5.3)
+//
+// Regression guard: when a possessed villager dies (life timer expires
+// -> DPVillager_Behaviour::TickLife dispatches DP_OnVillagerDied and
+// calls DP_Player::SetPossessedVillager(INVALID_ENTITY_ID)), NO
+// possession cooldown should accrue. The player must be able to
+// immediately TryVoluntaryPossessSwitch onto another villager.
+//
+// Tuning canon: "possession.cooldown_after_burnout_s = 0.0" --
+// burnout (death-by-life-timer) imposes no cooldown by design.
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Find two villagers (A and B; B != A).
+//   3. SetPossessedVillager(A). Wait one frame so DPVillager A's
+//      OnUpdate flips its m_bIsPossessed flag + bumps remaining life.
+//   4. SetRemainingLifeForTest(0.05f) -- shrink A's life so the next
+//      TickLife frame burns it down to zero.
+//   5. Tick ~10 frames. Within that window:
+//      - DPVillager_A::TickLife sees remainingLife <= 0
+//      - Dispatches DP_OnVillagerDied
+//      - Calls DP_Player::SetPossessedVillager(INVALID_ENTITY_ID)
+//      - This is the SYSTEM path -- NO cooldown set.
+//   6. Snapshot DP_Player::GetPossessionCooldownRemaining() (expect 0).
+//   7. Snapshot DP_Player::GetPossessedVillager() (expect INVALID).
+//   8. TryVoluntaryPossessSwitch(B). Expect success.
+//
+// What this proves:
+//   * Death path does not call any cooldown-setting code.
+//   * The cooldown timer state is clean after a death.
+//   * Player can immediately repossess after losing a vessel to
+//     burnout, without waiting out a switch-cooldown.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kND_Start, kND_WaitScene, kND_Possess, kND_AfterBump,
+	                   kND_ShrinkLife, kND_TickForDeath,
+	                   kND_VerifyDeath, kND_TrySwitchB, kND_Done };
+
+	int                     g_iPhase = kND_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	Zenith_EventHandle      g_xDeathHandle = INVALID_EVENT_HANDLE;
+	bool                    g_bDeathFired = false;
+	float                   g_fCooldownAfterDeath = -1.0f;
+	Zenith_EntityID         g_xPossessionAfterDeath;
+	bool                    g_bSwitchToBOk = false;
+	Zenith_EntityID         g_xPossessionAfterSwitch;
+	int                     g_iTickCount = 0;
+
+	constexpr int kFRAMES_FOR_DEATH = 30; // ~0.5s -- well past the 0.05s life budget
+}
+
+static void Setup_P1CooldownDeath()
+{
+	g_iPhase = kND_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_bDeathFired = false;
+	g_fCooldownAfterDeath = -1.0f;
+	g_xPossessionAfterDeath = INVALID_ENTITY_ID;
+	g_bSwitchToBOk = false;
+	g_xPossessionAfterSwitch = INVALID_ENTITY_ID;
+	g_iTickCount = 0;
+	g_xDeathHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnVillagerDied>(
+		[](const DP_OnVillagerDied&) { g_bDeathFired = true; });
+}
+
+static bool Step_P1CooldownDeath(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kND_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kND_WaitScene;
+		return true;
+
+	case kND_WaitScene:
+	{
+		// Pick first two distinct villagers iterated. Order matches
+		// DP_LevelData::kVillager insertion order, so this is reproducible.
+		Zenith_EntityID xFirst, xSecond;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFirst, &xSecond]
+			(Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFirst.IsValid()) { xFirst = xId; return; }
+				if (!xSecond.IsValid() && xId.m_uIndex != xFirst.m_uIndex)
+				{
+					xSecond = xId;
+				}
+			});
+		if (xFirst.IsValid() && xSecond.IsValid())
+		{
+			g_xA = xFirst;
+			g_xB = xSecond;
+			g_iPhase = kND_Possess;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kND_Done;
+		}
+		return true;
+	}
+
+	case kND_Possess:
+		// Direct write -- system path, no cooldown plumbing. This is
+		// also what DPPlayerController would have done historically
+		// before MVP-1.5; the test models the baseline state of "the
+		// player is currently possessing A" without going through
+		// TryVoluntaryPossessSwitch (which would itself arm a
+		// cooldown and confound the test).
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kND_AfterBump;
+		return true;
+
+	case kND_AfterBump:
+	{
+		// One frame later: DPVillager_A's OnUpdate has flipped its
+		// m_bIsPossessed flag and bumped m_fRemainingLife back to
+		// m_fMaxLife (the "freshly-possessed transition" handler). Now
+		// the test can shrink life without it being clobbered.
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(g_xA);
+		if (pxScene == nullptr) { g_iPhase = kND_Done; return false; }
+		Zenith_Entity xEnt = pxScene->TryGetEntity(g_xA);
+		if (!xEnt.IsValid() || !xEnt.HasComponent<Zenith_ScriptComponent>()) { g_iPhase = kND_Done; return false; }
+		DPVillager_Behaviour* pxV = xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+		if (pxV == nullptr) { g_iPhase = kND_Done; return false; }
+		pxV->SetRemainingLifeForTest(0.05f);
+		g_iPhase = kND_ShrinkLife;
+		return true;
+	}
+
+	case kND_ShrinkLife:
+		// One more frame to ensure TickLife sees the shrunk value next
+		// tick. Splitting kND_AfterBump from kND_ShrinkLife from
+		// kND_TickForDeath makes the test's timing pessimistic on
+		// purpose: each phase consumes exactly one Step() invocation,
+		// and the assertions don't depend on whether death fires on
+		// frame N or N+1.
+		g_iPhase = kND_TickForDeath;
+		return true;
+
+	case kND_TickForDeath:
+		++g_iTickCount;
+		if (g_bDeathFired || g_iTickCount >= kFRAMES_FOR_DEATH)
+		{
+			g_iPhase = kND_VerifyDeath;
+		}
+		return true;
+
+	case kND_VerifyDeath:
+		g_fCooldownAfterDeath = DP_Player::GetPossessionCooldownRemaining();
+		g_xPossessionAfterDeath = DP_Player::GetPossessedVillager();
+		g_iPhase = kND_TrySwitchB;
+		return true;
+
+	case kND_TrySwitchB:
+		// The crucial assertion: TryVoluntaryPossessSwitch onto B must
+		// succeed IMMEDIATELY after the death, with no cooldown wait.
+		g_bSwitchToBOk = DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_xPossessionAfterSwitch = DP_Player::GetPossessedVillager();
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1CooldownNoDeath: death=%d cooldownAfter=%.3f possAfter=(%u/%u) switchOk=%d possessionAfterSwitch=(%u/%u)",
+			(int)g_bDeathFired, g_fCooldownAfterDeath,
+			g_xPossessionAfterDeath.m_uIndex, g_xPossessionAfterDeath.m_uGeneration,
+			(int)g_bSwitchToBOk,
+			g_xPossessionAfterSwitch.m_uIndex, g_xPossessionAfterSwitch.m_uGeneration);
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xDeathHandle);
+		g_iPhase = kND_Done;
+		return false;
+
+	case kND_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1CooldownDeath()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1CooldownNoDeath: failed to pick two villagers");
+		return false;
+	}
+	if (!g_bDeathFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1CooldownNoDeath: DP_OnVillagerDied never fired -- TickLife didn't run");
+		return false;
+	}
+	if (g_xPossessionAfterDeath.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1CooldownNoDeath: possession not cleared by death (got %u/%u)",
+			g_xPossessionAfterDeath.m_uIndex, g_xPossessionAfterDeath.m_uGeneration);
+		return false;
+	}
+	if (g_fCooldownAfterDeath > 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1CooldownNoDeath: cooldown=%.3f after death -- death path is leaking into cooldown timer",
+			g_fCooldownAfterDeath);
+		return false;
+	}
+	if (!g_bSwitchToBOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1CooldownNoDeath: TryVoluntaryPossessSwitch(B) refused immediately after death");
+		return false;
+	}
+	if (g_xPossessionAfterSwitch.m_uIndex != g_xB.m_uIndex
+		|| g_xPossessionAfterSwitch.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1CooldownNoDeath: possession not switched to B");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1CooldownDeathTest = {
+	"Test_P1Cooldown_NotAffectedByDeath",
+	&Setup_P1CooldownDeath,
+	&Step_P1CooldownDeath,
+	&Verify_P1CooldownDeath,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1CooldownDeathTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Adds the cooldown gate the GDD specifies for voluntary switches: after a switch, the player can't switch again for `possession.cooldown_after_voluntary_switch_s` (default 1.5 s). Death + priest apprehend bypass the cooldown so the player can repossess immediately after losing a vessel.

### MVP-1.5.2 — DP_Player API

- `TryVoluntaryPossessSwitch(xId) -> bool` — new player entry point. Refuses when cooldown active; arms cooldown on success. Idempotent re-click on the same villager returns true without consuming the window.
- `TickPossessionCooldown(fDt)` — per-frame drain. Wired from `DPPlayerController_Behaviour::OnUpdate`.
- `GetPossessionCooldownRemaining()` — read accessor (HUD/debug; tests use it).
- Existing `SetPossessedVillager(xId)` is the "system" path used by villager death + priest apprehend + tests. Does NOT touch the cooldown, matching tuning's `cooldown_after_burnout_s = 0.0` canon.
- DPPlayerController's click-to-possess raycast now uses `TryVoluntaryPossessSwitch` so player clicks are subject to the cooldown gate.

### MVP-1.5.1 — `Test_P1Cooldown_CannotPossessFor1pt5s`

GameLevel scene. Possess A, voluntarily switch to B (success, cooldown armed), immediately try switch to C (refused), tick ~1 s (still refused), tick another ~0.7 s past the 1.5 s window, try switch to C (now succeeds). Asserts rejected switches leave possession on B, not null.

### MVP-1.5.3 — `Test_P1Cooldown_NotAffectedByDeath`

Direct SetPossessedVillager(A), wait one bump frame, SetRemainingLifeForTest(0.05), tick until DP_OnVillagerDied fires. After death: cooldown == 0 AND `TryVoluntaryPossessSwitch(B)` succeeds immediately.

## Test plan

- [x] Test_P1Cooldown_CannotPossessFor1pt5s passes in 109 frames
- [x] Test_P1Cooldown_NotAffectedByDeath passes in 13 frames
- [x] All existing tests pass (PriestPursuit, apprehend trilogy, etc.)
- [x] Full DP suite: **43 PASSED, 0 FAILED, 15 SKIPPED-headless**
- [x] Build clean (`vs2022_Debug_Win64_True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)