### PR TITLE
feat(dp): MVP-1.8.{1,2,3} -- possession range gate + tests

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -225,6 +225,8 @@
     <ClCompile Include="..\Tests\Test_P1Pause_InputSimDuringPause.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_PriestStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -101,6 +101,12 @@
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -519,6 +519,8 @@
     <ClCompile Include="..\Tests\Test_P1Pause_InputSimDuringPause.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_PriestStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -101,6 +101,12 @@
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -35,6 +35,30 @@ namespace
 	// canon: "cooldown_after_burnout_s = 0.0".
 	float g_fPossessionCooldownRemaining = 0.0f;
 
+	// MVP-1.8: anchor position. Set by SetPossessedVillager and
+	// TryVoluntaryPossessSwitch from the new villager's transform
+	// position on any successful possession. TryVoluntaryPossessSwitch
+	// then enforces that subsequent voluntary switches stay within
+	// `possession.range_from_anchor_m` (default 15 m) of the anchor.
+	// SetPossessedVillager(INVALID) clears the anchor; the next
+	// successful possession re-seeds it.
+	Zenith_Maths::Vector3 g_xPossessionAnchor = Zenith_Maths::Vector3(0.0f);
+	bool                  g_bHasPossessionAnchor = false;
+
+	// Resolves a villager handle to its world position. Returns false
+	// if the entity has no transform / no scene-data binding (e.g.,
+	// passed a stale handle after the villager was destroyed).
+	bool TryGetVillagerPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
 	// Per-villager held-item record. Mutated by DP_Player::SetHeldItem /
 	// RemoveHeldItem, read by DP_Player::GetHeldItem*. EntityID hashes via
 	// (m_uIndex,m_uGeneration) — pack to uint64_t for std::unordered_map.
@@ -79,12 +103,27 @@ namespace DP_Player
 	void SetPossessedVillager(Zenith_EntityID xId)
 	{
 		g_xPossessedVillager = xId;
+		// MVP-1.8: keep the anchor in sync with the latest possession.
+		// System callers (death cleared possession, apprehend cleared
+		// possession, test setup) reach this function; clearing to
+		// INVALID drops the anchor so the next voluntary attempt gets
+		// a fresh seed without inheriting a stale anchor from a long-
+		// dead villager.
+		if (xId.IsValid() && TryGetVillagerPos(xId, g_xPossessionAnchor))
+		{
+			g_bHasPossessionAnchor = true;
+		}
+		else
+		{
+			g_bHasPossessionAnchor = false;
+		}
 	}
 
 	bool TryVoluntaryPossessSwitch(Zenith_EntityID xId)
 	{
 		// Idempotent re-click: clicking the same villager you're already
-		// possessing is a no-op (and doesn't waste the cooldown window).
+		// possessing is a no-op (and doesn't waste the cooldown window
+		// or trip the range gate).
 		if (xId.IsValid()
 			&& g_xPossessedVillager.IsValid()
 			&& xId.m_uIndex == g_xPossessedVillager.m_uIndex
@@ -100,9 +139,43 @@ namespace DP_Player
 			return false;
 		}
 
+		// MVP-1.8: range gate. Anchor was set by the prior successful
+		// possession (or by a direct SetPossessedVillager). If no anchor
+		// has ever been set (fresh process / immediately after a death
+		// that cleared it), skip the range check -- the first voluntary
+		// switch establishes the anchor.
+		Zenith_Maths::Vector3 xNewPos(0.0f);
+		const bool bGotNewPos = xId.IsValid() && TryGetVillagerPos(xId, xNewPos);
+		if (g_bHasPossessionAnchor && bGotNewPos)
+		{
+			const float fDx = xNewPos.x - g_xPossessionAnchor.x;
+			const float fDz = xNewPos.z - g_xPossessionAnchor.z;
+			const float fDist = std::sqrt(fDx * fDx + fDz * fDz);
+			const float fMaxRange =
+				DP_Tuning::Get<float>("possession.range_from_anchor_m");
+			if (fDist > fMaxRange)
+			{
+				return false;
+			}
+		}
+
 		g_xPossessedVillager = xId;
 		g_fPossessionCooldownRemaining =
 			DP_Tuning::Get<float>("possession.cooldown_after_voluntary_switch_s");
+
+		// Update the anchor to the new villager so the next voluntary
+		// hop's range is measured from where the player jumped TO, not
+		// where they jumped FROM. (Matches "demon-hop chain" semantics:
+		// each successful possession defines a new anchor circle.)
+		if (bGotNewPos)
+		{
+			g_xPossessionAnchor = xNewPos;
+			g_bHasPossessionAnchor = true;
+		}
+		else
+		{
+			g_bHasPossessionAnchor = false;
+		}
 		return true;
 	}
 
@@ -157,6 +230,8 @@ namespace DP_Player
 		g_xPossessedVillager = INVALID_ENTITY_ID;
 		g_xHeldItems.clear();
 		g_fPossessionCooldownRemaining = 0.0f;
+		g_xPossessionAnchor = Zenith_Maths::Vector3(0.0f);
+		g_bHasPossessionAnchor = false;
 	}
 }
 

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -98,27 +98,30 @@ namespace DP_Player
 	Zenith_EntityID GetPossessedVillager();
 	void SetPossessedVillager(Zenith_EntityID xId);
 
-	// MVP-1.5: voluntary-switch possession path. Player-driven possession
-	// (click-to-possess, future switch UI) goes through this entry point
-	// so the cooldown gate fires. System paths -- villager death, priest
-	// apprehend -- keep calling SetPossessedVillager directly so they
-	// don't trigger a cooldown the player can't see coming.
+	// MVP-1.5 + 1.8: voluntary-switch possession path. Player-driven
+	// possession (click-to-possess, future switch UI) goes through this
+	// entry point so the cooldown + range gates fire. System paths --
+	// villager death, priest apprehend -- keep calling SetPossessedVillager
+	// directly so they don't trigger gates the player can't see coming.
 	//
 	// Returns true if the possession actually changed; false when the
-	// call was rejected by the cooldown gate. Resolving to the SAME
-	// villager that's already possessed returns true and is a no-op
-	// (idempotent re-clicks don't waste the cooldown window).
+	// call was rejected by the cooldown or range gates. Resolving to the
+	// SAME villager that's already possessed returns true and is a no-op
+	// (idempotent re-clicks don't waste the cooldown window or trip the
+	// range gate).
 	//
-	// Cooldown rules:
-	//   * Switching to a different valid villager (incl. INVALID -> X
-	//     while a cooldown is already burning down from a prior switch):
-	//     refused if cooldown > 0; on success, cooldown = priest_tuning
+	// Gates:
+	//   * Cooldown (MVP-1.5): refused if cooldown > 0; on success,
+	//     cooldown = priest_tuning
 	//     "possession.cooldown_after_voluntary_switch_s" (default 1.5 s).
-	//   * Voluntarily releasing to INVALID while currently possessing
-	//     a valid villager: cooldown = same as above.
-	//   * Resetting cooldown is automatic on death / apprehend (those
-	//     paths use SetPossessedVillager and don't touch the cooldown
-	//     timer; "cooldown_after_burnout_s = 0" in tuning is the canon).
+	//   * Range (MVP-1.8): refused if the new villager's world position
+	//     is more than "possession.range_from_anchor_m" (default 15 m)
+	//     from the anchor. Anchor is set by SetPossessedVillager and
+	//     TryVoluntaryPossessSwitch on success; cleared by
+	//     SetPossessedVillager(INVALID_ENTITY_ID).
+	//   * Resetting cooldown / range is automatic on death / apprehend
+	//     (those paths use SetPossessedVillager and don't trigger the
+	//     gates; "cooldown_after_burnout_s = 0" in tuning is the canon).
 	bool TryVoluntaryPossessSwitch(Zenith_EntityID xId);
 
 	// Per-frame cooldown decrement. DPPlayerController_Behaviour::OnUpdate

--- a/Games/DevilsPlayground/Tests/Test_P1Cooldown_CannotPossessFor1pt5s.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Cooldown_CannotPossessFor1pt5s.cpp
@@ -10,6 +10,7 @@
 
 #include "Source/PublicInterfaces.h"
 #include "Source/DP_Tuning.h"
+#include "Collections/Zenith_Vector.h"
 #include "Components/DPVillager_Behaviour.h"
 
 #include <cmath>
@@ -97,62 +98,78 @@ namespace
 		return std::sqrt(fDx * fDx + fDz * fDz);
 	}
 
-	// Pick three distinct villagers: closest, mid (≈median), farthest from
-	// the priest. The exact ordering doesn't matter for this test --
-	// we just need three different EntityIDs to switch between -- but
-	// using distance-from-priest gives a stable, reproducible pick if
-	// GameLevel ever shuffles villager order in DP_LevelData.
-	void PickThreeVillagers(Zenith_EntityID& xClosest,
-	                        Zenith_EntityID& xMid,
-	                        Zenith_EntityID& xFarthest)
+	// Pick three distinct villagers that are MUTUALLY within
+	// `possession.range_from_anchor_m` of each other. Required because
+	// MVP-1.8's range gate also fires inside TryVoluntaryPossessSwitch
+	// -- if A and B are 80 m apart, the switch is refused for the
+	// "out of range" reason, not the cooldown reason this test wants
+	// to assert.
+	//
+	// Strategy: find the closest pair (A, B) in the level, then pick C
+	// as the villager closest to A (other than B) that's also within
+	// range of A AND of B. With the stock 17-villager spread of
+	// GameLevel that gives the Blacksmith / Blacksmith2 / Pleb6
+	// cluster (all under 15 m mutually).
+	void PickThreeMutualRangeVillagers(Zenith_EntityID& xA,
+	                                    Zenith_EntityID& xB,
+	                                    Zenith_EntityID& xC)
 	{
-		// Anchor pick: use the active scene's first DPVillager-by-iteration
-		// as a reference. The DP_Query iteration order matches insertion
-		// order which matches DP_LevelData::kVillager order, so this is
-		// deterministic.
-		Zenith_Maths::Vector3 xAnchor(0.0f);
-		bool bGotAnchor = false;
-		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
-			[&xAnchor, &bGotAnchor]
-			(Zenith_EntityID xId, DPVillager_Behaviour&)
-			{
-				if (bGotAnchor) return;
-				bGotAnchor = TryGetEntityPos(xId, xAnchor);
-			});
-		if (!bGotAnchor) return;
+		const float fMaxRange =
+			DP_Tuning::Get<float>("possession.range_from_anchor_m");
 
-		struct Cand { Zenith_EntityID xId; float fDist; };
+		struct Cand { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
 		Zenith_Vector<Cand> axCands;
 		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
-			[&xAnchor, &axCands]
+			[&axCands]
 			(Zenith_EntityID xId, DPVillager_Behaviour&)
 			{
-				Zenith_Maths::Vector3 xPos;
-				if (!TryGetEntityPos(xId, xPos)) return;
-				Cand xC;
-				xC.xId = xId;
-				xC.fDist = HorizontalDistance(xPos, xAnchor);
-				axCands.PushBack(xC);
+				Cand xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos))
+				{
+					axCands.PushBack(xV);
+				}
 			});
 		if (axCands.GetSize() < 3) return;
 
-		// Cheap "sort by distance" -- bubble for the 17-villager scene.
+		// Find the closest pair (A, B).
+		float fMinPair = 1e30f;
+		uint32_t uA = UINT32_MAX, uB = UINT32_MAX;
 		for (uint32_t i = 0; i < axCands.GetSize(); ++i)
 		{
 			for (uint32_t j = i + 1; j < axCands.GetSize(); ++j)
 			{
-				if (axCands.Get(j).fDist < axCands.Get(i).fDist)
+				const float fD = HorizontalDistance(
+					axCands.Get(i).xPos, axCands.Get(j).xPos);
+				if (fD < fMinPair)
 				{
-					const Cand xTmp = axCands.Get(i);
-					axCands.Get(i) = axCands.Get(j);
-					axCands.Get(j) = xTmp;
+					fMinPair = fD;
+					uA = i;
+					uB = j;
 				}
 			}
 		}
+		if (uA == UINT32_MAX) return;
+		if (fMinPair > fMaxRange) return; // No in-range pair anywhere.
 
-		xClosest  = axCands.Get(0).xId;
-		xMid      = axCands.Get(axCands.GetSize() / 2).xId;
-		xFarthest = axCands.Get(axCands.GetSize() - 1).xId;
+		// Find C: a villager (not A, not B) within fMaxRange of BOTH
+		// A AND B. We try every remaining candidate and stop on the
+		// first hit. If none qualify, give up -- the caller will see
+		// xC.IsValid() == false and fail with a test-design message.
+		for (uint32_t k = 0; k < axCands.GetSize(); ++k)
+		{
+			if (k == uA || k == uB) continue;
+			const float fDA = HorizontalDistance(
+				axCands.Get(k).xPos, axCands.Get(uA).xPos);
+			const float fDB = HorizontalDistance(
+				axCands.Get(k).xPos, axCands.Get(uB).xPos);
+			if (fDA <= fMaxRange && fDB <= fMaxRange)
+			{
+				xA = axCands.Get(uA).xId;
+				xB = axCands.Get(uB).xId;
+				xC = axCands.Get(k).xId;
+				return;
+			}
+		}
 	}
 }
 
@@ -183,7 +200,7 @@ static bool Step_P1Cooldown(int iFrame)
 
 	case kCD_WaitScene:
 	{
-		PickThreeVillagers(g_xA, g_xB, g_xC);
+		PickThreeMutualRangeVillagers(g_xA, g_xB, g_xC);
 		if (g_xA.IsValid() && g_xB.IsValid() && g_xC.IsValid()
 			&& g_xA.m_uIndex != g_xB.m_uIndex
 			&& g_xB.m_uIndex != g_xC.m_uIndex

--- a/Games/DevilsPlayground/Tests/Test_P1Range_AcceptedInRange.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Range_AcceptedInRange.cpp
@@ -1,0 +1,211 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P1Range_AcceptedInRange (MVP-1.8.3)
+//
+// Positive-case counterpart to Test_P1Range_RefusedOutOfRange: when the
+// target villager is WITHIN `possession.range_from_anchor_m` (default
+// 15 m) of the anchor, `TryVoluntaryPossessSwitch` must SUCCEED (modulo
+// the cooldown gate, which the test setup steers clear of).
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Find the closest pair of villagers anywhere in the level.
+//      (Blacksmith <-> Blacksmith2 ~3.7 m in stock authoring; well
+//      under the 15 m gate.)
+//   3. SetPossessedVillager(A) -- direct write seeds the anchor at A's
+//      world position, no cooldown.
+//   4. TryVoluntaryPossessSwitch(B) -- range gate sees fDist < 15 m,
+//      cooldown gate sees 0, so the call must SUCCEED.
+//   5. Assert the call returned true AND DP_Player now reports B as
+//      the possessed villager.
+//
+// Combined with the OutOfRange test, this proves the range gate fires
+// on the right side of the threshold (refuses past, accepts within)
+// rather than being a constant-FAIL bug.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kRA_Start, kRA_WaitScene, kRA_PossessA,
+	                   kRA_TrySwitchB, kRA_Done };
+
+	int                     g_iPhase = kRA_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	float                   g_fSeparation = 0.0f;
+	bool                    g_bSwitchOk = false;
+	Zenith_EntityID         g_xPossessionAfterTry;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+}
+
+static void Setup_P1RangeAccepted()
+{
+	g_iPhase = kRA_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_fSeparation = 0.0f;
+	g_bSwitchOk = false;
+	g_xPossessionAfterTry = INVALID_ENTITY_ID;
+}
+
+static bool Step_P1RangeAccepted(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kRA_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kRA_WaitScene;
+		return true;
+
+	case kRA_WaitScene:
+	{
+		// Find the closest pair of villagers. Same O(n^2) shape as the
+		// OutOfRange test, opposite extremum.
+		struct VillagerPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VillagerPos> axCands;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axCands]
+			(Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VillagerPos xV;
+				xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos))
+				{
+					axCands.PushBack(xV);
+				}
+			});
+		if (axCands.GetSize() >= 2)
+		{
+			float fMin = 1e30f;
+			for (uint32_t i = 0; i < axCands.GetSize(); ++i)
+			{
+				for (uint32_t j = i + 1; j < axCands.GetSize(); ++j)
+				{
+					const float fD = HorizontalDistance(
+						axCands.Get(i).xPos, axCands.Get(j).xPos);
+					if (fD < fMin)
+					{
+						fMin = fD;
+						g_xA = axCands.Get(i).xId;
+						g_xB = axCands.Get(j).xId;
+					}
+				}
+			}
+			g_fSeparation = fMin;
+			g_iPhase = kRA_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kRA_Done;
+		}
+		return true;
+	}
+
+	case kRA_PossessA:
+		// Direct write seeds the anchor at A's world position, with no
+		// cooldown. The subsequent TryVoluntaryPossessSwitch is gated
+		// only by range (which should pass) -- if it failed, we'd know
+		// the impl is broken.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kRA_TrySwitchB;
+		return true;
+
+	case kRA_TrySwitchB:
+		g_bSwitchOk = DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_xPossessionAfterTry = DP_Player::GetPossessedVillager();
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeAccepted: separation=%.2fm switchOk=%d possessionAfter=(%u/%u) target=(%u/%u)",
+			g_fSeparation, (int)g_bSwitchOk,
+			g_xPossessionAfterTry.m_uIndex, g_xPossessionAfterTry.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		g_iPhase = kRA_Done;
+		return false;
+
+	case kRA_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1RangeAccepted()
+{
+	const float fMaxRange = DP_Tuning::Get<float>("possession.range_from_anchor_m");
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1RangeAccepted: failed to pick a closest pair");
+		return false;
+	}
+	if (g_fSeparation > fMaxRange)
+	{
+		// Sanity guard: GameLevel must contain at least one pair within
+		// the range threshold, otherwise this test has no teeth. With
+		// stock 17-villager authoring the closest pair is ~3.7 m vs a
+		// 15 m threshold; if a future GameLevel rework spreads villagers
+		// out so the closest pair exceeds 15 m, surface that here.
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeAccepted: closest villager pair %.2fm exceeds range threshold %.2fm -- test setup is meaningless",
+			g_fSeparation, fMaxRange);
+		return false;
+	}
+	if (!g_bSwitchOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeAccepted: switch to villager %.2fm away was REFUSED (range gate is too strict)",
+			g_fSeparation);
+		return false;
+	}
+	if (g_xPossessionAfterTry.m_uIndex != g_xB.m_uIndex
+		|| g_xPossessionAfterTry.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeAccepted: accepted switch did not move possession to B (%u/%u)",
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1RangeAcceptedTest = {
+	"Test_P1Range_AcceptedInRange",
+	&Setup_P1RangeAccepted,
+	&Step_P1RangeAccepted,
+	&Verify_P1RangeAccepted,
+	120
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1RangeAcceptedTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Range_RefusedOutOfRange.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Range_RefusedOutOfRange.cpp
@@ -1,0 +1,211 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+
+// ============================================================================
+// Test_P1Range_RefusedOutOfRange (MVP-1.8.1 + 1.8.2)
+//
+// Verifies the possession-range gate added by MVP-1.8.2. After the
+// anchor is seeded by a successful possession, voluntary switches to a
+// villager OUTSIDE `possession.range_from_anchor_m` (default 15 m) MUST
+// be refused.
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Pick two villagers separated by >> 15 m (closest <-> farthest
+//      pair from an anchor reference -- in stock GameLevel this is
+//      ~65-80 m horizontally).
+//   3. SetPossessedVillager(near) -- direct write seeds the anchor at
+//      the near villager's world position.
+//   4. TryVoluntaryPossessSwitch(far) -- the range gate must REFUSE
+//      because horizontal distance(near.pos, far.pos) > 15 m.
+//   5. Assert the call returned false AND DP_Player still has the
+//      anchor villager possessed (not the far one, not INVALID).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kRR_Start, kRR_WaitScene, kRR_PossessNear,
+	                   kRR_TrySwitchFar, kRR_Done };
+
+	int                     g_iPhase = kRR_Start;
+	Zenith_EntityID         g_xNear;
+	Zenith_EntityID         g_xFar;
+	float                   g_fSeparation = 0.0f;
+	bool                    g_bSwitchOk = true;  // tracks return value; pre-set to "fail" sentinel
+	Zenith_EntityID         g_xPossessionAfterTry;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+}
+
+static void Setup_P1RangeRefused()
+{
+	g_iPhase = kRR_Start;
+	g_xNear = INVALID_ENTITY_ID;
+	g_xFar = INVALID_ENTITY_ID;
+	g_fSeparation = 0.0f;
+	g_bSwitchOk = true;
+	g_xPossessionAfterTry = INVALID_ENTITY_ID;
+}
+
+static bool Step_P1RangeRefused(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kRR_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kRR_WaitScene;
+		return true;
+
+	case kRR_WaitScene:
+	{
+		// Pick the most-separated pair among all DPVillager entities.
+		// 17 villagers in GameLevel; O(n^2) at 17 is 289 distance
+		// computations -- trivial.
+		struct VillagerPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VillagerPos> axCands;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axCands]
+			(Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VillagerPos xV;
+				xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos))
+				{
+					axCands.PushBack(xV);
+				}
+			});
+		if (axCands.GetSize() >= 2)
+		{
+			float fMax = -1.0f;
+			for (uint32_t i = 0; i < axCands.GetSize(); ++i)
+			{
+				for (uint32_t j = i + 1; j < axCands.GetSize(); ++j)
+				{
+					const float fD = HorizontalDistance(
+						axCands.Get(i).xPos, axCands.Get(j).xPos);
+					if (fD > fMax)
+					{
+						fMax = fD;
+						g_xNear = axCands.Get(i).xId;
+						g_xFar  = axCands.Get(j).xId;
+					}
+				}
+			}
+			g_fSeparation = fMax;
+			g_iPhase = kRR_PossessNear;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kRR_Done;
+		}
+		return true;
+	}
+
+	case kRR_PossessNear:
+		// Seed the anchor by directly possessing the "near" villager
+		// (which is one half of the most-separated pair; the names
+		// "near" and "far" are just labels for "anchor" and "the one
+		// we're trying to switch to"). SetPossessedVillager is the
+		// system path -- no cooldown, no gate -- so the next switch
+		// attempt is gated only by range, not by a hangover cooldown.
+		DP_Player::SetPossessedVillager(g_xNear);
+		g_iPhase = kRR_TrySwitchFar;
+		return true;
+
+	case kRR_TrySwitchFar:
+		g_bSwitchOk = DP_Player::TryVoluntaryPossessSwitch(g_xFar);
+		g_xPossessionAfterTry = DP_Player::GetPossessedVillager();
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeRefused: separation=%.2fm switchOk=%d possessionAfter=(%u/%u) anchor=(%u/%u)",
+			g_fSeparation, (int)g_bSwitchOk,
+			g_xPossessionAfterTry.m_uIndex, g_xPossessionAfterTry.m_uGeneration,
+			g_xNear.m_uIndex, g_xNear.m_uGeneration);
+		g_iPhase = kRR_Done;
+		return false;
+
+	case kRR_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1RangeRefused()
+{
+	const float fMaxRange = DP_Tuning::Get<float>("possession.range_from_anchor_m");
+	if (!g_xNear.IsValid() || !g_xFar.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1RangeRefused: failed to pick a villager pair");
+		return false;
+	}
+	if (g_fSeparation <= fMaxRange)
+	{
+		// Sanity guard: GameLevel must contain at least one pair separated
+		// by more than the range threshold, otherwise this test has no
+		// teeth. With the stock 17-villager spread the max separation is
+		// ~80 m vs a 15 m threshold; if a future GameLevel rework drops
+		// below that, surface the test-design break.
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeRefused: max villager separation %.2fm is within range threshold %.2fm -- test setup is meaningless",
+			g_fSeparation, fMaxRange);
+		return false;
+	}
+	if (g_bSwitchOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeRefused: switch to far villager %.2fm away was ALLOWED (range gate didn't fire)",
+			g_fSeparation);
+		return false;
+	}
+	if (g_xPossessionAfterTry.m_uIndex != g_xNear.m_uIndex
+		|| g_xPossessionAfterTry.m_uGeneration != g_xNear.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1RangeRefused: rejected switch left possession on (%u/%u) instead of anchor (%u/%u)",
+			g_xPossessionAfterTry.m_uIndex, g_xPossessionAfterTry.m_uGeneration,
+			g_xNear.m_uIndex, g_xNear.m_uGeneration);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1RangeRefusedTest = {
+	"Test_P1Range_RefusedOutOfRange",
+	&Setup_P1RangeRefused,
+	&Step_P1RangeRefused,
+	&Verify_P1RangeRefused,
+	120
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1RangeRefusedTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Adds the possession-range gate from the GDD: after the anchor is set by a successful possession, the player can only switch to a villager within `possession.range_from_anchor_m` (default 15 m) of the anchor. Demon-hop chain semantics — each successful possession redefines the anchor circle for the next hop.

### MVP-1.8.2 — DP_Player range plumbing

- `g_xPossessionAnchor` + `g_bHasPossessionAnchor` track the latest anchor.
- `SetPossessedVillager(valid)` seeds the anchor; `SetPossessedVillager(INVALID)` clears it.
- `TryVoluntaryPossessSwitch` adds horizontal-distance check; refuses if > range.
- Anchor MOVES on each successful voluntary hop (range is measured from where you just jumped TO, not where you started the run).
- Idempotent re-clicks bypass both cooldown and range gates.

### MVP-1.8.1 — `Test_P1Range_RefusedOutOfRange`

Finds max-separation villager pair (~101 m apart), possesses one, asserts `TryVoluntaryPossessSwitch` to the other returns false.

### MVP-1.8.3 — `Test_P1Range_AcceptedInRange`

Finds closest villager pair (~3.75 m), possesses one, asserts switch to the other returns true.

### Compatibility fix in `Test_P1Cooldown_CannotPossessFor1pt5s`

The MVP-1.5 cooldown test (merged in PR #43) picks three villagers from across the level; on master + this PR, those switches get range-refused before the cooldown gate fires. Updated the picker to find three villagers all mutually within `range_from_anchor_m`, so the cooldown test asserts the cooldown gate specifically rather than some other denial reason.

## Test plan

- [x] `Test_P1Range_RefusedOutOfRange` passes (separation 101 m → refused)
- [x] `Test_P1Range_AcceptedInRange` passes (separation 3.75 m → accepted)
- [x] `Test_P1Cooldown_CannotPossessFor1pt5s` still passes after the picker update
- [x] All other tests pass
- [x] Full DP suite: **45 PASSED, 0 FAILED, 15 SKIPPED-headless**
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)