### PR TITLE
feat(dp): MVP-1.7.{4,5} -- walk-quiet (Ctrl) + footstep emission system

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -235,6 +235,7 @@
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
+    <ClCompile Include="..\Tests\Test_P1WalkQuiet_FootstepLoudnessHalved.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1WalkQuiet_FootstepLoudnessHalved.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -529,6 +529,7 @@
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp" />
+    <ClCompile Include="..\Tests\Test_P1WalkQuiet_FootstepLoudnessHalved.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -131,6 +131,9 @@
     <ClCompile Include="..\Tests\Test_P1Villager_TuningMigration.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1WalkQuiet_FootstepLoudnessHalved.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
@@ -22,6 +22,8 @@
 #include "Physics/Zenith_Physics.h"
 #include "Input/Zenith_Input.h"
 #include "Maths/Zenith_Maths.h"
+#include "Core/Zenith_AudioBus.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 #include "Flux/Flux_ModelInstance.h"
 #include "AssetHandling/Zenith_MaterialAsset.h"
 
@@ -126,20 +128,24 @@ public:
 
 		if (m_bIsPossessed)
 		{
-			// MVP-1.7: compute "sprinting now" once per frame so TickLife
-			// and TickMovement agree. Sprint requires BOTH the input
-			// (Shift held) AND movement input (otherwise standing-still
-			// with Shift down would burn life for no movement -- failing
-			// MVP-1.7.3's "no drain when not moving" test).
+			// MVP-1.7: compute movement-state booleans once per frame so
+			// TickLife / TickMovement / TickFootsteps all agree. Sprint
+			// requires Shift+moving; walk-quiet requires Ctrl+moving;
+			// sprint wins ties so Shift+Ctrl resolves to sprint.
 			const Zenith_Maths::Vector2 xMove = DP_Input::ReadMoveVillager();
 			const float fMoveLen = glm::length(xMove);
-			m_bIsSprintingNow = DP_Input::ReadSprintHeld() && (fMoveLen > 0.01f);
+			const bool bMoving = (fMoveLen > 0.01f);
+			m_bIsSprintingNow = DP_Input::ReadSprintHeld() && bMoving;
+			m_bIsWalkQuietNow = !m_bIsSprintingNow
+				&& DP_Input::ReadWalkQuietHeld() && bMoving;
 			TickLife(fDt);
 			TickMovement(fDt);
+			TickFootsteps(fDt, bMoving);
 		}
 		else
 		{
 			m_bIsSprintingNow = false;
+			m_bIsWalkQuietNow = false;
 			ZeroHorizontalVelocity();
 		}
 
@@ -218,6 +224,8 @@ public:
 	// Test_P1Sprint_* to verify the sprint state machine without
 	// faking input.
 	bool IsSprintingNow() const { return m_bIsSprintingNow; }
+	// MVP-1.7: walk-quiet cache; same shape as IsSprintingNow.
+	bool IsWalkQuietNow() const { return m_bIsWalkQuietNow; }
 
 	// Test/debug only: shrink the timer so death-by-timeout tests don't need
 	// 1800+ simulated frames to fire. Production gameplay sets m_fMaxLife
@@ -282,18 +290,71 @@ private:
 		{
 			const Zenith_Maths::Vector3 xDir =
 				glm::normalize(xInput.x * xRight + xInput.y * xForward);
-			// MVP-1.7: sprint speed multiplier. The "AND moving"
-			// guard lives in OnUpdate (m_bIsSprintingNow); we just
-			// read the flag here to swap m_fMoveSpeed for the sprint
-			// tuning value when active.
+			// MVP-1.7: speed override based on movement modifier state.
+			// Sprint wins ties; walk-quiet takes the slow speed.
 			float fSpeed = m_fMoveSpeed;
 			if (m_bIsSprintingNow)
 			{
 				fSpeed = DP_Tuning::Get<float>("movement.sprint_speed_mps");
 			}
+			else if (m_bIsWalkQuietNow)
+			{
+				fSpeed = DP_Tuning::Get<float>("movement.walk_speed_mps");
+			}
 			xVel = xDir * fSpeed;
 		}
 		Zenith_Physics::SetLinearVelocity(xCollider.GetBodyID(), xVel);
+	}
+
+	// MVP-1.7.5: footstep emission. Called once per frame from
+	// OnUpdate while the villager is possessed. While moving,
+	// accumulates a countdown timer; when it expires, emits a
+	// footstep via Zenith_AudioBus::EmitSound (for the test recorder)
+	// AND Zenith_PerceptionSystem::EmitSoundStimulus (so the priest
+	// can actually hear it). Loudness is multiplied by
+	// `movement.walk_footstep_loudness_multiplier` while walk-quiet
+	// is active; sprint runs at full loudness (no extra loudness mult
+	// in MVP -- the sprint cost is movement.sprint_life_cost, the
+	// audibility multiplier is post-MVP).
+	void TickFootsteps(float fDt, bool bMoving)
+	{
+		if (!bMoving)
+		{
+			// Hold the timer at zero so the FIRST step after starting
+			// to move emits immediately, not after a full interval.
+			m_fFootstepCountdown = 0.0f;
+			return;
+		}
+		m_fFootstepCountdown -= fDt;
+		if (m_fFootstepCountdown > 0.0f) return;
+
+		const float fInterval = DP_Tuning::Get<float>("movement.footstep_interval_s");
+		m_fFootstepCountdown = fInterval;
+
+		const float fBaseLoudness = DP_Tuning::Get<float>("movement.footstep_loudness");
+		const float fRadius = DP_Tuning::Get<float>("movement.footstep_radius_m");
+		float fLoudness = fBaseLoudness;
+		if (m_bIsWalkQuietNow)
+		{
+			fLoudness *= DP_Tuning::Get<float>("movement.walk_footstep_loudness_multiplier");
+		}
+
+		Zenith_Maths::Vector3 xPos(0.0f);
+		if (m_xParentEntity.HasComponent<Zenith_TransformComponent>())
+		{
+			m_xParentEntity.GetComponent<Zenith_TransformComponent>().GetPosition(xPos);
+		}
+
+		// Tag emissions with a name the AudioBus test recorder can
+		// filter on. The "DP.Villager.Footstep" prefix lets future
+		// graphics builds attach an actual sample file by name.
+		Zenith_AudioBus::EmitSound("DP.Villager.Footstep", xPos, fLoudness, fRadius);
+
+		// Drive priest hearing through the perception system. The
+		// Priest_Behaviour bridge consumes the freshest hearing
+		// stimulus into BB.InvestigatePos.
+		Zenith_PerceptionSystem::EmitSoundStimulus(
+			xPos, fLoudness, fRadius, m_xParentEntity.GetEntityID());
 	}
 
 	void ZeroHorizontalVelocity()
@@ -482,6 +543,13 @@ private:
 	// both read this so they agree on whether sprint is active this
 	// tick.
 	bool  m_bIsSprintingNow = false;
+	// MVP-1.7: walk-quiet cache, computed similarly. Sprint wins on
+	// Shift+Ctrl ties (the louder, faster mode shouldn't be silenced
+	// by a held Ctrl).
+	bool  m_bIsWalkQuietNow = false;
+	// MVP-1.7: footstep emission countdown. Counts down each frame
+	// while moving; when it hits 0, TickFootsteps emits a step + resets.
+	float m_fFootstepCountdown = 0.0f;
 	// Snapshot of the base materials taken on first possession - used to
 	// restore the un-tinted look when un-possessed.
 	Zenith_Vector<Zenith_MaterialAsset*> m_apxBaseMaterials;

--- a/Games/DevilsPlayground/Config/Tuning.json
+++ b/Games/DevilsPlayground/Config/Tuning.json
@@ -35,7 +35,11 @@
     "sprint_speed_mps": 12.0,
     "sprint_life_cost_extra_per_s": 3.0,
     "walk_footstep_loudness_multiplier": 0.5,
-    "_comment_walk_loudness": "Multiplier applied to THE MOVING VILLAGER'S FOOTSTEP LOUDNESS when walking (0.5 = half loudness). Aelfric's perception radius is unchanged; the quieter footstep simply reaches him from half as far away. NOT a reduction on Aelfric's hearing range."
+    "_comment_walk_loudness": "Multiplier applied to THE MOVING VILLAGER'S FOOTSTEP LOUDNESS when walking (0.5 = half loudness). Aelfric's perception radius is unchanged; the quieter footstep simply reaches him from half as far away. NOT a reduction on Aelfric's hearing range.",
+    "footstep_interval_s": 0.4,
+    "footstep_loudness": 0.3,
+    "footstep_radius_m": 10.0,
+    "_comment_footstep": "MVP-1.7.5: baseline footstep emission tuning. Possessed villagers emit a footstep every footstep_interval_s while moving. Per Zenith perception default (loudness 0.3, radius 10m) -- matches CLAUDE.md's 'common sound types' table. walk_footstep_loudness_multiplier above is applied on top when Ctrl is held."
   },
 
   "camera": {

--- a/Games/DevilsPlayground/Source/DPInputActions.h
+++ b/Games/DevilsPlayground/Source/DPInputActions.h
@@ -31,6 +31,18 @@ namespace DP_Input
 			|| Zenith_Input::IsKeyHeld(ZENITH_KEY_RIGHT_SHIFT);
 	}
 
+	// MVP-1.7: walk-quiet hold. Either Ctrl key works. While held AND
+	// the villager is moving, footsteps emit at
+	// `movement.walk_footstep_loudness_multiplier` (0.5x default) and
+	// the villager moves at `movement.walk_speed_mps` instead of the
+	// jog default. Sprint wins ties (holding Shift+Ctrl resolves to
+	// sprint -- the louder, faster mode).
+	inline bool ReadWalkQuietHeld()
+	{
+		return Zenith_Input::IsKeyHeld(ZENITH_KEY_LEFT_CONTROL)
+			|| Zenith_Input::IsKeyHeld(ZENITH_KEY_RIGHT_CONTROL);
+	}
+
 	inline bool ReadInteractPressed()
 	{
 		return Zenith_Input::WasKeyPressedThisFrame(ZENITH_KEY_F);

--- a/Games/DevilsPlayground/Tests/Test_P1WalkQuiet_FootstepLoudnessHalved.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1WalkQuiet_FootstepLoudnessHalved.cpp
@@ -1,0 +1,266 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "Core/Zenith_AudioBus.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "Input/Zenith_InputSimulator.h"
+#include "Input/Zenith_KeyCodes.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P1WalkQuiet_FootstepLoudnessHalved (MVP-1.7.4 + 1.7.5)
+//
+// Verifies that holding Ctrl ("walk-quiet") halves the loudness of
+// every emitted footstep. The data path goes:
+//   DPVillager_Behaviour::TickFootsteps
+//     -> Zenith_AudioBus::EmitSound(name, pos, loudness, radius)
+//     -> Zenith_PerceptionSystem::EmitSoundStimulus(...) [same loudness]
+//
+// The test only inspects the AudioBus recorder; the perception-system
+// half is covered indirectly by the priest BB tests that consume
+// `BB.InvestigatePos`.
+//
+// Procedure:
+//   1. Load GameLevel, possess any villager.
+//   2. Wait one bump frame.
+//   3. **Normal walk window**: clear AudioBus, hold W (move), tick
+//      until at least 2 footsteps are recorded.  Average their loudness.
+//   4. **Walk-quiet window**: clear AudioBus, hold W + Ctrl, tick
+//      until at least 2 footsteps recorded.  Average their loudness.
+//   5. Assert: average walk-quiet loudness ≈
+//        0.5 * average normal loudness
+//      (within 5% tolerance -- the multiplier is exactly 0.5 by
+//      default but float math + sample averaging introduces small
+//      rounding).
+//   6. Also assert: AT LEAST one normal footstep emission AND one
+//      walk-quiet emission were observed.  (A zero-on-one-side run
+//      would let a "did nothing" impl pass the ratio check
+//      trivially.)
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kWQ_Start, kWQ_WaitScene, kWQ_Possess, kWQ_AfterBump,
+	                   kWQ_NormalArm, kWQ_NormalTick, kWQ_NormalRecord,
+	                   kWQ_QuietArm, kWQ_QuietTick, kWQ_QuietRecord,
+	                   kWQ_Verify, kWQ_Done };
+
+	int                     g_iPhase = kWQ_Start;
+	Zenith_EntityID         g_xVillager;
+	float                   g_fNormalSum = 0.0f;
+	int                     g_iNormalCount = 0;
+	float                   g_fQuietSum = 0.0f;
+	int                     g_iQuietCount = 0;
+	int                     g_iTickCount = 0;
+
+	// 0.4 s footstep interval = 24 frames at 60 Hz. Two intervals + slack.
+	constexpr int kTICK_FRAMES = 80;
+
+	bool IsFootstep(const Zenith_AudioBus::EmittedSound& xS)
+	{
+		return xS.m_szName != nullptr
+			&& std::strcmp(xS.m_szName, "DP.Villager.Footstep") == 0;
+	}
+
+	void SampleFootsteps(float& fSumOut, int& iCountOut)
+	{
+		fSumOut = 0.0f;
+		iCountOut = 0;
+		const Zenith_Vector<Zenith_AudioBus::EmittedSound>& xSounds =
+			Zenith_AudioBus::GetEmittedSoundsForTest();
+		for (uint32_t u = 0; u < xSounds.GetSize(); ++u)
+		{
+			const Zenith_AudioBus::EmittedSound& xS = xSounds.Get(u);
+			if (!IsFootstep(xS)) continue;
+			fSumOut += xS.m_fLoudness;
+			++iCountOut;
+		}
+	}
+
+	void ReleaseAllMovementKeys()
+	{
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_A, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_S, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_D, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_CONTROL, false);
+	}
+}
+
+static void Setup_P1WalkQuiet()
+{
+	g_iPhase = kWQ_Start;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_fNormalSum = 0.0f;
+	g_iNormalCount = 0;
+	g_fQuietSum = 0.0f;
+	g_iQuietCount = 0;
+	g_iTickCount = 0;
+	Zenith_AudioBus::ClearEmittedSoundsForTest();
+}
+
+static bool Step_P1WalkQuiet(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kWQ_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kWQ_WaitScene;
+		return true;
+
+	case kWQ_WaitScene:
+	{
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFound](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFound.IsValid()) xFound = xId;
+			});
+		if (xFound.IsValid())
+		{
+			g_xVillager = xFound;
+			g_iPhase = kWQ_Possess;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kWQ_Done;
+		}
+		return true;
+	}
+
+	case kWQ_Possess:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kWQ_AfterBump;
+		return true;
+
+	case kWQ_AfterBump:
+		// One frame later DPVillager has flipped m_bIsPossessed. From
+		// here on we control input directly.
+		g_iPhase = kWQ_NormalArm;
+		return true;
+
+	case kWQ_NormalArm:
+		// Drop any footsteps that fired during the bump frame so the
+		// "normal" sample isn't polluted by setup transients.
+		Zenith_AudioBus::ClearEmittedSoundsForTest();
+		ReleaseAllMovementKeys();
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, true);
+		g_iTickCount = 0;
+		g_iPhase = kWQ_NormalTick;
+		return true;
+
+	case kWQ_NormalTick:
+		++g_iTickCount;
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kWQ_NormalRecord;
+		}
+		return true;
+
+	case kWQ_NormalRecord:
+		SampleFootsteps(g_fNormalSum, g_iNormalCount);
+		g_iPhase = kWQ_QuietArm;
+		return true;
+
+	case kWQ_QuietArm:
+		// Reset recorder + arm walk-quiet (Ctrl) on top of forward.
+		Zenith_AudioBus::ClearEmittedSoundsForTest();
+		ReleaseAllMovementKeys();
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, true);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_CONTROL, true);
+		g_iTickCount = 0;
+		g_iPhase = kWQ_QuietTick;
+		return true;
+
+	case kWQ_QuietTick:
+		++g_iTickCount;
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kWQ_QuietRecord;
+		}
+		return true;
+
+	case kWQ_QuietRecord:
+		SampleFootsteps(g_fQuietSum, g_iQuietCount);
+		ReleaseAllMovementKeys();
+		g_iPhase = kWQ_Verify;
+		return true;
+
+	case kWQ_Verify:
+	{
+		const float fNormalAvg = g_iNormalCount > 0
+			? g_fNormalSum / static_cast<float>(g_iNormalCount) : 0.0f;
+		const float fQuietAvg = g_iQuietCount > 0
+			? g_fQuietSum / static_cast<float>(g_iQuietCount) : 0.0f;
+		const float fRatio = fNormalAvg > 0.0f ? fQuietAvg / fNormalAvg : 0.0f;
+		std::printf("[P1WalkQuiet] normal: n=%d avg=%.3f  quiet: n=%d avg=%.3f  ratio=%.3f\n",
+			g_iNormalCount, fNormalAvg, g_iQuietCount, fQuietAvg, fRatio);
+		std::fflush(stdout);
+		g_iPhase = kWQ_Done;
+		return false;
+	}
+
+	case kWQ_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1WalkQuiet()
+{
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1WalkQuiet: villager not found");
+		return false;
+	}
+	if (g_iNormalCount < 1)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1WalkQuiet: normal-walk window emitted no footsteps -- TickFootsteps didn't fire");
+		return false;
+	}
+	if (g_iQuietCount < 1)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1WalkQuiet: walk-quiet window emitted no footsteps -- Ctrl-held walking didn't emit");
+		return false;
+	}
+	const float fNormalAvg = g_fNormalSum / static_cast<float>(g_iNormalCount);
+	const float fQuietAvg = g_fQuietSum / static_cast<float>(g_iQuietCount);
+	const float fExpectedMult =
+		DP_Tuning::Get<float>("movement.walk_footstep_loudness_multiplier");
+	const float fExpectedQuiet = fNormalAvg * fExpectedMult;
+	// 10% tolerance on the multiplied product. Generous because the
+	// emissions might happen at sub-frame boundaries with tiny
+	// timing jitter.
+	const float fTol = 0.10f * fNormalAvg;
+	if (fQuietAvg < fExpectedQuiet - fTol || fQuietAvg > fExpectedQuiet + fTol)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1WalkQuiet: quietAvg=%.3f outside expected [%.3f..%.3f] (normal=%.3f mult=%.3f)",
+			fQuietAvg, fExpectedQuiet - fTol, fExpectedQuiet + fTol,
+			fNormalAvg, fExpectedMult);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1WalkQuietTest = {
+	"Test_P1WalkQuiet_FootstepLoudnessHalved",
+	&Setup_P1WalkQuiet,
+	&Step_P1WalkQuiet,
+	&Verify_P1WalkQuiet,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1WalkQuietTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Adds the walk-quiet mechanic + the footstep emission system it sits on. While Ctrl is held AND the player is moving, the possessed villager walks at `movement.walk_speed_mps` (4 m/s) AND every emitted footstep's loudness is multiplied by `movement.walk_footstep_loudness_multiplier` (0.5). Sprint wins on Shift+Ctrl ties.

### MVP-1.7.5 — impl

- Config: new `movement` keys — `footstep_interval_s` (0.4 s), `footstep_loudness` (0.3), `footstep_radius_m` (10.0). Matches Zenith perception's stock "Footstep" sound.
- `DP_Input::ReadWalkQuietHeld()` — either Ctrl key.
- `DPVillager_Behaviour::OnUpdate` sets `m_bIsWalkQuietNow` (Ctrl held && moving; sprint wins ties).
- New `TickFootsteps(fDt, bMoving)` — countdown timer; on expiry emits via BOTH `Zenith_AudioBus::EmitSound("DP.Villager.Footstep", ...)` (test recorder + audio asset hook) AND `Zenith_PerceptionSystem::EmitSoundStimulus(...)` (priest hearing). Loudness multiplied by 0.5 when walk-quiet.
- Timer held at 0 while stationary so the first step after starting to move emits immediately.

### MVP-1.7.4 — `Test_P1WalkQuiet_FootstepLoudnessHalved`

Walk normally for 80 frames, capture audio emissions. Walk + Ctrl for 80 frames, capture. Average each window's loudness; assert quiet ≈ 0.5 × normal within 10%.

Local result: **normal n=4 avg=0.300, quiet n=3 avg=0.150, ratio=0.500** — exact tuning value, zero rounding drift.

MVP-1.7.6 (Aelfric perception test) deferred — requires precise distance-threshold setup. The data path is exercised by existing `Test_PriestBBBridge` / `Test_HearingFlow`.

## Test plan

- [x] Test_P1WalkQuiet_FootstepLoudnessHalved passes in 171 frames
- [x] Full DP suite: **50 PASSED, 0 FAILED, 15 SKIPPED-headless**
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)