### PR TITLE
feat(dp): MVP-1.4.1-3 -- Faint/Dead state machine for villagers

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -241,6 +241,8 @@
     <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Switch_BurnOutDoesDie.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Switch_FaintNotDie.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -149,6 +149,12 @@
     <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Switch_BurnOutDoesDie.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Switch_FaintNotDie.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -535,6 +535,8 @@
     <ClCompile Include="..\Tests\Test_P1Sprint_DrainsLifeFaster.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_NoDrainWhenNotMoving.cpp" />
     <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Switch_BurnOutDoesDie.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Switch_FaintNotDie.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_LoadsAndValuesInBand.cpp" />
     <ClCompile Include="..\Tests\Test_P1Tuning_PriestValuesMatchConfig.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -149,6 +149,12 @@
     <ClCompile Include="..\Tests\Test_P1Sprint_WinsTieOverWalkQuiet.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Switch_BurnOutDoesDie.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Switch_FaintNotDie.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Tuning_InteractableValuesMatchConfig.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
@@ -35,6 +35,27 @@
 
 #include <cstdio>
 
+// MVP-1.4.1-3: villager lifecycle state machine.
+//
+// Idle:      not possessed; life > 0; available for possession.
+// Possessed: currently the player's vessel; TickLife/TickMovement run.
+// Fainted:   voluntarily switched off by the player. Recovers to Idle
+//            after `possession.faint_recovery_s` seconds. Refused by
+//            TryVoluntaryPossessSwitch (player can't re-possess until
+//            recovered). System path SetPossessedVillager bypasses the
+//            refusal as a debug/test backdoor.
+// Dead:      life timer expired (or test-driven Kill()). Terminal --
+//            permanently unavailable. Distinct from Fainted so a future
+//            GDD "permanent vessel pool decrement" mechanic has a clean
+//            boundary.
+enum class DPVillagerState : uint8_t
+{
+	Idle,
+	Possessed,
+	Fainted,
+	Dead
+};
+
 class DPVillager_Behaviour ZENITH_FINAL : Zenith_ScriptBehaviour
 {
 	friend class Zenith_ScriptComponent;
@@ -92,19 +113,95 @@ public:
 
 	void OnUpdate(const float fDt) ZENITH_FINAL override
 	{
-		// Possession state is observed via DP_Player; refresh per frame so a
-		// click-to-possess on another villager flips us back to idle without
-		// the controller having to broadcast.
+		// MVP-1.4.1-3: state-machine-driven possession transitions.
+		// Observe DP_Player's possessed handle each frame and drive
+		// m_eState through Idle/Possessed/Fainted/Dead.
+		//
+		// Transition table:
+		//   Idle      + possessed         -> Possessed  (bump life to max)
+		//   Possessed + un-possessed      -> Fainted    (arm faint timer)
+		//                                                EXCEPT if we're
+		//                                                already Dead --
+		//                                                Kill() ran inline
+		//                                                from TickLife and
+		//                                                set state=Dead
+		//                                                before OnUpdate
+		//                                                got a chance to
+		//                                                observe the
+		//                                                un-possession.
+		//   Fainted   + (timer expires)   -> Idle
+		//   Fainted   + possessed (SYSTEM path bypass) -> Possessed
+		//                                                (test backdoor;
+		//                                                 voluntary switch
+		//                                                 is refused at
+		//                                                 the TryVoluntary-
+		//                                                 PossessSwitch
+		//                                                 level via
+		//                                                 IsPossessable())
+		//   Dead      + *                 -> Dead (terminal)
 		const Zenith_EntityID xPossessed = DP_Player::GetPossessedVillager();
-		const bool bWasPossessed = m_bIsPossessed;
-		m_bIsPossessed = (xPossessed.m_uIndex == m_xParentEntity.GetEntityID().m_uIndex)
-		             && (xPossessed.m_uGeneration == m_xParentEntity.GetEntityID().m_uGeneration);
+		const bool bIsPossessedThisFrame =
+			(xPossessed.m_uIndex == m_xParentEntity.GetEntityID().m_uIndex)
+			&& (xPossessed.m_uGeneration == m_xParentEntity.GetEntityID().m_uGeneration);
+		const DPVillagerState ePrevState = m_eState;
 
-		// Bump life on freshly-possessed transition.
-		if (m_bIsPossessed && !bWasPossessed)
+		switch (m_eState)
 		{
-			m_fRemainingLife = m_fMaxLife;
+		case DPVillagerState::Idle:
+			if (bIsPossessedThisFrame)
+			{
+				m_eState = DPVillagerState::Possessed;
+				m_fRemainingLife = m_fMaxLife;
+			}
+			break;
+		case DPVillagerState::Possessed:
+			if (!bIsPossessedThisFrame)
+			{
+				// We were the possessed villager last frame and we're
+				// not now. Two ways this can happen:
+				//   1. Voluntary switch: player chose another vessel.
+				//      Kill() did NOT run; m_bDispatchedDeath is false.
+				//      -> Fainted.
+				//   2. Death: Kill() already set m_eState=Dead inline
+				//      from TickLife. We won't reach this branch then
+				//      because the switch's outer case is Dead, not
+				//      Possessed. So unconditional Fainted is correct.
+				m_eState = DPVillagerState::Fainted;
+				m_fFaintRecoveryRemaining =
+					DP_Tuning::Get<float>("possession.voluntary_switch_faint_recovery_s");
+			}
+			break;
+		case DPVillagerState::Fainted:
+			if (bIsPossessedThisFrame)
+			{
+				// System path bypass -- e.g., a test calling
+				// SetPossessedVillager(faintedVillager) directly.
+				// The voluntary-switch path refuses this via
+				// IsPossessable(); reaching here means the developer
+				// chose to override. Wake up.
+				m_eState = DPVillagerState::Possessed;
+				m_fRemainingLife = m_fMaxLife;
+				m_fFaintRecoveryRemaining = 0.0f;
+			}
+			else
+			{
+				m_fFaintRecoveryRemaining -= fDt;
+				if (m_fFaintRecoveryRemaining <= 0.0f)
+				{
+					m_fFaintRecoveryRemaining = 0.0f;
+					m_eState = DPVillagerState::Idle;
+				}
+			}
+			break;
+		case DPVillagerState::Dead:
+			// Terminal.
+			break;
 		}
+
+		// Legacy flag sync. Kept for the existing public API
+		// (IsPossessed()) and the rest of OnUpdate's gate below.
+		m_bIsPossessed = (m_eState == DPVillagerState::Possessed);
+		const bool bWasPossessed = (ePrevState == DPVillagerState::Possessed);
 
 		// Swap to / from the possessed-tint material on transition. Only swap
 		// when the possession state actually flipped to avoid thrashing the
@@ -219,6 +316,25 @@ public:
 	// the move speed externally (it's only consumed inside TickMovement).
 	float GetMoveSpeed() const { return m_fMoveSpeed; }
 	bool IsPossessed() const { return m_bIsPossessed; }
+
+	// MVP-1.4.1-3 state accessors.
+	DPVillagerState GetState() const { return m_eState; }
+
+	// Whether the player's voluntary-switch path is allowed to
+	// possess this villager. Refused for Fainted (still recovering)
+	// and Dead (permanent). Idle and Possessed both pass -- re-
+	// clicking the same villager is idempotent in
+	// TryVoluntaryPossessSwitch.
+	bool IsPossessable() const
+	{
+		return m_eState == DPVillagerState::Idle
+			|| m_eState == DPVillagerState::Possessed;
+	}
+
+	// Diagnostic only -- the recovery countdown while Fainted, 0
+	// otherwise. Tests inspect this to assert the timer arms on
+	// voluntary switch.
+	float GetFaintRecoveryRemaining() const { return m_fFaintRecoveryRemaining; }
 	// MVP-1.7: test accessor -- returns true if Shift was held AND the
 	// villager was actually moving on the most recent OnUpdate. Used by
 	// Test_P1Sprint_* to verify the sprint state machine without
@@ -281,6 +397,13 @@ public:
 		if (m_bDispatchedDeath) return;
 		m_bDispatchedDeath = true;
 		m_fRemainingLife = 0.0f;
+		// MVP-1.4.3: distinguish death from voluntary-switch faint.
+		// Setting state=Dead here (BEFORE the next OnUpdate observes
+		// the un-possession) is what makes the burn-out path skip the
+		// Possessed -> Fainted transition. The OnUpdate switch's outer
+		// `case Dead` is terminal, so the un-possession on the next
+		// frame is a no-op rather than a faint.
+		m_eState = DPVillagerState::Dead;
 		Zenith_EventDispatcher::Get().Dispatch(
 			DP_OnVillagerDied{ m_xParentEntity.GetEntityID() });
 		// Only clear possession if WE were the possessed villager.
@@ -592,6 +715,14 @@ private:
 	// skip collider response.
 	float m_fMoveSpeed      = 8.0f;
 	bool  m_bIsPossessed    = false;
+	// MVP-1.4.1-3: villager lifecycle state. Drives the Idle/Possessed/
+	// Fainted/Dead transitions in OnUpdate. The legacy m_bIsPossessed
+	// flag (above) is kept in sync for the IsPossessed() API.
+	DPVillagerState m_eState = DPVillagerState::Idle;
+	// MVP-1.4.2: countdown while Fainted. Set on Possessed->Fainted
+	// transition from possession.faint_recovery_s. When it reaches 0
+	// the state advances to Idle.
+	float m_fFaintRecoveryRemaining = 0.0f;
 	// MVP-1.7: sprint-state cache. Set in OnUpdate to
 	// (DP_Input::ReadSprintHeld() && moving). TickLife / TickMovement
 	// both read this so they agree on whether sprint is active this

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -13,6 +13,7 @@
 #include "AI/BehaviorTree/Zenith_Blackboard.h"
 
 #include "DP_Tuning.h"
+#include "../Components/DPVillager_Behaviour.h"
 
 #include <unordered_map>
 
@@ -165,6 +166,28 @@ namespace DP_Player
 		if (g_fPossessionCooldownRemaining > 0.0f)
 		{
 			return false;
+		}
+
+		// MVP-1.4.1-3: state gate. Refuse fainted (still recovering) or
+		// dead villagers. SetPossessedVillager (system path) bypasses
+		// this -- only the player-driven voluntary switch enforces it.
+		if (xId.IsValid())
+		{
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+			if (pxScene != nullptr)
+			{
+				Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+				if (xEnt.IsValid() && xEnt.HasComponent<Zenith_ScriptComponent>())
+				{
+					DPVillager_Behaviour* pxV =
+						xEnt.GetComponent<Zenith_ScriptComponent>()
+							.GetScript<DPVillager_Behaviour>();
+					if (pxV != nullptr && !pxV->IsPossessable())
+					{
+						return false;
+					}
+				}
+			}
 		}
 
 		// MVP-1.8: range gate. Anchor was set by the prior successful

--- a/Games/DevilsPlayground/Tests/Test_P1Scent_AccumulatesOnPossession.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Scent_AccumulatesOnPossession.cpp
@@ -33,12 +33,19 @@
 //
 // Procedure:
 //   1. Load GameLevel.
-//   2. Find the closest pair of villagers.
-//   3. Snapshot baseline scent on both (expect 0.0 after suite reset).
+//   2. Find a trio of villagers in mutual range (A, B, C). Three
+//      rather than two because MVP-1.4.1-3 added the Fainted state:
+//      after switching away from A, A is unavailable for re-
+//      possession until the 10 s faint recovery completes. The
+//      original 2-villager A->B->A test no longer fits because the
+//      B->A leg is refused by the faint gate. Using a fresh C
+//      preserves the accumulation assertion (each successful switch
+//      bumps scent on the destination) without bumping into faint.
+//   3. Snapshot baseline scent on all three.
 //   4. SetPossessedVillager(A) -- direct write, no scent bump.
 //   5. TryVoluntaryPossessSwitch(A) -- idempotent re-click; no bump.
 //   6. TryVoluntaryPossessSwitch(B) -- scent[B] = 0.3.
-//   7. Wait cooldown + TryVoluntaryPossessSwitch(A) -- scent[A] = 0.3.
+//   7. Wait cooldown + TryVoluntaryPossessSwitch(C) -- scent[C] = 0.3.
 //
 // Why no hard saturation assert: the test's natural pacing (1.5 s
 // cooldown between switches) interacts with the 0.05 /s decay rate
@@ -56,20 +63,22 @@ namespace
 		kSA_PossessADirect, kSA_VerifyANoBump,
 		kSA_TryIdempotent, kSA_VerifyIdempotentNoBump,
 		kSA_SwitchToB, kSA_VerifyBAfterFirst,
-		kSA_WaitCooldown1, kSA_SwitchToA2, kSA_VerifyAAfterFirst,
+		kSA_WaitCooldown1, kSA_SwitchToC, kSA_VerifyCAfterSwitch,
 		kSA_Done
 	};
 
 	int                     g_iPhase = kSA_Start;
 	Zenith_EntityID         g_xA;
 	Zenith_EntityID         g_xB;
+	Zenith_EntityID         g_xC;
 
 	float                   g_fBaselineA = -1.0f;
 	float                   g_fBaselineB = -1.0f;
+	float                   g_fBaselineC = -1.0f;
 	float                   g_fScentAfterADirect = -1.0f;
 	float                   g_fScentAfterIdempotent = -1.0f;
 	float                   g_fScentBAfterFirstSwitch = -1.0f;
-	float                   g_fScentAAfterFirstSwitch = -1.0f;
+	float                   g_fScentCAfterSwitch = -1.0f;
 
 	int                     g_iCooldownWaitFrames = 0;
 
@@ -96,8 +105,16 @@ namespace
 		return std::sqrt(fDx * fDx + fDz * fDz);
 	}
 
-	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	// Find any trio A, B, C all within the possession range gate
+	// (15 m default) of each other -- A is anchor, then B->C hop
+	// must satisfy both d(A,B)<=range and d(B,C)<=range. Brute-force
+	// O(n^3) over GameLevel's 17 villagers = 4913 candidates, trivially
+	// fast.
+	bool PickMutualRangeTrio(Zenith_EntityID& xA,
+	                         Zenith_EntityID& xB,
+	                         Zenith_EntityID& xC)
 	{
+		const float fRange = DP_Tuning::Get<float>("possession.range_from_anchor_m");
 		struct Cand { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
 		Zenith_Vector<Cand> axCands;
 		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
@@ -106,22 +123,23 @@ namespace
 				Cand xV; xV.xId = xId;
 				if (TryGetEntityPos(xId, xV.xPos)) axCands.PushBack(xV);
 			});
-		if (axCands.GetSize() < 2) return;
-		float fMin = 1e30f;
+		if (axCands.GetSize() < 3) return false;
 		for (uint32_t i = 0; i < axCands.GetSize(); ++i)
+		for (uint32_t j = 0; j < axCands.GetSize(); ++j)
+		for (uint32_t k = 0; k < axCands.GetSize(); ++k)
 		{
-			for (uint32_t j = i + 1; j < axCands.GetSize(); ++j)
+			if (i == j || j == k || i == k) continue;
+			const float fAB = HorizontalDistance(axCands.Get(i).xPos, axCands.Get(j).xPos);
+			const float fBC = HorizontalDistance(axCands.Get(j).xPos, axCands.Get(k).xPos);
+			if (fAB <= fRange && fBC <= fRange)
 			{
-				const float fD = HorizontalDistance(
-					axCands.Get(i).xPos, axCands.Get(j).xPos);
-				if (fD < fMin)
-				{
-					fMin = fD;
-					xA = axCands.Get(i).xId;
-					xB = axCands.Get(j).xId;
-				}
+				xA = axCands.Get(i).xId;
+				xB = axCands.Get(j).xId;
+				xC = axCands.Get(k).xId;
+				return true;
 			}
 		}
+		return false;
 	}
 
 	bool ApproxEquals(float fA, float fB, float fTol = 0.001f)
@@ -136,12 +154,14 @@ static void Setup_P1ScentAccumulates()
 	g_iPhase = kSA_Start;
 	g_xA = INVALID_ENTITY_ID;
 	g_xB = INVALID_ENTITY_ID;
+	g_xC = INVALID_ENTITY_ID;
 	g_fBaselineA = -1.0f;
 	g_fBaselineB = -1.0f;
+	g_fBaselineC = -1.0f;
 	g_fScentAfterADirect = -1.0f;
 	g_fScentAfterIdempotent = -1.0f;
 	g_fScentBAfterFirstSwitch = -1.0f;
-	g_fScentAAfterFirstSwitch = -1.0f;
+	g_fScentCAfterSwitch = -1.0f;
 	g_iCooldownWaitFrames = 0;
 }
 
@@ -155,9 +175,7 @@ static bool Step_P1ScentAccumulates(int iFrame)
 		return true;
 
 	case kSA_WaitScene:
-		PickClosestPair(g_xA, g_xB);
-		if (g_xA.IsValid() && g_xB.IsValid()
-			&& g_xA.m_uIndex != g_xB.m_uIndex)
+		if (PickMutualRangeTrio(g_xA, g_xB, g_xC))
 		{
 			g_iPhase = kSA_RecordBaseline;
 		}
@@ -170,6 +188,7 @@ static bool Step_P1ScentAccumulates(int iFrame)
 	case kSA_RecordBaseline:
 		g_fBaselineA = DP_Player::GetDemonScent(g_xA);
 		g_fBaselineB = DP_Player::GetDemonScent(g_xB);
+		g_fBaselineC = DP_Player::GetDemonScent(g_xC);
 		g_iPhase = kSA_PossessADirect;
 		return true;
 
@@ -213,23 +232,24 @@ static bool Step_P1ScentAccumulates(int iFrame)
 		++g_iCooldownWaitFrames;
 		if (g_iCooldownWaitFrames >= kCOOLDOWN_FRAMES)
 		{
-			g_iPhase = kSA_SwitchToA2;
+			g_iPhase = kSA_SwitchToC;
 		}
 		return true;
 
-	case kSA_SwitchToA2:
-		// Switch back to A. scent[A] += 0.3.
-		DP_Player::TryVoluntaryPossessSwitch(g_xA);
-		g_iPhase = kSA_VerifyAAfterFirst;
+	case kSA_SwitchToC:
+		// Switch onward to C (NOT back to A -- A is Fainted post-MVP-
+		// 1.4). scent[C] += 0.3.
+		DP_Player::TryVoluntaryPossessSwitch(g_xC);
+		g_iPhase = kSA_VerifyCAfterSwitch;
 		return true;
 
-	case kSA_VerifyAAfterFirst:
-		g_fScentAAfterFirstSwitch = DP_Player::GetDemonScent(g_xA);
+	case kSA_VerifyCAfterSwitch:
+		g_fScentCAfterSwitch = DP_Player::GetDemonScent(g_xC);
 		Zenith_Log(LOG_CATEGORY_AI,
-			"P1ScentAccumulates: baseA=%.3f baseB=%.3f directA=%.3f idempA=%.3f firstB=%.3f firstA=%.3f",
-			g_fBaselineA, g_fBaselineB, g_fScentAfterADirect,
-			g_fScentAfterIdempotent, g_fScentBAfterFirstSwitch,
-			g_fScentAAfterFirstSwitch);
+			"P1ScentAccumulates: baseA=%.3f baseB=%.3f baseC=%.3f directA=%.3f idempA=%.3f firstB=%.3f firstC=%.3f",
+			g_fBaselineA, g_fBaselineB, g_fBaselineC,
+			g_fScentAfterADirect, g_fScentAfterIdempotent,
+			g_fScentBAfterFirstSwitch, g_fScentCAfterSwitch);
 		g_iPhase = kSA_Done;
 		return false;
 
@@ -241,16 +261,18 @@ static bool Step_P1ScentAccumulates(int iFrame)
 
 static bool Verify_P1ScentAccumulates()
 {
-	if (!g_xA.IsValid() || !g_xB.IsValid())
+	if (!g_xA.IsValid() || !g_xB.IsValid() || !g_xC.IsValid())
 	{
-		Zenith_Log(LOG_CATEGORY_AI, "P1ScentAccumulates: villager pick failed");
+		Zenith_Log(LOG_CATEGORY_AI, "P1ScentAccumulates: villager trio pick failed");
 		return false;
 	}
-	if (!ApproxEquals(g_fBaselineA, 0.0f) || !ApproxEquals(g_fBaselineB, 0.0f))
+	if (!ApproxEquals(g_fBaselineA, 0.0f)
+		|| !ApproxEquals(g_fBaselineB, 0.0f)
+		|| !ApproxEquals(g_fBaselineC, 0.0f))
 	{
 		Zenith_Log(LOG_CATEGORY_AI,
-			"P1ScentAccumulates: baseline non-zero (A=%.3f B=%.3f) -- did ResetForTest run?",
-			g_fBaselineA, g_fBaselineB);
+			"P1ScentAccumulates: baseline non-zero (A=%.3f B=%.3f C=%.3f) -- did ResetForTest run?",
+			g_fBaselineA, g_fBaselineB, g_fBaselineC);
 		return false;
 	}
 	if (!ApproxEquals(g_fScentAfterADirect, 0.0f))
@@ -276,17 +298,15 @@ static bool Verify_P1ScentAccumulates()
 			g_fScentBAfterFirstSwitch, fPerPossession);
 		return false;
 	}
-	// scent[A] after switching back has been decayed by the cooldown
-	// wait (110 frames * 0.01666 s/frame * 0.05/s = ~0.09 lost).
-	// Expected: 0.3 (from this switch) but the read is BEFORE any
-	// decay tick after the switch frame, so we expect exactly 0.3 +/-
-	// one-frame-of-decay. Allow 0.05 tolerance.
-	if (g_fScentAAfterFirstSwitch < fPerPossession - 0.05f
-		|| g_fScentAAfterFirstSwitch > fPerPossession + 0.05f)
+	// scent[C] after switching onward to C. C is fresh (no prior
+	// bumps), so this is just the per-possession amount. Allow 0.05
+	// tolerance for one-frame-of-decay slop.
+	if (g_fScentCAfterSwitch < fPerPossession - 0.05f
+		|| g_fScentCAfterSwitch > fPerPossession + 0.05f)
 	{
 		Zenith_Log(LOG_CATEGORY_AI,
-			"P1ScentAccumulates: scent[A] after second switch = %.3f, expected near %.3f",
-			g_fScentAAfterFirstSwitch, fPerPossession);
+			"P1ScentAccumulates: scent[C] after onward switch = %.3f, expected near %.3f",
+			g_fScentCAfterSwitch, fPerPossession);
 		return false;
 	}
 	return true;

--- a/Games/DevilsPlayground/Tests/Test_P1Switch_BurnOutDoesDie.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Switch_BurnOutDoesDie.cpp
@@ -1,0 +1,230 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Switch_BurnOutDoesDie (MVP-1.4.3)
+//
+// Negative-control sibling to `Test_P1Switch_FaintNotDie`: burn-out
+// (life timer hits 0) sets state to Dead, NOT Fainted.
+//
+// Without this guard, an over-zealous "all un-possession faints"
+// regression in DPVillager_Behaviour::OnUpdate would have the
+// possessed-villager's burn-out moment treated as a voluntary
+// switch -- letting the player re-possess the burned-out villager
+// after 10 s "recovery". That breaks the GDD's permanent-loss
+// semantic for run-end conditions and would also break the
+// MVP-1.3.5 NoVessels detection (burned-out villagers would tick
+// back to Idle, never letting "all dead" hold).
+//
+// Procedure:
+//   1. Load GameLevel; pick any villager.
+//   2. SetPossessedVillager(V).
+//   3. Wait for the Idle -> Possessed transition.
+//   4. SetRemainingLifeForTest(0.001 s) -- one frame's drain past 0.
+//   5. Tick a frame so TickLife drains + calls Kill().
+//   6. Snapshot state + life + faint-recovery-remaining.
+//   7. Assert:
+//        V.state == Dead (NOT Fainted)
+//        V.remainingLife == 0
+//        V.faintRecoveryRemaining == 0 (timer didn't arm)
+//   8. Also assert: TryVoluntaryPossessSwitch(V) refuses (V is Dead).
+//
+// What this catches:
+//   * The OnUpdate state machine treats burn-out's un-possession
+//     transition as voluntary (state -> Fainted) because Kill()
+//     forgot to set state=Dead BEFORE the next OnUpdate observes
+//     the un-possession.
+//   * IsPossessable() returns true for Dead -- the dead villager
+//     is selectable.
+//   * Kill() set state=Fainted by accident, allowing recovery (the
+//     GDD's permanent-loss promise breaks).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kBD_Start, kBD_WaitScene, kBD_PossessV, kBD_WaitForV,
+	                   kBD_DrainLife, kBD_WaitForKill, kBD_Snapshot,
+	                   kBD_TryRePossess, kBD_Verify, kBD_Done };
+
+	int                     g_iPhase = kBD_Start;
+	Zenith_EntityID         g_xV;
+	DPVillagerState         g_eVFinalState = DPVillagerState::Idle;
+	float                   g_fVFinalLife = 0.0f;
+	float                   g_fVFaintTimer = -1.0f;
+	bool                    g_bRePossessOk = false;
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1BurnOutDoesDie()
+{
+	g_iPhase = kBD_Start;
+	g_xV = INVALID_ENTITY_ID;
+	g_eVFinalState = DPVillagerState::Idle;
+	g_fVFinalLife = 0.0f;
+	g_fVFaintTimer = -1.0f;
+	g_bRePossessOk = false;
+}
+
+static bool Step_P1BurnOutDoesDie(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kBD_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kBD_WaitScene;
+		return true;
+
+	case kBD_WaitScene:
+	{
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFound](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFound.IsValid()) xFound = xId;
+			});
+		if (xFound.IsValid())
+		{
+			g_xV = xFound;
+			g_iPhase = kBD_PossessV;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kBD_Done;
+		}
+		return true;
+	}
+
+	case kBD_PossessV:
+		DP_Player::SetPossessedVillager(g_xV);
+		g_iPhase = kBD_WaitForV;
+		return true;
+
+	case kBD_WaitForV:
+		// One frame for OnUpdate to run Idle -> Possessed.
+		g_iPhase = kBD_DrainLife;
+		return true;
+
+	case kBD_DrainLife:
+	{
+		// One frame's worth of TickLife drain (~0.01666 s) is more than
+		// 0.001, so next OnUpdate's TickLife will drain past 0 and
+		// invoke Kill().
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xV);
+		if (pxV != nullptr)
+		{
+			pxV->SetRemainingLifeForTest(0.001f);
+		}
+		g_iPhase = kBD_WaitForKill;
+		return true;
+	}
+
+	case kBD_WaitForKill:
+		// One frame for TickLife -> Kill -> state=Dead, plus the
+		// NoVessels scan (which won't trigger because there are 16
+		// other villagers alive).
+		g_iPhase = kBD_Snapshot;
+		return true;
+
+	case kBD_Snapshot:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xV);
+		if (pxV != nullptr)
+		{
+			g_eVFinalState = pxV->GetState();
+			g_fVFinalLife = pxV->GetRemainingLife();
+			g_fVFaintTimer = pxV->GetFaintRecoveryRemaining();
+		}
+		g_iPhase = kBD_TryRePossess;
+		return true;
+	}
+
+	case kBD_TryRePossess:
+		// V is Dead. Voluntary switch should refuse.
+		g_bRePossessOk = DP_Player::TryVoluntaryPossessSwitch(g_xV);
+		g_iPhase = kBD_Verify;
+		return true;
+
+	case kBD_Verify:
+		std::printf("[P1BurnOutDoesDie] state=%d life=%.3f faintTimer=%.3f rePossessOk=%d\n",
+			(int)g_eVFinalState, g_fVFinalLife, g_fVFaintTimer,
+			(int)g_bRePossessOk);
+		std::fflush(stdout);
+		g_iPhase = kBD_Done;
+		return false;
+
+	case kBD_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1BurnOutDoesDie()
+{
+	if (!g_xV.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1BurnOutDoesDie: villager not found");
+		return false;
+	}
+	if (g_eVFinalState != DPVillagerState::Dead)
+	{
+		const char* szState = "Idle";
+		if (g_eVFinalState == DPVillagerState::Possessed) szState = "Possessed";
+		else if (g_eVFinalState == DPVillagerState::Fainted) szState = "Fainted";
+		else if (g_eVFinalState == DPVillagerState::Dead) szState = "Dead";
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1BurnOutDoesDie: V's state after burn-out is %s, expected Dead. Kill() forgot to set state=Dead, or OnUpdate's Possessed->Fainted transition fired before Kill()'s state assignment",
+			szState);
+		return false;
+	}
+	if (g_fVFinalLife > 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1BurnOutDoesDie: V's remaining life is %.3f after burn-out, expected 0 -- Kill() didn't clamp life",
+			g_fVFinalLife);
+		return false;
+	}
+	if (g_fVFaintTimer > 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1BurnOutDoesDie: V's faint recovery timer is %.3f after burn-out, expected 0 -- burn-out leaked into the Fainted-state code path",
+			g_fVFaintTimer);
+		return false;
+	}
+	if (g_bRePossessOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1BurnOutDoesDie: TryVoluntaryPossessSwitch(deadVillager) succeeded -- IsPossessable() returns true for Dead, or the gate is missing");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1BurnOutDoesDieTest = {
+	"Test_P1Switch_BurnOutDoesDie",
+	&Setup_P1BurnOutDoesDie,
+	&Step_P1BurnOutDoesDie,
+	&Verify_P1BurnOutDoesDie,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1BurnOutDoesDieTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Switch_FaintNotDie.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Switch_FaintNotDie.cpp
@@ -1,0 +1,288 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Switch_FaintNotDie (MVP-1.4.1)
+//
+// Pins the GDD's "voluntary switch faints, doesn't kill" semantic:
+// when the player voluntarily switches off villager A (mid-life, NOT
+// at burn-out), A enters Fainted state -- temporarily unavailable for
+// re-possession -- and recovers to Idle after
+// `possession.voluntary_switch_faint_recovery_s` seconds.
+//
+// Crucially DISTINCT from MVP-1.4.3 (BurnOutDoesDie): voluntary
+// switch must NOT set state=Dead, otherwise the villager is lost
+// for the rest of the run. That's a one-life-per-villager mechanic
+// the GDD explicitly rejects -- the demon can revisit vessels after
+// they recover.
+//
+// Procedure:
+//   1. Load GameLevel; pick two villagers (A and B) in mutual range.
+//   2. SetPossessedVillager(A) -- system path, anchor at A. A's
+//      state transitions Idle -> Possessed in OnUpdate.
+//   3. Wait one frame for that transition.
+//   4. TryVoluntaryPossessSwitch(B) -- player-driven path. B becomes
+//      possessed. A's possession flag clears.
+//   5. Wait one frame so A's OnUpdate observes the un-possession
+//      and runs the Possessed -> Fainted transition.
+//   6. Snapshot A's state + faint-recovery-remaining + remaining-life.
+//   7. Assert:
+//        A.state == Fainted (NOT Dead, NOT Idle)
+//        A.faintRecoveryRemaining > 0 (timer armed)
+//        A.remainingLife > 0 (didn't die)
+//   8. Also assert: TryVoluntaryPossessSwitch(A) refuses because A
+//      is Fainted -- the player can't possess them again until
+//      recovery completes.
+//
+// What this catches:
+//   * Voluntary switch transitions to Dead instead of Fainted.
+//   * Faint-recovery timer never arms (=0 immediately) -- the
+//     state-transition forgot to set the timer.
+//   * IsPossessable() returns true for Fainted -- the refusal
+//     gate in TryVoluntaryPossessSwitch is missing or wrong.
+//   * Voluntary-switch path bumps life to 0 (regression where
+//     un-possession is treated as death).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kFN_Start, kFN_WaitScene, kFN_PossessA, kFN_WaitForA,
+	                   kFN_SwitchToB, kFN_WaitForFaint, kFN_Snapshot,
+	                   kFN_TryRePossessA, kFN_Verify, kFN_Done };
+
+	int                     g_iPhase = kFN_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	DPVillagerState         g_eAFinalState = DPVillagerState::Idle;
+	float                   g_fAFaintTimer = 0.0f;
+	float                   g_fALifeAfterSwitch = 0.0f;
+	bool                    g_bSwitchToBOk = false;
+	bool                    g_bRePossessAOk = false;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1FaintNotDie()
+{
+	g_iPhase = kFN_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_eAFinalState = DPVillagerState::Idle;
+	g_fAFaintTimer = 0.0f;
+	g_fALifeAfterSwitch = 0.0f;
+	g_bSwitchToBOk = false;
+	g_bRePossessAOk = false;
+}
+
+static bool Step_P1FaintNotDie(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kFN_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kFN_WaitScene;
+		return true;
+
+	case kFN_WaitScene:
+		PickClosestPair(g_xA, g_xB);
+		if (g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_iPhase = kFN_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kFN_Done;
+		}
+		return true;
+
+	case kFN_PossessA:
+		// System path -- anchor at A, no scent. A's state transitions
+		// Idle -> Possessed on the next OnUpdate.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kFN_WaitForA;
+		return true;
+
+	case kFN_WaitForA:
+		// One frame for A's OnUpdate to observe possession and run
+		// the Idle -> Possessed transition.
+		g_iPhase = kFN_SwitchToB;
+		return true;
+
+	case kFN_SwitchToB:
+		// Player-driven voluntary switch. A's possession flag clears
+		// after B becomes possessed.
+		g_bSwitchToBOk = DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kFN_WaitForFaint;
+		return true;
+
+	case kFN_WaitForFaint:
+		// One frame so A's OnUpdate observes the un-possession and
+		// runs Possessed -> Fainted.
+		g_iPhase = kFN_Snapshot;
+		return true;
+
+	case kFN_Snapshot:
+	{
+		DPVillager_Behaviour* pxA = GetVillagerBehaviour(g_xA);
+		if (pxA != nullptr)
+		{
+			g_eAFinalState = pxA->GetState();
+			g_fAFaintTimer = pxA->GetFaintRecoveryRemaining();
+			g_fALifeAfterSwitch = pxA->GetRemainingLife();
+		}
+		g_iPhase = kFN_TryRePossessA;
+		return true;
+	}
+
+	case kFN_TryRePossessA:
+	{
+		// Try to voluntary-switch back to A. A is Fainted, so the
+		// switch should be REFUSED by the IsPossessable() gate.
+		// (Aside: the cooldown from kFN_SwitchToB is still active
+		// at ~1.5s; the test does NOT distinguish between cooldown
+		// refusal and faint refusal -- it only proves "refused".
+		// Both refusals are correct for this scenario; the faint
+		// refusal is the one that would persist after cooldown
+		// expires. We accept the conjunction as the assertion.)
+		g_bRePossessAOk = DP_Player::TryVoluntaryPossessSwitch(g_xA);
+		g_iPhase = kFN_Verify;
+		return true;
+	}
+
+	case kFN_Verify:
+		std::printf("[P1FaintNotDie] state=%d faintTimer=%.3f life=%.3f switchToBOk=%d rePossessAOk=%d\n",
+			(int)g_eAFinalState, g_fAFaintTimer, g_fALifeAfterSwitch,
+			(int)g_bSwitchToBOk, (int)g_bRePossessAOk);
+		std::fflush(stdout);
+		g_iPhase = kFN_Done;
+		return false;
+
+	case kFN_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1FaintNotDie()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1FaintNotDie: villager pair pick failed");
+		return false;
+	}
+	if (!g_bSwitchToBOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintNotDie: voluntary switch A->B was refused -- precondition failure (cooldown still active from a previous test? range gate?)");
+		return false;
+	}
+	if (g_eAFinalState != DPVillagerState::Fainted)
+	{
+		const char* szState = "Idle";
+		if (g_eAFinalState == DPVillagerState::Possessed) szState = "Possessed";
+		else if (g_eAFinalState == DPVillagerState::Fainted) szState = "Fainted";
+		else if (g_eAFinalState == DPVillagerState::Dead) szState = "Dead";
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintNotDie: A's state after voluntary-switch-away is %s, expected Fainted. Possessed->Fainted transition didn't fire in OnUpdate",
+			szState);
+		return false;
+	}
+	const float fExpectedFaintTimer =
+		DP_Tuning::Get<float>("possession.voluntary_switch_faint_recovery_s");
+	// Allow 1 frame's worth of tick decrement (~0.017 s) since
+	// OnUpdate may have started counting down already.
+	if (g_fAFaintTimer < fExpectedFaintTimer - 0.05f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintNotDie: A's faint recovery timer is %.3f s but should be ~%.3f s -- transition forgot to arm the timer, or the tuning key is wrong",
+			g_fAFaintTimer, fExpectedFaintTimer);
+		return false;
+	}
+	if (g_fALifeAfterSwitch <= 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintNotDie: A's remaining life is %.3f after voluntary switch -- voluntary-switch-away should NOT kill the villager",
+			g_fALifeAfterSwitch);
+		return false;
+	}
+	if (g_bRePossessAOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintNotDie: TryVoluntaryPossessSwitch(A) succeeded but A is Fainted -- IsPossessable() gate in PublicInterfaces.cpp didn't fire");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1FaintNotDieTest = {
+	"Test_P1Switch_FaintNotDie",
+	&Setup_P1FaintNotDie,
+	&Step_P1FaintNotDie,
+	&Verify_P1FaintNotDie,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1FaintNotDieTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Closes the third Phase-1 deferred item. Voluntary switch-away puts the **old** villager into **Fainted** state (10 s recovery), while burn-out (life expired) puts them into **Dead** (terminal). The voluntary-switch path now refuses Fainted/Dead targets.

## Why both states are necessary

The GDD distinguishes:
- **Faint**: switching off a vessel mid-life exhausts them temporarily; after ~10 s they recover and are possessable again.
- **Dead**: burning out a vessel (life timer to 0) permanently destroys their viability. Combined with MVP-1.3.5's NoVessels detection, a player who burns through all 17 villagers loses the run.

Without distinct states a future "permanent vessel pool" mechanic would have no clean boundary.

## Implementation

| Element | Change |
|---|---|
| `DPVillagerState` enum | Idle / Possessed / Fainted / Dead |
| `OnUpdate` state machine | 5 transitions table |
| `Kill()` | Sets `m_eState = Dead` BEFORE dispatch (so burn-out skips Possessed→Fainted via the state's terminal-case branch) |
| `IsPossessable()` | new — true iff Idle or Possessed |
| `TryVoluntaryPossessSwitch` (PublicInterfaces.cpp) | New gate: looks up target's script, refuses if `!IsPossessable()` |
| `voluntary_switch_faint_recovery_s` | Existing tuning key (10s default), now actually wired |

## Tests

| Test | Pins |
|---|---|
| `Test_P1Switch_FaintNotDie` | Voluntary switch puts old villager in Fainted (timer armed, life > 0). Re-possession refused. |
| `Test_P1Switch_BurnOutDoesDie` | Life-expiry puts villager in Dead (no faint timer, no life). Possession refused. |
| `Test_P1Scent_AccumulatesOnPossession` (rewritten) | The original A→B→A path now hits faint refusal on the second A bump. Refactored to A→B→C (mutual-range trio) so accumulation assertion still holds without repossession. |

## Test plan

- [x] Both new tests pass in isolation
- [x] Full DP suite green: **78 passed, 0 failed** (76 + 2 new + 1 rewritten = same count, +2 net new tests)
- [x] Identified + fixed the scent-accumulation test's stale assumption about repossession-after-switch

## Roadmap impact

Closes **MVP-1.4.1, MVP-1.4.2, MVP-1.4.3** in one PR. Remaining Phase-1 deferred items:
- ⏸ MVP-1.3.5 Dawn half (needs Phase-4 Night timer)
- ⏸ MVP-1.10 Save/load run state (next on the deferred list — PR #56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)