### PR TITLE
feat(dp): MVP-1.7.{1,2,3} -- sprint (Shift + move = +3 s/s life cost + 12 m/s)

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -229,6 +229,8 @@
     <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_AccumulatesOnPossession.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -113,6 +113,12 @@
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -523,6 +523,8 @@
     <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_AccumulatesOnPossession.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -113,6 +113,12 @@
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
@@ -126,11 +126,20 @@ public:
 
 		if (m_bIsPossessed)
 		{
+			// MVP-1.7: compute "sprinting now" once per frame so TickLife
+			// and TickMovement agree. Sprint requires BOTH the input
+			// (Shift held) AND movement input (otherwise standing-still
+			// with Shift down would burn life for no movement -- failing
+			// MVP-1.7.3's "no drain when not moving" test).
+			const Zenith_Maths::Vector2 xMove = DP_Input::ReadMoveVillager();
+			const float fMoveLen = glm::length(xMove);
+			m_bIsSprintingNow = DP_Input::ReadSprintHeld() && (fMoveLen > 0.01f);
 			TickLife(fDt);
 			TickMovement(fDt);
 		}
 		else
 		{
+			m_bIsSprintingNow = false;
 			ZeroHorizontalVelocity();
 		}
 
@@ -204,6 +213,11 @@ public:
 	// the move speed externally (it's only consumed inside TickMovement).
 	float GetMoveSpeed() const { return m_fMoveSpeed; }
 	bool IsPossessed() const { return m_bIsPossessed; }
+	// MVP-1.7: test accessor -- returns true if Shift was held AND the
+	// villager was actually moving on the most recent OnUpdate. Used by
+	// Test_P1Sprint_* to verify the sprint state machine without
+	// faking input.
+	bool IsSprintingNow() const { return m_bIsSprintingNow; }
 
 	// Test/debug only: shrink the timer so death-by-timeout tests don't need
 	// 1800+ simulated frames to fire. Production gameplay sets m_fMaxLife
@@ -213,7 +227,20 @@ public:
 private:
 	void TickLife(float fDt)
 	{
-		m_fRemainingLife -= fDt;
+		// MVP-1.7: sprinting AND moving drains an extra
+		// movement.sprint_life_cost_extra_per_s on TOP of the baseline
+		// 1.0 s/s drain. The "AND moving" condition is enforced by
+		// OnUpdate's m_bIsSprintingNow computation so a player who
+		// holds Shift while standing still doesn't burn life for
+		// nothing (Test_P1Sprint_NoDrainWhenNotMoving).
+		float fDrain = fDt;
+		if (m_bIsSprintingNow)
+		{
+			const float fExtra =
+				DP_Tuning::Get<float>("movement.sprint_life_cost_extra_per_s");
+			fDrain += fExtra * fDt;
+		}
+		m_fRemainingLife -= fDrain;
 		if (m_fRemainingLife <= 0.0f)
 		{
 			m_fRemainingLife = 0.0f;
@@ -255,7 +282,16 @@ private:
 		{
 			const Zenith_Maths::Vector3 xDir =
 				glm::normalize(xInput.x * xRight + xInput.y * xForward);
-			xVel = xDir * m_fMoveSpeed;
+			// MVP-1.7: sprint speed multiplier. The "AND moving"
+			// guard lives in OnUpdate (m_bIsSprintingNow); we just
+			// read the flag here to swap m_fMoveSpeed for the sprint
+			// tuning value when active.
+			float fSpeed = m_fMoveSpeed;
+			if (m_bIsSprintingNow)
+			{
+				fSpeed = DP_Tuning::Get<float>("movement.sprint_speed_mps");
+			}
+			xVel = xDir * fSpeed;
 		}
 		Zenith_Physics::SetLinearVelocity(xCollider.GetBodyID(), xVel);
 	}
@@ -441,6 +477,11 @@ private:
 	// skip collider response.
 	float m_fMoveSpeed      = 8.0f;
 	bool  m_bIsPossessed    = false;
+	// MVP-1.7: sprint-state cache. Set in OnUpdate to
+	// (DP_Input::ReadSprintHeld() && moving). TickLife / TickMovement
+	// both read this so they agree on whether sprint is active this
+	// tick.
+	bool  m_bIsSprintingNow = false;
 	// Snapshot of the base materials taken on first possession - used to
 	// restore the un-tinted look when un-possessed.
 	Zenith_Vector<Zenith_MaterialAsset*> m_apxBaseMaterials;

--- a/Games/DevilsPlayground/Source/DPInputActions.h
+++ b/Games/DevilsPlayground/Source/DPInputActions.h
@@ -20,6 +20,17 @@ namespace DP_Input
 		return xInput;
 	}
 
+	// MVP-1.7: sprint hold. Either Shift key works (some Windows /
+	// laptop keyboards don't fire both as the same logical key).
+	// DPVillager_Behaviour reads this each frame to decide whether
+	// to apply movement.sprint_speed_mps and the
+	// movement.sprint_life_cost_extra_per_s drain.
+	inline bool ReadSprintHeld()
+	{
+		return Zenith_Input::IsKeyHeld(ZENITH_KEY_LEFT_SHIFT)
+			|| Zenith_Input::IsKeyHeld(ZENITH_KEY_RIGHT_SHIFT);
+	}
+
 	inline bool ReadInteractPressed()
 	{
 		return Zenith_Input::WasKeyPressedThisFrame(ZENITH_KEY_F);

--- a/Games/DevilsPlayground/Tests/Test_P1Sprint_DrainsLifeFaster.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Sprint_DrainsLifeFaster.cpp
@@ -1,0 +1,275 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "Input/Zenith_InputSimulator.h"
+#include "Input/Zenith_KeyCodes.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Sprint_DrainsLifeFaster (MVP-1.7.1 + 1.7.2)
+//
+// Verifies MVP-1.7's sprint mechanic: while sprinting (Shift held AND
+// moving), the possessed villager's life drains at
+//   1.0 + movement.sprint_life_cost_extra_per_s   (1.0 + 3.0 = 4.0 s/s)
+// versus the 1.0 s/s baseline when only moving (no Shift).
+//
+// Procedure:
+//   1. Load GameLevel, possess any villager.
+//   2. Wait one bump frame so OnUpdate sets m_bIsPossessed and bumps
+//      life to m_fMaxLife.
+//   3. **Sprint window**: SetRemainingLifeForTest(30.0) as a baseline,
+//      SimulateKeyHeld(W) + SimulateKeyHeld(LEFT_SHIFT), tick 60
+//      frames (~1.0 s).  Snapshot life delta.
+//   4. **Walk window**: SetRemainingLifeForTest(30.0) again,
+//      SimulateKeyHeld(LEFT_SHIFT, false) but keep W held, tick 60
+//      frames.  Snapshot life delta.
+//   5. Assert: sprint delta > walk delta by AT LEAST 2 s (out of the
+//      3 s/s extra-cost-per-second the tuning specifies; 2 s gives
+//      slack against frame-time jitter / boundary frames).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kSP_Start, kSP_WaitScene, kSP_Possess, kSP_AfterBump,
+	                   kSP_SprintBaseline, kSP_SprintTick, kSP_SprintRecord,
+	                   kSP_WalkBaseline, kSP_WalkTick, kSP_WalkRecord,
+	                   kSP_Verify, kSP_Done };
+
+	int                     g_iPhase = kSP_Start;
+	Zenith_EntityID         g_xVillager;
+	float                   g_fSprintBaseline = 0.0f;
+	float                   g_fSprintAfter = 0.0f;
+	float                   g_fWalkBaseline = 0.0f;
+	float                   g_fWalkAfter = 0.0f;
+	int                     g_iTickCount = 0;
+	bool                    g_bSprintingObservedSprintWindow = false;
+	bool                    g_bSprintingObservedWalkWindow = true; // pre-set to "fail sentinel"
+
+	constexpr int kTICK_FRAMES = 60; // ~1.0 s at 60 Hz fixed-dt
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1Sprint()
+{
+	g_iPhase = kSP_Start;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_fSprintBaseline = 0.0f;
+	g_fSprintAfter = 0.0f;
+	g_fWalkBaseline = 0.0f;
+	g_fWalkAfter = 0.0f;
+	g_iTickCount = 0;
+	g_bSprintingObservedSprintWindow = false;
+	g_bSprintingObservedWalkWindow = true;
+}
+
+static bool Step_P1Sprint(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kSP_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kSP_WaitScene;
+		return true;
+
+	case kSP_WaitScene:
+	{
+		// Grab any villager -- which one doesn't matter for the sprint
+		// life math.
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFound](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFound.IsValid()) xFound = xId;
+			});
+		if (xFound.IsValid())
+		{
+			g_xVillager = xFound;
+			g_iPhase = kSP_Possess;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kSP_Done;
+		}
+		return true;
+	}
+
+	case kSP_Possess:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kSP_AfterBump;
+		return true;
+
+	case kSP_AfterBump:
+		// One frame later OnUpdate has flipped m_bIsPossessed and bumped
+		// remaining life to m_fMaxLife. From here on we control life via
+		// SetRemainingLifeForTest.
+		g_iPhase = kSP_SprintBaseline;
+		return true;
+
+	case kSP_SprintBaseline:
+	{
+		// Snapshot baseline + arm sprint inputs.
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+		if (pxV == nullptr) { g_iPhase = kSP_Done; return false; }
+		pxV->SetRemainingLifeForTest(30.0f);
+		g_fSprintBaseline = pxV->GetRemainingLife();
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, true);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, true);
+		g_iTickCount = 0;
+		g_iPhase = kSP_SprintTick;
+		return true;
+	}
+
+	case kSP_SprintTick:
+	{
+		++g_iTickCount;
+		// Sample m_bIsSprintingNow at least once during the window so
+		// the verify step can fail noisily if the sprint state machine
+		// didn't actually flip on. We check on a mid-window tick so we
+		// don't grab the first-frame transient.
+		if (g_iTickCount == kTICK_FRAMES / 2)
+		{
+			DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+			if (pxV != nullptr) g_bSprintingObservedSprintWindow = pxV->IsSprintingNow();
+		}
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kSP_SprintRecord;
+		}
+		return true;
+	}
+
+	case kSP_SprintRecord:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+		if (pxV == nullptr) { g_iPhase = kSP_Done; return false; }
+		g_fSprintAfter = pxV->GetRemainingLife();
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, false);
+		// Leave W held -- walk window keeps the movement.
+		g_iPhase = kSP_WalkBaseline;
+		return true;
+	}
+
+	case kSP_WalkBaseline:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+		if (pxV == nullptr) { g_iPhase = kSP_Done; return false; }
+		pxV->SetRemainingLifeForTest(30.0f);
+		g_fWalkBaseline = pxV->GetRemainingLife();
+		g_iTickCount = 0;
+		g_iPhase = kSP_WalkTick;
+		return true;
+	}
+
+	case kSP_WalkTick:
+	{
+		++g_iTickCount;
+		if (g_iTickCount == kTICK_FRAMES / 2)
+		{
+			DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+			if (pxV != nullptr) g_bSprintingObservedWalkWindow = pxV->IsSprintingNow();
+		}
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kSP_WalkRecord;
+		}
+		return true;
+	}
+
+	case kSP_WalkRecord:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+		if (pxV == nullptr) { g_iPhase = kSP_Done; return false; }
+		g_fWalkAfter = pxV->GetRemainingLife();
+		// Release W so we don't leak input state into a subsequent
+		// batched test.
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, false);
+		g_iPhase = kSP_Verify;
+		return true;
+	}
+
+	case kSP_Verify:
+	{
+		const float fSprintDrop = g_fSprintBaseline - g_fSprintAfter;
+		const float fWalkDrop = g_fWalkBaseline - g_fWalkAfter;
+		std::printf("[P1Sprint] sprintDrop=%.3fs walkDrop=%.3fs diff=%.3fs sprintObs=%d walkObs=%d\n",
+			fSprintDrop, fWalkDrop, fSprintDrop - fWalkDrop,
+			(int)g_bSprintingObservedSprintWindow,
+			(int)g_bSprintingObservedWalkWindow);
+		std::fflush(stdout);
+		g_iPhase = kSP_Done;
+		return false;
+	}
+
+	case kSP_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1Sprint()
+{
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Sprint: villager not found");
+		return false;
+	}
+	if (!g_bSprintingObservedSprintWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Sprint: IsSprintingNow was false during sprint window -- state machine didn't engage");
+		return false;
+	}
+	if (g_bSprintingObservedWalkWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Sprint: IsSprintingNow was true during walk window -- Shift release didn't disengage sprint");
+		return false;
+	}
+	const float fSprintDrop = g_fSprintBaseline - g_fSprintAfter;
+	const float fWalkDrop = g_fWalkBaseline - g_fWalkAfter;
+	if (fWalkDrop <= 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1Sprint: walk window had no life drop -- TickLife didn't run");
+		return false;
+	}
+	// Expected difference: ~3 s/s extra cost over a 1 s window = 3 s.
+	// Allow 33% slack (2 s minimum) for frame-time / boundary jitter.
+	const float fDiff = fSprintDrop - fWalkDrop;
+	const float fMinDiff = 2.0f;
+	if (fDiff < fMinDiff)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1Sprint: sprint drop (%.3fs) - walk drop (%.3fs) = %.3fs, expected >= %.3fs",
+			fSprintDrop, fWalkDrop, fDiff, fMinDiff);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1SprintTest = {
+	"Test_P1Sprint_DrainsLifeFaster",
+	&Setup_P1Sprint,
+	&Step_P1Sprint,
+	&Verify_P1Sprint,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1SprintTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Sprint_NoDrainWhenNotMoving.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Sprint_NoDrainWhenNotMoving.cpp
@@ -1,0 +1,212 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "Input/Zenith_InputSimulator.h"
+#include "Input/Zenith_KeyCodes.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Sprint_NoDrainWhenNotMoving (MVP-1.7.3)
+//
+// Negative-case sibling to Test_P1Sprint_DrainsLifeFaster: holding
+// Shift while NOT moving must NOT incur the sprint life cost. The
+// guard lives in DPVillager_Behaviour::OnUpdate, where
+// m_bIsSprintingNow is computed as `ReadSprintHeld() && moving`. If
+// the guard's "moving" check got dropped (e.g., during a refactor),
+// standing-still players would burn life for nothing, breaking
+// MVPScope's promise that Shift is a no-op without movement input.
+//
+// Procedure:
+//   1. Load GameLevel, possess any villager.
+//   2. Wait one bump frame.
+//   3. SetRemainingLifeForTest(30.0).
+//   4. SimulateKeyHeld(LEFT_SHIFT) -- shift held but NO movement key.
+//   5. Tick 60 frames (~1.0 s).
+//   6. Snapshot life delta.
+//   7. Assert: drop is approximately 1.0 s (baseline only -- no
+//      sprint cost added). Tolerance generous because exact-baseline
+//      assertions are covered by LifeTimer_Test; here we only need
+//      to prove the sprint extra cost did NOT fire.
+//   8. Also assert IsSprintingNow() returned false during the window.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kSN_Start, kSN_WaitScene, kSN_Possess, kSN_AfterBump,
+	                   kSN_ArmInputs, kSN_Tick, kSN_Verify, kSN_Done };
+
+	int                     g_iPhase = kSN_Start;
+	Zenith_EntityID         g_xVillager;
+	float                   g_fBaseline = 0.0f;
+	float                   g_fAfter = 0.0f;
+	bool                    g_bSprintingObservedMidWindow = true;
+	int                     g_iTickCount = 0;
+
+	constexpr int kTICK_FRAMES = 60;
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1SprintNoDrain()
+{
+	g_iPhase = kSN_Start;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_fBaseline = 0.0f;
+	g_fAfter = 0.0f;
+	g_bSprintingObservedMidWindow = true; // sentinel: must end up false
+	g_iTickCount = 0;
+}
+
+static bool Step_P1SprintNoDrain(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kSN_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kSN_WaitScene;
+		return true;
+
+	case kSN_WaitScene:
+	{
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFound](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFound.IsValid()) xFound = xId;
+			});
+		if (xFound.IsValid())
+		{
+			g_xVillager = xFound;
+			g_iPhase = kSN_Possess;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kSN_Done;
+		}
+		return true;
+	}
+
+	case kSN_Possess:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kSN_AfterBump;
+		return true;
+
+	case kSN_AfterBump:
+		g_iPhase = kSN_ArmInputs;
+		return true;
+
+	case kSN_ArmInputs:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+		if (pxV == nullptr) { g_iPhase = kSN_Done; return false; }
+		pxV->SetRemainingLifeForTest(30.0f);
+		g_fBaseline = pxV->GetRemainingLife();
+		// Shift held but NO movement key. The guard in OnUpdate
+		// (m_bIsSprintingNow = Shift && moving) should leave it false.
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, true);
+		// Make absolutely sure no movement keys are held from a prior
+		// batched test (the InputSimulator's between-tests reset
+		// should cover this, but belt-and-braces).
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_A, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_S, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_D, false);
+		g_iTickCount = 0;
+		g_iPhase = kSN_Tick;
+		return true;
+	}
+
+	case kSN_Tick:
+	{
+		++g_iTickCount;
+		if (g_iTickCount == kTICK_FRAMES / 2)
+		{
+			DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+			if (pxV != nullptr) g_bSprintingObservedMidWindow = pxV->IsSprintingNow();
+		}
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+			if (pxV != nullptr) g_fAfter = pxV->GetRemainingLife();
+			Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, false);
+			g_iPhase = kSN_Verify;
+		}
+		return true;
+	}
+
+	case kSN_Verify:
+	{
+		const float fDrop = g_fBaseline - g_fAfter;
+		std::printf("[P1SprintNoDrain] drop=%.3fs (expect ~1.0s, def NOT ~4.0s) sprintObs=%d (expect 0)\n",
+			fDrop, (int)g_bSprintingObservedMidWindow);
+		std::fflush(stdout);
+		g_iPhase = kSN_Done;
+		return false;
+	}
+
+	case kSN_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1SprintNoDrain()
+{
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1SprintNoDrain: villager not found");
+		return false;
+	}
+	if (g_bSprintingObservedMidWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1SprintNoDrain: IsSprintingNow() returned true with no movement input -- guard misfired");
+		return false;
+	}
+	const float fDrop = g_fBaseline - g_fAfter;
+	// Expected ~1.0 s baseline drop over 1 s. Allow 0.5 s tolerance
+	// on the high side -- but anything >= 2.0 s implies the sprint
+	// cost (3 s/s) leaked in for at least part of the window.
+	const float fMaxAllowedDrop = 2.0f;
+	if (fDrop >= fMaxAllowedDrop)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1SprintNoDrain: life drop %.3fs is too high (limit %.3fs) -- sprint cost leaked through the no-movement guard",
+			fDrop, fMaxAllowedDrop);
+		return false;
+	}
+	if (fDrop <= 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1SprintNoDrain: no life drop at all -- TickLife didn't fire");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1SprintNoDrainTest = {
+	"Test_P1Sprint_NoDrainWhenNotMoving",
+	&Setup_P1SprintNoDrain,
+	&Step_P1SprintNoDrain,
+	&Verify_P1SprintNoDrain,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1SprintNoDrainTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Adds the sprint mechanic. While Shift is held AND the player is moving, the possessed villager moves at `movement.sprint_speed_mps` (12 m/s vs 8 m/s walk) and burns an extra `movement.sprint_life_cost_extra_per_s` (3.0 s/s) on top of the 1.0 s/s baseline. Shift without movement = no-op.

### MVP-1.7.2 — impl

- `DP_Input::ReadSprintHeld()` — either Shift key.
- `DPVillager_Behaviour::OnUpdate` computes `m_bIsSprintingNow = ReadSprintHeld() && moving` once per frame so TickLife + TickMovement agree.
- `TickLife` adds sprint extra cost when active.
- `TickMovement` swaps walk speed for `sprint_speed_mps` when active.
- `IsSprintingNow()` test accessor in the simulator block.

### MVP-1.7.1 — `Test_P1Sprint_DrainsLifeFaster`

Two 1-second windows (W+Shift, then W only). Asserts sprint delta − walk delta ≥ 2 s (expected 3 s). Local result: sprint=4.065s walk=1.016s diff=3.049s ✓

### MVP-1.7.3 — `Test_P1Sprint_NoDrainWhenNotMoving`

Shift held but no movement key. Asserts life drop < 2 s (a sprint cost leak would push to ~4 s) AND `IsSprintingNow()` was false. Local result: drop=1.000s ✓

## Test plan

- [x] Test_P1Sprint_DrainsLifeFaster passes in 131 frames
- [x] Test_P1Sprint_NoDrainWhenNotMoving passes in 68 frames
- [x] Full DP suite: **49 PASSED, 0 FAILED, 15 SKIPPED-headless**
- [x] Build clean

Walk-quiet (MVP-1.7.4/5/6) lands in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)