### PR TITLE
test(dp): add 5 high-value coverage tests for MVP-1.5..1.8 systems

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -227,11 +227,16 @@
     <ClCompile Include="..\Tests\Test_P1Pause_PriestStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Range_AnchorMovesWithEachHop.cpp" />
     <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_AccumulatesOnPossession.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Scent_DecaysOverTime.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Scent_HighestWinsInBlackboard.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Scent_NoBumpWhilePossessing.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -107,10 +107,22 @@
     <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Range_AnchorMovesWithEachHop.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Scent_AccumulatesOnPossession.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Scent_DecaysOverTime.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Scent_HighestWinsInBlackboard.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Scent_NoBumpWhilePossessing.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp">
@@ -120,6 +132,9 @@
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -521,11 +521,16 @@
     <ClCompile Include="..\Tests\Test_P1Pause_PriestStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Pause_TimerStopsOnEscape.cpp" />
     <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Range_AnchorMovesWithEachHop.cpp" />
     <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_AccumulatesOnPossession.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Scent_DecaysOverTime.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Scent_HighestWinsInBlackboard.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Scent_NoBumpWhilePossessing.cpp" />
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -107,10 +107,22 @@
     <ClCompile Include="..\Tests\Test_P1Range_AcceptedInRange.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Range_AnchorMovesWithEachHop.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Range_RefusedOutOfRange.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Scent_AccumulatesOnPossession.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Scent_DecaysOverTime.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Scent_HighestWinsInBlackboard.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Scent_NoBumpWhilePossessing.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Scent_NotificationToBlackboard.cpp">
@@ -120,6 +132,9 @@
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">

--- a/Games/DevilsPlayground/Tests/Test_P1Range_AnchorMovesWithEachHop.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Range_AnchorMovesWithEachHop.cpp
@@ -1,0 +1,262 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Range_AnchorMovesWithEachHop (MVP-1.8 follow-up coverage gap)
+//
+// MVP-1.8's two existing tests (`RefusedOutOfRange`, `AcceptedInRange`)
+// only check ONE hop from the anchor. A regression where the anchor
+// was set on the first possession and never updated (i.e., stuck at
+// the run-start position) would still pass both tests because each
+// only validates a single A->B switch.
+//
+// This test pins the GDD's "demon-hop chain" semantic: each successful
+// voluntary switch redefines the anchor circle for the next hop.
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Find three villagers A, B, C such that:
+//        d(A, B) <= range_from_anchor_m  (A->B is a legal hop)
+//        d(B, C) <= range_from_anchor_m  (B->C is legal IF anchor moved)
+//        d(A, C) >  range_from_anchor_m  (B->C would be REFUSED if anchor stuck on A)
+//      The gap between d(B, C) and d(A, C) is what makes this test
+//      meaningfully distinguish "anchor moves" from "anchor stuck".
+//   3. SetPossessedVillager(A) -- direct write, seeds anchor at A.
+//   4. TryVoluntaryPossessSwitch(B) -- legal, anchor moves to B per
+//      the impl's intent. Cooldown armed for ~1.5 s.
+//   5. Wait the cooldown out.
+//   6. TryVoluntaryPossessSwitch(C). With anchor at B this succeeds
+//      (d(B, C) <= 15 m). With anchor stuck at A it would refuse
+//      (d(A, C) > 15 m).
+//   7. Assert the switch succeeded AND possession is now C.
+//
+// What this catches:
+//   * A regression where `TryVoluntaryPossessSwitch` updates
+//     `g_xPossessedVillager` but FORGETS to update
+//     `g_xPossessionAnchor` (anchor stays on whatever the first
+//     possession was).
+//   * A semantic refactor to "anchor = run-start position" -- the
+//     test would fail noisily because the run started at A and
+//     C would be out of range.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kAH_Start, kAH_WaitScene, kAH_PossessA, kAH_HopToB,
+	                   kAH_WaitCooldown, kAH_HopToC, kAH_Verify, kAH_Done };
+
+	int                     g_iPhase = kAH_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	Zenith_EntityID         g_xC;
+	float                   g_fDistAB = 0.0f;
+	float                   g_fDistBC = 0.0f;
+	float                   g_fDistAC = 0.0f;
+	bool                    g_bHopAToBOk = false;
+	bool                    g_bHopBToCOk = false;
+	Zenith_EntityID         g_xFinalPossession;
+	int                     g_iCooldownWait = 0;
+
+	// 1.5 s cooldown default -> ~95 frames at fixed 60 Hz dt.
+	constexpr int kCOOLDOWN_FRAMES = 110;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	// Search GameLevel for a {A, B, C} trio satisfying the distance
+	// inequality above. Brute-force O(n^3) on 17 villagers = 4913
+	// candidates -- trivially fast.
+	bool FindHopChainTrio(Zenith_EntityID& xA,
+	                     Zenith_EntityID& xB,
+	                     Zenith_EntityID& xC,
+	                     float& fDAB, float& fDBC, float& fDAC)
+	{
+		const float fRange =
+			DP_Tuning::Get<float>("possession.range_from_anchor_m");
+
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 3) return false;
+
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = 0; j < axVs.GetSize(); ++j)
+		for (uint32_t k = 0; k < axVs.GetSize(); ++k)
+		{
+			if (i == j || j == k || i == k) continue;
+			const float fAB = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			const float fBC = HorizontalDistance(axVs.Get(j).xPos, axVs.Get(k).xPos);
+			const float fAC = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(k).xPos);
+			if (fAB <= fRange && fBC <= fRange && fAC > fRange)
+			{
+				xA = axVs.Get(i).xId;
+				xB = axVs.Get(j).xId;
+				xC = axVs.Get(k).xId;
+				fDAB = fAB; fDBC = fBC; fDAC = fAC;
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+static void Setup_P1AnchorMoves()
+{
+	g_iPhase = kAH_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_xC = INVALID_ENTITY_ID;
+	g_fDistAB = g_fDistBC = g_fDistAC = 0.0f;
+	g_bHopAToBOk = false;
+	g_bHopBToCOk = false;
+	g_xFinalPossession = INVALID_ENTITY_ID;
+	g_iCooldownWait = 0;
+}
+
+static bool Step_P1AnchorMoves(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kAH_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kAH_WaitScene;
+		return true;
+
+	case kAH_WaitScene:
+		if (FindHopChainTrio(g_xA, g_xB, g_xC, g_fDistAB, g_fDistBC, g_fDistAC))
+		{
+			g_iPhase = kAH_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kAH_Done;
+		}
+		return true;
+
+	case kAH_PossessA:
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kAH_HopToB;
+		return true;
+
+	case kAH_HopToB:
+		g_bHopAToBOk = DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iCooldownWait = 0;
+		g_iPhase = kAH_WaitCooldown;
+		return true;
+
+	case kAH_WaitCooldown:
+		++g_iCooldownWait;
+		if (g_iCooldownWait >= kCOOLDOWN_FRAMES)
+		{
+			g_iPhase = kAH_HopToC;
+		}
+		return true;
+
+	case kAH_HopToC:
+		g_bHopBToCOk = DP_Player::TryVoluntaryPossessSwitch(g_xC);
+		g_xFinalPossession = DP_Player::GetPossessedVillager();
+		g_iPhase = kAH_Verify;
+		return true;
+
+	case kAH_Verify:
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1AnchorMoves: AB=%.1fm BC=%.1fm AC=%.1fm hopAB=%d hopBC=%d possessionFinal=(%u/%u) expected=(%u/%u)",
+			g_fDistAB, g_fDistBC, g_fDistAC,
+			(int)g_bHopAToBOk, (int)g_bHopBToCOk,
+			g_xFinalPossession.m_uIndex, g_xFinalPossession.m_uGeneration,
+			g_xC.m_uIndex, g_xC.m_uGeneration);
+		g_iPhase = kAH_Done;
+		return false;
+
+	case kAH_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1AnchorMoves()
+{
+	const float fRange = DP_Tuning::Get<float>("possession.range_from_anchor_m");
+	if (!g_xA.IsValid() || !g_xB.IsValid() || !g_xC.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1AnchorMoves: failed to find a 3-villager hop chain in GameLevel (need d(A,B) <= %.1f, d(B,C) <= %.1f, d(A,C) > %.1f)",
+			fRange, fRange, fRange);
+		return false;
+	}
+	// Pre-flight: make sure the trio actually has the inequality we
+	// claimed. Catches an O(n^3) bug in the picker, not the SUT.
+	if (g_fDistAB > fRange || g_fDistBC > fRange || g_fDistAC <= fRange)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1AnchorMoves: trio inequality broken: AB=%.1f BC=%.1f AC=%.1f range=%.1f",
+			g_fDistAB, g_fDistBC, g_fDistAC, fRange);
+		return false;
+	}
+	if (!g_bHopAToBOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1AnchorMoves: A->B hop refused -- AB distance was supposed to be in range");
+		return false;
+	}
+	if (!g_bHopBToCOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1AnchorMoves: B->C hop refused (AB=%.1f BC=%.1f AC=%.1f). If d(B,C) is in range and d(A,C) is out, the anchor is STUCK on A -- range gate uses the wrong reference",
+			g_fDistAB, g_fDistBC, g_fDistAC);
+		return false;
+	}
+	if (g_xFinalPossession.m_uIndex != g_xC.m_uIndex
+		|| g_xFinalPossession.m_uGeneration != g_xC.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1AnchorMoves: B->C reported success but possession isn't C");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1AnchorMovesTest = {
+	"Test_P1Range_AnchorMovesWithEachHop",
+	&Setup_P1AnchorMoves,
+	&Step_P1AnchorMoves,
+	&Verify_P1AnchorMoves,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1AnchorMovesTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Scent_DecaysOverTime.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Scent_DecaysOverTime.cpp
@@ -1,0 +1,247 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Scent_DecaysOverTime (MVP-1.6 follow-up coverage gap)
+//
+// `Test_P1Scent_AccumulatesOnPossession` verifies scent accumulates on
+// voluntary switches and that the BB-write picks the highest, but
+// NOTHING in the suite asserts that `TickDemonScent`'s decay path
+// actually runs. A regression where:
+//   * `decay_per_s` got set to 0 in tuning, or
+//   * the controller stopped calling `DP_Player::TickDemonScent`, or
+//   * the per-frame `fDt` arithmetic got broken
+// would silently leak through. Scent would just sit at its accumulated
+// peak forever -- gameplay-wise, the priest's future hound subsystem
+// would react to "every villager you ever possessed" instead of
+// "recently possessed".
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Pick a villager.
+//   3. SetPossessedVillager(villager) -- no scent bump (system path).
+//   4. TryVoluntaryPossessSwitch on a different villager -- bumps scent
+//      to ~0.3 on THAT villager (we choose the FIRST villager iterated
+//      and switch to it from a different anchor; cleaner than poking
+//      the impl directly).
+//      Actually simpler: bump the chosen villager directly.
+//      Picking 2 villagers in mutual range so the range gate doesn't
+//      refuse the bump-switch.
+//   5. Snapshot scent on the bumped villager immediately.
+//   6. Tick N frames (~2 s = 120 frames at fixed 60 Hz dt).
+//   7. Snapshot scent again.
+//   8. Assert: scent[2] < scent[1] by at least `expected_decay * 0.5`
+//      (50% tolerance absorbs frame-time jitter; we just need to
+//      prove the decay path RAN, not measure the rate precisely).
+//
+// Expected math:
+//   per_possession = 0.3
+//   decay_per_s    = 0.05
+//   2 s wait        -> ~0.10 decay
+//   Lower bound on observed decay: 0.05
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kSD_Start, kSD_WaitScene, kSD_PossessA, kSD_BumpB,
+	                   kSD_SnapshotInitial, kSD_Tick, kSD_SnapshotFinal,
+	                   kSD_Verify, kSD_Done };
+
+	int                     g_iPhase = kSD_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	float                   g_fScentInitial = 0.0f;
+	float                   g_fScentFinal = 0.0f;
+	int                     g_iTickCount = 0;
+
+	// 2 s decay window -- long enough for measurable drop, short
+	// enough to fit in a single test budget.
+	constexpr int kTICK_FRAMES = 120;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+}
+
+static void Setup_P1ScentDecays()
+{
+	g_iPhase = kSD_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_fScentInitial = 0.0f;
+	g_fScentFinal = 0.0f;
+	g_iTickCount = 0;
+}
+
+static bool Step_P1ScentDecays(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kSD_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kSD_WaitScene;
+		return true;
+
+	case kSD_WaitScene:
+		PickClosestPair(g_xA, g_xB);
+		if (g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_iPhase = kSD_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kSD_Done;
+		}
+		return true;
+
+	case kSD_PossessA:
+		// System path -- no scent. Anchor on A.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kSD_BumpB;
+		return true;
+
+	case kSD_BumpB:
+		// Voluntary switch onto B -- scent[B] += 0.3.
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kSD_SnapshotInitial;
+		return true;
+
+	case kSD_SnapshotInitial:
+		g_fScentInitial = DP_Player::GetDemonScent(g_xB);
+		g_iTickCount = 0;
+		g_iPhase = kSD_Tick;
+		return true;
+
+	case kSD_Tick:
+		++g_iTickCount;
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kSD_SnapshotFinal;
+		}
+		return true;
+
+	case kSD_SnapshotFinal:
+		g_fScentFinal = DP_Player::GetDemonScent(g_xB);
+		g_iPhase = kSD_Verify;
+		return true;
+
+	case kSD_Verify:
+	{
+		const float fDecayPerSec =
+			DP_Tuning::Get<float>("possession.demon_scent_decay_per_s");
+		const float fElapsed = kTICK_FRAMES * 0.01666f;
+		const float fExpectedDrop = fDecayPerSec * fElapsed;
+		const float fObservedDrop = g_fScentInitial - g_fScentFinal;
+		std::printf("[P1ScentDecays] initial=%.3f final=%.3f drop=%.3f (expected ~%.3f over %.2fs)\n",
+			g_fScentInitial, g_fScentFinal, fObservedDrop,
+			fExpectedDrop, fElapsed);
+		std::fflush(stdout);
+		g_iPhase = kSD_Done;
+		return false;
+	}
+
+	case kSD_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1ScentDecays()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ScentDecays: villager pick failed");
+		return false;
+	}
+	if (g_fScentInitial <= 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentDecays: initial scent on B is %.3f -- TryVoluntaryPossessSwitch didn't bump scent",
+			g_fScentInitial);
+		return false;
+	}
+	const float fObservedDrop = g_fScentInitial - g_fScentFinal;
+	const float fDecayPerSec =
+		DP_Tuning::Get<float>("possession.demon_scent_decay_per_s");
+	const float fElapsed = kTICK_FRAMES * 0.01666f;
+	const float fExpectedDrop = fDecayPerSec * fElapsed;
+	// 50% tolerance: catches "decay path didn't run at all" cleanly
+	// without coupling tightly to the exact tuning value or timing.
+	const float fMinDrop = fExpectedDrop * 0.5f;
+	if (fObservedDrop < fMinDrop)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentDecays: scent dropped only %.3f over %.2fs (expected at least %.3f given decay_per_s=%.3f) -- TickDemonScent isn't running or decay is 0",
+			fObservedDrop, fElapsed, fMinDrop, fDecayPerSec);
+		return false;
+	}
+	if (g_fScentFinal >= g_fScentInitial)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentDecays: final scent (%.3f) is not less than initial (%.3f) -- decay didn't fire",
+			g_fScentFinal, g_fScentInitial);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1ScentDecaysTest = {
+	"Test_P1Scent_DecaysOverTime",
+	&Setup_P1ScentDecays,
+	&Step_P1ScentDecays,
+	&Verify_P1ScentDecays,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1ScentDecaysTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Scent_HighestWinsInBlackboard.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Scent_HighestWinsInBlackboard.cpp
@@ -1,0 +1,286 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "AI/Components/Zenith_AIAgentComponent.h"
+#include "AI/BehaviorTree/Zenith_Blackboard.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/Priest_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Scent_HighestWinsInBlackboard (MVP-1.6 follow-up coverage gap)
+//
+// `Test_P1Scent_NotificationToBlackboard` proves the BB receives a
+// non-null scent target after a single switch -- but with only ONE
+// villager bumped, "highest" trivially equals "the only one". A
+// regression where `WriteHighestScentToBlackboard` got rewritten as
+// "most recently bumped" or "first found" would silently pass that
+// test.
+//
+// This test bumps TWO villagers different amounts (B twice, A once)
+// AND ensures A is the most recently bumped villager, then asserts
+// the priest's BB reads B (the higher scent) -- not A (the most
+// recent).
+//
+// Procedure:
+//   1. Load GameLevel + find priest + two villagers in mutual range.
+//   2. SetPossessedVillager(A) -- system path, no scent bump.
+//   3. TryVoluntaryPossessSwitch(B) -- scent[B] = 0.3. Wait cooldown.
+//   4. SetPossessedVillager(A) -- system path BACK TO A, no scent
+//      bump. (Using SetPossessedVillager here is the trick: it re-
+//      anchors at A without crediting A any scent. A regular
+//      TryVoluntaryPossessSwitch(A) would bump scent[A] and ruin the
+//      asymmetry we need.)
+//   5. TryVoluntaryPossessSwitch(B) -- scent[B] += 0.3. (With ~2s of
+//      decay from step 3 the previous deposit is ~0.21, so total
+//      scent[B] ~= 0.51.) Wait cooldown.
+//   6. TryVoluntaryPossessSwitch(A) -- scent[A] = 0.3, A is now the
+//      most recently bumped villager. scent[B] decayed ~0.09 in this
+//      cooldown wait so it's ~0.42 -- still higher than A's 0.3.
+//   7. Wait one frame for the controller's per-frame
+//      WriteHighestScentToBlackboard to run.
+//   8. Read priest's BB_KEY_HIGH_SCENT_TARGET.
+//   9. Assert BB target == B (higher scent), NOT A (most recent).
+//
+// What this catches:
+//   * A refactor that swapped `>` for `<` in the scan (lowest wins).
+//   * A refactor to "most recently bumped" semantics (would write A).
+//   * A regression where the scan returned the first map entry rather
+//     than the max-by-value entry (would write whichever villager
+//     happened to hash first in the unordered_map -- non-deterministic
+//     and rarely matches the highest).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kHW_Start, kHW_WaitScene, kHW_PossessA, kHW_HopBFirst,
+	                   kHW_Wait1, kHW_ReanchorA, kHW_HopBSecond,
+	                   kHW_Wait2, kHW_HopAFinal, kHW_WaitForBBWrite,
+	                   kHW_Verify, kHW_Done };
+
+	int                     g_iPhase = kHW_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	Zenith_EntityID         g_xBBTarget;
+	float                   g_fScentAFinal = 0.0f;
+	float                   g_fScentBFinal = 0.0f;
+	int                     g_iCooldownWait = 0;
+
+	constexpr int kCOOLDOWN_FRAMES = 110;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+
+	Zenith_EntityID ReadPriestBBHighScent(Zenith_EntityID xPriestId)
+	{
+		Zenith_SceneData* pxScene =
+			Zenith_SceneManager::GetSceneDataForEntity(xPriestId);
+		if (pxScene == nullptr) return INVALID_ENTITY_ID;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xPriestId);
+		if (!xEnt.IsValid()) return INVALID_ENTITY_ID;
+		if (!xEnt.HasComponent<Zenith_AIAgentComponent>()) return INVALID_ENTITY_ID;
+		Zenith_AIAgentComponent& xAg = xEnt.GetComponent<Zenith_AIAgentComponent>();
+		return xAg.GetBlackboard().GetEntityID(DP_AI::BB_KEY_HIGH_SCENT_TARGET);
+	}
+}
+
+static void Setup_P1ScentHighest()
+{
+	g_iPhase = kHW_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_xBBTarget = INVALID_ENTITY_ID;
+	g_fScentAFinal = 0.0f;
+	g_fScentBFinal = 0.0f;
+	g_iCooldownWait = 0;
+}
+
+static bool Step_P1ScentHighest(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kHW_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kHW_WaitScene;
+		return true;
+
+	case kHW_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest](Zenith_EntityID xId, Priest_Behaviour&)
+			{ xFoundPriest = xId; });
+		PickClosestPair(g_xA, g_xB);
+		if (xFoundPriest.IsValid() && g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_xPriest = xFoundPriest;
+			g_iPhase = kHW_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kHW_Done;
+		}
+		return true;
+	}
+
+	case kHW_PossessA:
+		// System path -- anchor at A, no scent.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kHW_HopBFirst;
+		return true;
+
+	case kHW_HopBFirst:
+		// scent[B] = 0.3, anchor moves to B, cooldown armed.
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iCooldownWait = 0;
+		g_iPhase = kHW_Wait1;
+		return true;
+
+	case kHW_Wait1:
+		if (++g_iCooldownWait >= kCOOLDOWN_FRAMES) g_iPhase = kHW_ReanchorA;
+		return true;
+
+	case kHW_ReanchorA:
+		// SYSTEM path back to A. No scent bump for A. Anchor moves
+		// to A. The next TryVoluntaryPossessSwitch(B) will pay
+		// scent into B again without ever crediting A.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kHW_HopBSecond;
+		return true;
+
+	case kHW_HopBSecond:
+		// scent[B] += 0.3 (B now has TWO deposits minus decay). Anchor
+		// moves to B again, cooldown re-armed.
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iCooldownWait = 0;
+		g_iPhase = kHW_Wait2;
+		return true;
+
+	case kHW_Wait2:
+		if (++g_iCooldownWait >= kCOOLDOWN_FRAMES) g_iPhase = kHW_HopAFinal;
+		return true;
+
+	case kHW_HopAFinal:
+		// FINAL hop to A. scent[A] = 0.3 (single bump, fresh). A is now
+		// the most recently bumped villager. scent[B] has decayed across
+		// 2 cooldown windows since its 2nd bump (~1.8s), so scent[B] is
+		// ~0.51 - 0.09 ~= 0.42. Higher than A's 0.3.
+		DP_Player::TryVoluntaryPossessSwitch(g_xA);
+		g_iPhase = kHW_WaitForBBWrite;
+		return true;
+
+	case kHW_WaitForBBWrite:
+		// One frame so the controller's per-frame
+		// `WriteHighestScentToBlackboard` runs.
+		g_xBBTarget = ReadPriestBBHighScent(g_xPriest);
+		g_fScentAFinal = DP_Player::GetDemonScent(g_xA);
+		g_fScentBFinal = DP_Player::GetDemonScent(g_xB);
+		g_iPhase = kHW_Verify;
+		return true;
+
+	case kHW_Verify:
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentHighest: scent[A]=%.3f scent[B]=%.3f bbTarget=(%u/%u) A=(%u/%u) B=(%u/%u)",
+			g_fScentAFinal, g_fScentBFinal,
+			g_xBBTarget.m_uIndex, g_xBBTarget.m_uGeneration,
+			g_xA.m_uIndex, g_xA.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		g_iPhase = kHW_Done;
+		return false;
+
+	case kHW_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1ScentHighest()
+{
+	if (!g_xPriest.IsValid() || !g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ScentHighest: priest/villager pick failed");
+		return false;
+	}
+	// Pre-flight: confirm our test setup actually produced scent[B] > scent[A].
+	// If decay was so aggressive (or accumulation so weak) that B isn't
+	// higher, the assertion below would be meaningless.
+	if (g_fScentBFinal <= g_fScentAFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentHighest: scent[B]=%.3f not > scent[A]=%.3f -- test setup didn't produce the expected ordering (decay too aggressive or accumulation cap hit)",
+			g_fScentBFinal, g_fScentAFinal);
+		return false;
+	}
+	if (g_xBBTarget.m_uIndex != g_xB.m_uIndex
+		|| g_xBBTarget.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentHighest: BB target = (%u/%u), expected B=(%u/%u) (scent[B]=%.3f > scent[A]=%.3f). Possible impl bug: WriteHighestScentToBlackboard is using 'most recently bumped' instead of 'highest scent'",
+			g_xBBTarget.m_uIndex, g_xBBTarget.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration,
+			g_fScentBFinal, g_fScentAFinal);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1ScentHighestTest = {
+	"Test_P1Scent_HighestWinsInBlackboard",
+	&Setup_P1ScentHighest,
+	&Step_P1ScentHighest,
+	&Verify_P1ScentHighest,
+	600
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1ScentHighestTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Scent_NoBumpWhilePossessing.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Scent_NoBumpWhilePossessing.cpp
@@ -1,0 +1,270 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Scent_NoBumpWhilePossessing (MVP-1.6 follow-up coverage gap)
+//
+// Scent is supposed to accumulate on the EVENT of voluntary switching
+// onto a villager -- NOT continuously while you possess that villager.
+// The GDD frames it as "the demon's stink lingers where the demon HAS
+// BEEN, not where it currently IS". A regression where:
+//   * `TryVoluntaryPossessSwitch` got rewritten to bump scent each
+//     frame the target is possessed instead of once on the switch
+//     edge, or
+//   * `TickDemonScent` accidentally accumulated alongside decay (sign
+//     flip on the per-frame delta) only for the currently-possessed
+//     villager, or
+//   * Some new "scent gain over time" feature snuck in unannounced
+// would cause scent on the currently-possessed villager to GROW (or
+// at least stop decaying) over multi-second possession windows.
+//
+// Gameplay symptom: the future hound subsystem would track wherever
+// the player is currently sitting, not wherever the player has been.
+// Defeats the point.
+//
+// `Test_P1Scent_DecaysOverTime` only covers UNPOSSESSED decay (it
+// bumps B, then switches off / sits idle). It does NOT cover the
+// scenario where the player just sits possessing the bumped villager
+// for a long time, which is exactly the regression this test catches.
+//
+// Procedure:
+//   1. Load GameLevel + pick two villagers in mutual range.
+//   2. SetPossessedVillager(A) -- system path, no scent.
+//   3. TryVoluntaryPossessSwitch(B) -- scent[B] = 0.3, B is now
+//      possessed. Snapshot scent[B] one frame later.
+//   4. Tick 120 frames (~2 s) WITHOUT switching anywhere else.
+//   5. Snapshot scent[B] again.
+//   6. Assert:
+//        scent[B] strictly decreased (didn't grow)
+//        scent[B] dropped by approximately decay_per_s * 2s (matches
+//        the expectation of `Test_P1Scent_DecaysOverTime`).
+//
+// The "approximately decay rate" assertion is what specifically
+// catches a "bump-every-frame while possessed" regression -- in that
+// world, scent[B] would either pin at 1.0 (saturation) or grow at
+// `per_possession * 60 frames/s` minus decay = wildly positive.
+// Decay alone would give us ~0.10 drop; bump-per-frame would give
+// us ~+18 (or saturate). The 0.5 * decay_per_s * 2s lower bound
+// cleanly separates the two regimes.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kNB_Start, kNB_WaitScene, kNB_PossessA, kNB_HopToB,
+	                   kNB_SnapshotInitial, kNB_Tick, kNB_SnapshotFinal,
+	                   kNB_Verify, kNB_Done };
+
+	int                     g_iPhase = kNB_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	float                   g_fScentInitial = 0.0f;
+	float                   g_fScentFinal = 0.0f;
+	int                     g_iTickCount = 0;
+
+	// 2 s window: long enough that bump-per-frame would saturate or
+	// rocket past, short enough that a normal decay-only world only
+	// drops by ~0.10. The two regimes are unambiguous.
+	constexpr int kTICK_FRAMES = 120;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+}
+
+static void Setup_P1ScentNoBumpWhilePossessing()
+{
+	g_iPhase = kNB_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_fScentInitial = 0.0f;
+	g_fScentFinal = 0.0f;
+	g_iTickCount = 0;
+}
+
+static bool Step_P1ScentNoBumpWhilePossessing(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kNB_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kNB_WaitScene;
+		return true;
+
+	case kNB_WaitScene:
+		PickClosestPair(g_xA, g_xB);
+		if (g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_iPhase = kNB_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kNB_Done;
+		}
+		return true;
+
+	case kNB_PossessA:
+		// System path -- no scent on A.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kNB_HopToB;
+		return true;
+
+	case kNB_HopToB:
+		// Voluntary switch onto B -- scent[B] += 0.3 ONCE on the edge.
+		// B is now the possessed villager.
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kNB_SnapshotInitial;
+		return true;
+
+	case kNB_SnapshotInitial:
+		// One frame later so the bump landed in the table.
+		g_fScentInitial = DP_Player::GetDemonScent(g_xB);
+		g_iTickCount = 0;
+		g_iPhase = kNB_Tick;
+		return true;
+
+	case kNB_Tick:
+		// Sit on B. Do NOT issue any further voluntary switches. If
+		// the impl is correct, only TickDemonScent's decay branch runs
+		// on this entry across the next 120 frames. If a regression
+		// has slipped in that bumps the possessed villager per frame,
+		// scent[B] will skyrocket or pin at 1.0.
+		++g_iTickCount;
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kNB_SnapshotFinal;
+		}
+		return true;
+
+	case kNB_SnapshotFinal:
+		g_fScentFinal = DP_Player::GetDemonScent(g_xB);
+		g_iPhase = kNB_Verify;
+		return true;
+
+	case kNB_Verify:
+	{
+		const float fDecayPerSec =
+			DP_Tuning::Get<float>("possession.demon_scent_decay_per_s");
+		const float fElapsed = kTICK_FRAMES * 0.01666f;
+		const float fExpectedDrop = fDecayPerSec * fElapsed;
+		const float fObservedDelta = g_fScentInitial - g_fScentFinal;
+		std::printf("[P1ScentNoBumpWhilePossessing] initial=%.3f final=%.3f delta=%.3f (expected decay ~%.3f over %.2fs; positive delta = decay-only, negative = bump-while-possessed regression)\n",
+			g_fScentInitial, g_fScentFinal, fObservedDelta,
+			fExpectedDrop, fElapsed);
+		std::fflush(stdout);
+		g_iPhase = kNB_Done;
+		return false;
+	}
+
+	case kNB_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1ScentNoBumpWhilePossessing()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1ScentNoBumpWhilePossessing: villager pick failed");
+		return false;
+	}
+	if (g_fScentInitial <= 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentNoBumpWhilePossessing: initial scent on B is %.3f -- TryVoluntaryPossessSwitch didn't bump scent (precondition failure)",
+			g_fScentInitial);
+		return false;
+	}
+	// Primary assertion: scent must strictly decrease (decay only).
+	// If it grew, somebody bumped it while possessed.
+	if (g_fScentFinal >= g_fScentInitial)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentNoBumpWhilePossessing: final scent (%.3f) >= initial (%.3f). Scent grew or stayed flat while continuously possessing B for 2s -- a per-frame bump regression in TickDemonScent or TryVoluntaryPossessSwitch is leaking scent every tick.",
+			g_fScentFinal, g_fScentInitial);
+		return false;
+	}
+	// Secondary assertion: the drop matches the decay expectation. If
+	// scent dropped but by FAR LESS than the decay rate would predict
+	// (or NEGATIVE delta below the floor), that suggests a partial
+	// bump is fighting decay -- e.g., bumping by 0.005/frame against
+	// 0.05/s decay would net out at ~+0.25 over 2s but scent caps at
+	// 1.0 so we'd see ~+0.2 here.
+	const float fDecayPerSec =
+		DP_Tuning::Get<float>("possession.demon_scent_decay_per_s");
+	const float fElapsed = kTICK_FRAMES * 0.01666f;
+	const float fExpectedDrop = fDecayPerSec * fElapsed;
+	const float fObservedDrop = g_fScentInitial - g_fScentFinal;
+	// 50% tolerance: same lower bound as Test_P1Scent_DecaysOverTime
+	// so the two tests fail together if decay rate or tick path break.
+	const float fMinDrop = fExpectedDrop * 0.5f;
+	if (fObservedDrop < fMinDrop)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1ScentNoBumpWhilePossessing: scent dropped only %.3f over %.2fs while possessed -- expected at least %.3f given decay_per_s=%.3f. Suggests partial bump leaking each frame and partially cancelling decay.",
+			fObservedDrop, fElapsed, fMinDrop, fDecayPerSec);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1ScentNoBumpWhilePossessingTest = {
+	"Test_P1Scent_NoBumpWhilePossessing",
+	&Setup_P1ScentNoBumpWhilePossessing,
+	&Step_P1ScentNoBumpWhilePossessing,
+	&Verify_P1ScentNoBumpWhilePossessing,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1ScentNoBumpWhilePossessingTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Sprint_WinsTieOverWalkQuiet.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Sprint_WinsTieOverWalkQuiet.cpp
@@ -1,0 +1,283 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "Input/Zenith_InputSimulator.h"
+#include "Input/Zenith_KeyCodes.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Sprint_WinsTieOverWalkQuiet (MVP-1.7 follow-up coverage gap)
+//
+// MVP-1.7 has tests for sprint-on (Test_P1Sprint_DrainsLifeFaster),
+// sprint-off-when-still (Test_P1Sprint_NoDrainWhenNotMoving), and
+// walk-quiet loudness (Test_P1WalkQuiet_*), but NOTHING in the suite
+// asserts the documented Shift+Ctrl tie-breaking semantic from the
+// villager header comment:
+//
+//   "Sprint wins ties; walk-quiet takes the slow speed. Holding
+//    Shift+Ctrl resolves to sprint -- the louder, faster mode
+//    shouldn't be silenced by a held Ctrl."
+//
+// The relevant code in DPVillager_Behaviour::OnUpdate:
+//   m_bIsSprintingNow = DP_Input::ReadSprintHeld() && bMoving;
+//   m_bIsWalkQuietNow = !m_bIsSprintingNow
+//       && DP_Input::ReadWalkQuietHeld() && bMoving;
+//
+// A regression where the `!m_bIsSprintingNow` guard got dropped, or
+// the two reads got reordered (walk-quiet wins), would silently leak.
+// Gameplay-wise this would mean a sprinting player who happens to be
+// holding Ctrl (common keyboard ergonomics -- pinky on Ctrl, ring on
+// Shift) would suddenly emit quieter footsteps AND move slower while
+// still paying the sprint life cost.
+//
+// Procedure:
+//   1. Load GameLevel + pick any villager.
+//   2. SetPossessedVillager + wait one bump frame.
+//   3. **Sprint+Ctrl window**: hold Shift + Ctrl + W simultaneously.
+//      Tick ~30 frames. Sample IsSprintingNow + IsWalkQuietNow on a
+//      mid-window frame.
+//   4. **Ctrl-only sanity window**: release Shift, keep Ctrl + W.
+//      Tick another ~30 frames. Sample IsSprintingNow + IsWalkQuietNow.
+//      This proves walk-quiet ACTUALLY works without sprint -- so
+//      the "walk-quiet=false in window 1" assertion has teeth.
+//   5. Release all inputs.
+//   6. Assert:
+//        Window 1: sprintingNow=true, walkQuietNow=false
+//        Window 2: sprintingNow=false, walkQuietNow=true
+//
+// What this catches:
+//   * A regression where walk-quiet's input read got reordered to win
+//     ties (Ctrl+Shift => walk-quiet=true, sprint=false).
+//   * A regression where the `!m_bIsSprintingNow` guard inside
+//     `m_bIsWalkQuietNow`'s assignment got dropped (Ctrl+Shift =>
+//     BOTH true at once, which would also break the speed switch
+//     in TickMovement because the if/else-if would pick sprint but
+//     subsequent code paths might still see walkQuietNow=true).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kTW_Start, kTW_WaitScene, kTW_Possess, kTW_AfterBump,
+	                   kTW_ArmSprintWindow, kTW_TickSprintWindow,
+	                   kTW_ArmCtrlOnlyWindow, kTW_TickCtrlOnlyWindow,
+	                   kTW_ReleaseInputs, kTW_Verify, kTW_Done };
+
+	int                     g_iPhase = kTW_Start;
+	Zenith_EntityID         g_xVillager;
+	int                     g_iTickCount = 0;
+	bool                    g_bSprintingObservedShiftCtrlWindow = false;
+	bool                    g_bWalkQuietObservedShiftCtrlWindow = true; // sentinel: must end up false
+	bool                    g_bSprintingObservedCtrlOnlyWindow = true;  // sentinel: must end up false
+	bool                    g_bWalkQuietObservedCtrlOnlyWindow = false;
+
+	constexpr int kTICK_FRAMES = 30;
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1SprintWinsTie()
+{
+	g_iPhase = kTW_Start;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_iTickCount = 0;
+	g_bSprintingObservedShiftCtrlWindow = false;
+	g_bWalkQuietObservedShiftCtrlWindow = true;
+	g_bSprintingObservedCtrlOnlyWindow = true;
+	g_bWalkQuietObservedCtrlOnlyWindow = false;
+}
+
+static bool Step_P1SprintWinsTie(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kTW_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kTW_WaitScene;
+		return true;
+
+	case kTW_WaitScene:
+	{
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFound](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFound.IsValid()) xFound = xId;
+			});
+		if (xFound.IsValid())
+		{
+			g_xVillager = xFound;
+			g_iPhase = kTW_Possess;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kTW_Done;
+		}
+		return true;
+	}
+
+	case kTW_Possess:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kTW_AfterBump;
+		return true;
+
+	case kTW_AfterBump:
+		// One frame later OnUpdate has flipped m_bIsPossessed.
+		g_iPhase = kTW_ArmSprintWindow;
+		return true;
+
+	case kTW_ArmSprintWindow:
+		// Hold Shift + Ctrl + W simultaneously. Sprint MUST win the tie.
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, true);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, true);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_CONTROL, true);
+		// Belt-and-braces: defensively clear other movement keys so a
+		// leaked-state from a prior batched test doesn't flip the
+		// movement direction (shouldn't matter for the sprint flag,
+		// but cheap insurance).
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_A, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_S, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_D, false);
+		g_iTickCount = 0;
+		g_iPhase = kTW_TickSprintWindow;
+		return true;
+
+	case kTW_TickSprintWindow:
+	{
+		++g_iTickCount;
+		// Sample state at the mid-window frame so we skip any
+		// first-frame transient (the kAfterBump frame already gave
+		// OnUpdate one tick to observe possession + compute state).
+		if (g_iTickCount == kTICK_FRAMES / 2)
+		{
+			DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+			if (pxV != nullptr)
+			{
+				g_bSprintingObservedShiftCtrlWindow = pxV->IsSprintingNow();
+				g_bWalkQuietObservedShiftCtrlWindow = pxV->IsWalkQuietNow();
+			}
+		}
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kTW_ArmCtrlOnlyWindow;
+		}
+		return true;
+	}
+
+	case kTW_ArmCtrlOnlyWindow:
+		// Release Shift, keep Ctrl + W. Walk-quiet should engage.
+		// This window's job is to prove that walk-quiet CAN engage in
+		// the absence of Shift -- so "walk-quiet=false in Shift+Ctrl"
+		// can't be explained by "walk-quiet never engages anyway".
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, false);
+		// W + Ctrl still held from previous window.
+		g_iTickCount = 0;
+		g_iPhase = kTW_TickCtrlOnlyWindow;
+		return true;
+
+	case kTW_TickCtrlOnlyWindow:
+	{
+		++g_iTickCount;
+		if (g_iTickCount == kTICK_FRAMES / 2)
+		{
+			DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xVillager);
+			if (pxV != nullptr)
+			{
+				g_bSprintingObservedCtrlOnlyWindow = pxV->IsSprintingNow();
+				g_bWalkQuietObservedCtrlOnlyWindow = pxV->IsWalkQuietNow();
+			}
+		}
+		if (g_iTickCount >= kTICK_FRAMES)
+		{
+			g_iPhase = kTW_ReleaseInputs;
+		}
+		return true;
+	}
+
+	case kTW_ReleaseInputs:
+		// Don't leak input state into the next batched test.
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_W, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_SHIFT, false);
+		Zenith_InputSimulator::SetKeyHeld(ZENITH_KEY_LEFT_CONTROL, false);
+		g_iPhase = kTW_Verify;
+		return true;
+
+	case kTW_Verify:
+		std::printf("[P1SprintWinsTie] Shift+Ctrl window: sprint=%d walkQuiet=%d (expect 1/0). Ctrl-only window: sprint=%d walkQuiet=%d (expect 0/1)\n",
+			(int)g_bSprintingObservedShiftCtrlWindow,
+			(int)g_bWalkQuietObservedShiftCtrlWindow,
+			(int)g_bSprintingObservedCtrlOnlyWindow,
+			(int)g_bWalkQuietObservedCtrlOnlyWindow);
+		std::fflush(stdout);
+		g_iPhase = kTW_Done;
+		return false;
+
+	case kTW_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1SprintWinsTie()
+{
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1SprintWinsTie: villager not found");
+		return false;
+	}
+	// Shift+Ctrl: sprint must win. walkQuiet must be false.
+	if (!g_bSprintingObservedShiftCtrlWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1SprintWinsTie: IsSprintingNow was false with Shift+Ctrl+W held -- sprint didn't engage at all (precondition failure or sprint guard misfired)");
+		return false;
+	}
+	if (g_bWalkQuietObservedShiftCtrlWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1SprintWinsTie: IsWalkQuietNow was true with Shift+Ctrl+W held -- walk-quiet won the tie. The '!m_bIsSprintingNow' guard inside m_bIsWalkQuietNow's assignment is missing or reordered. Header semantic 'sprint wins ties' is broken.");
+		return false;
+	}
+	// Sanity window: Ctrl alone must engage walk-quiet.
+	if (g_bSprintingObservedCtrlOnlyWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1SprintWinsTie: Ctrl-only sanity window had IsSprintingNow=true -- Shift release didn't disengage sprint, or sprint is reading the wrong key");
+		return false;
+	}
+	if (!g_bWalkQuietObservedCtrlOnlyWindow)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1SprintWinsTie: Ctrl-only sanity window had IsWalkQuietNow=false -- walk-quiet doesn't engage even without sprint, so the Shift+Ctrl assertion has no teeth. ReadWalkQuietHeld bug?");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1SprintWinsTieTest = {
+	"Test_P1Sprint_WinsTieOverWalkQuiet",
+	&Setup_P1SprintWinsTie,
+	&Step_P1SprintWinsTie,
+	&Verify_P1SprintWinsTie,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1SprintWinsTieTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Closes coverage gaps where existing single-event tests would silently pass through regressions in multi-event semantics. Each test pins a specific implementation contract that no current test verifies:

| Test | Pins | Catches |
|---|---|---|
| `Test_P1Range_AnchorMovesWithEachHop` | Anchor moves on each successful voluntary hop (A→B→C with d(A,C) > range) | Anchor stuck on run-start position |
| `Test_P1Scent_DecaysOverTime` | TickDemonScent's decay path actually runs | decay_per_s=0, missed controller hook, broken fDt arithmetic |
| `Test_P1Scent_HighestWinsInBlackboard` | "Highest scent" semantic (B bumped twice, A bumped once last) | Refactor to "most recently bumped" or "first found in map" |
| `Test_P1Sprint_WinsTieOverWalkQuiet` | Sprint wins Shift+Ctrl tie (header semantic) | Dropped `!m_bIsSprintingNow` guard in walk-quiet assignment |
| `Test_P1Scent_NoBumpWhilePossessing` | Scent bumps on edge, not continuously while possessed | Per-frame bump regression or decay sign flip |

## Test plan

- [x] All 5 new tests pass individually (per-process via -Filter)
- [x] Full DP suite green: **71 passed, 0 failed**
- [x] Sharpmake regen + clean build of DevilsPlayground (no warnings)
- [x] Test_P1Scent_HighestWinsInBlackboard initial implementation failed (symmetric bump count) -- rewrote using SetPossessedVillager (system path) between voluntary switches so B accumulates two deposits while A only accumulates one. The test now distinguishes "highest" from "most recent" unambiguously.

## Implementation notes

- Tests are pure additions to `Games/DevilsPlayground/Tests/` -- no engine or game-code changes. No conflict surface with PRs #49 or #50.
- All 5 tests use the existing `Zenith_AutomatedTest` phase-state-machine pattern + `ZENITH_INPUT_SIMULATOR` gate.
- `Test_P1Scent_HighestWinsInBlackboard` uses `SetPossessedVillager` (system path, no scent bump) as the "return to A without crediting A" trick -- crucial for setting up the test's asymmetric scent state.
- The anchor-moves test uses brute-force O(n³) search through GameLevel's 17 villagers for a trio with d(A,B)≤15, d(B,C)≤15, d(A,C)>15. Trivially fast (4913 candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)