### PR TITLE
feat(dp): MVP-1.3.5 Dawn -- night-timer + DP_OnRunLost{Dawn}

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -221,6 +221,8 @@
     <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P1Cooldown_CannotPossessFor1pt5s.cpp" />
     <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Dawn_DispatchesRunLost.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Dawn_NoFireWhenNotStarted.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_GoesToGroundAtBodyPosition.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_PickupChainHandoff.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -86,6 +86,12 @@
     <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Dawn_DispatchesRunLost.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Dawn_NoFireWhenNotStarted.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Drop_GoesToGroundAtBodyPosition.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -515,6 +515,8 @@
     <ClCompile Include="..\Tests\Test_P1Apprehend_SwitchBreaksChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P1Cooldown_CannotPossessFor1pt5s.cpp" />
     <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Dawn_DispatchesRunLost.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Dawn_NoFireWhenNotStarted.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_GoesToGroundAtBodyPosition.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_PickupChainHandoff.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -86,6 +86,12 @@
     <ClCompile Include="..\Tests\Test_P1Cooldown_NotAffectedByDeath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Dawn_DispatchesRunLost.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Dawn_NoFireWhenNotStarted.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1Drop_GoesToGroundAtBodyPosition.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
@@ -58,6 +58,13 @@ public:
 		DP_Player::TickDemonScent(fDt);
 		DP_Player::WriteHighestScentToBlackboard();
 
+		// MVP-1.3.5 Dawn: tick the night-timer countdown. Quiet
+		// no-op until DP_Night::StartNight has been called (production
+		// path: scene-entry hook or future Begin-Run menu; test path:
+		// tests call StartNight directly). On the frame the timer
+		// crosses 0, DP_OnRunLost{Dawn} dispatches exactly once.
+		DP_Night::TickNight(fDt);
+
 		HandleClickToPossess();
 		HandleDropItem();
 	}

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -96,6 +96,7 @@ namespace DevilsPlayground
 			DP_Win::Reset();
 			DP_Fog::ClearAllFogHoles();
 			DP_AI::ResetLevelNavMesh();
+			DP_Night::Reset();
 			DPPauseMenuController_Behaviour::ResetForTest();
 		});
 #endif

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -709,3 +709,73 @@ namespace DP_Win
 	}
 }
 
+// ============================================================================
+// DP_Night (MVP-1.3.5 Dawn half)
+// ============================================================================
+namespace
+{
+	// Per-run timer state. Set by StartNight, ticked by TickNight,
+	// cleared by Reset (between-tests hook + future "menu -> game"
+	// flow). The dispatch flag prevents repeat DP_OnRunLost emits if
+	// TickNight is called multiple frames after timer hits 0.
+	float g_fNightRemainingSec = 0.0f;
+	bool  g_bNightActive       = false;
+	bool  g_bDawnDispatched    = false;
+}
+
+namespace DP_Night
+{
+	void StartNight(float fDurationSeconds)
+	{
+		g_fNightRemainingSec = (fDurationSeconds > 0.0f) ? fDurationSeconds : 0.0f;
+		g_bNightActive       = true;
+		// Re-arm: a new run begins, even if a prior dawn already
+		// dispatched.
+		g_bDawnDispatched    = false;
+	}
+
+	void TickNight(float fDt)
+	{
+		if (!g_bNightActive)        return;
+		if (g_bDawnDispatched)
+		{
+			// Stay at 0; do not dispatch again until StartNight()
+			// or Reset() re-arms. Pinning the remaining time at 0
+			// (rather than letting it drift negative) keeps the
+			// GetNightTimeRemaining() readout stable for HUD use.
+			g_fNightRemainingSec = 0.0f;
+			return;
+		}
+		g_fNightRemainingSec -= fDt;
+		if (g_fNightRemainingSec <= 0.0f)
+		{
+			g_fNightRemainingSec = 0.0f;
+			g_bDawnDispatched    = true;
+			Zenith_EventDispatcher::Get().Dispatch(
+				DP_OnRunLost{ DP_RunLostCause::Dawn });
+		}
+	}
+
+	float GetNightTimeRemaining()
+	{
+		return g_fNightRemainingSec;
+	}
+
+	bool IsNightActive()
+	{
+		return g_bNightActive;
+	}
+
+	bool HasDawnReached()
+	{
+		return g_bDawnDispatched;
+	}
+
+	void Reset()
+	{
+		g_fNightRemainingSec = 0.0f;
+		g_bNightActive       = false;
+		g_bDawnDispatched    = false;
+	}
+}
+

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -287,6 +287,59 @@ namespace DP_Win
 }
 
 // ============================================================================
+// DP_Night (MVP-1.3.5 Dawn half) -- night-timer countdown. When the
+// timer expires, dispatches DP_OnRunLost{Dawn} EXACTLY ONCE.
+//
+// Design:
+//   * StartNight(durationSeconds) seeds the timer. Idempotent re-arm:
+//     calling Start while a night is already active resets the timer
+//     to the new duration AND clears the dawn-dispatched flag (a
+//     "new run begins" semantic).
+//   * TickNight(fDt) is driven by DPPlayerController::OnUpdate at
+//     game-frame rate. It decrements only while the timer is active;
+//     it does NOT auto-start (production code calls StartNight on
+//     scene entry; tests drive it directly).
+//   * Dispatch happens on the frame the timer crosses zero. The
+//     m_bDawnDispatched flag prevents repeat dispatch on subsequent
+//     ticks at <= 0.
+//
+// Why DP_Night and not part of DP_AI / DP_Player: the night timer
+// is a global run-state concept (like DP_Win), not a per-agent
+// behaviour. Keeping it in its own namespace makes the
+// reset/test-cleanup story symmetric with the other run-state
+// systems.
+// ============================================================================
+namespace DP_Night
+{
+	// Begin a night countdown. duration_s typically reads from
+	// possession.night_duration_s (~30 s default per GDD). Calling
+	// while already active resets to the new duration and re-arms
+	// the dispatch flag (think of it as "start a fresh run").
+	void StartNight(float fDurationSeconds);
+
+	// Per-frame tick. Decrements m_fRemaining while active; on the
+	// frame it crosses 0, dispatches DP_OnRunLost{Dawn} exactly once
+	// and stays active (remains at 0) until either StartNight() or
+	// Reset() is called. Called from DPPlayerController::OnUpdate.
+	void TickNight(float fDt);
+
+	// Seconds remaining; 0 once the timer has expired; equal to the
+	// last StartNight argument before any ticks.
+	float GetNightTimeRemaining();
+
+	// True iff StartNight was called and Reset wasn't called since.
+	// Stays true after dawn (timer at 0).
+	bool IsNightActive();
+
+	// True iff the dawn-dispatch fired this run.
+	bool HasDawnReached();
+
+	// Between-tests cleanup hook. Called from DevilsPlayground.cpp's
+	// between-tests reset.
+	void Reset();
+}
+
+// ============================================================================
 // DP_Query — script-iteration helpers. Scripts live INSIDE
 // Zenith_ScriptComponent, so we cannot Query<T> them directly.
 // ============================================================================

--- a/Games/DevilsPlayground/Tests/Test_P1Dawn_DispatchesRunLost.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Dawn_DispatchesRunLost.cpp
@@ -1,0 +1,185 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+
+#include "Source/PublicInterfaces.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Dawn_DispatchesRunLost (MVP-1.3.5 Dawn half)
+//
+// Pins the Dawn run-loss path: when the night timer reaches 0,
+// `DP_OnRunLost{Dawn}` dispatches EXACTLY ONCE. Subsequent ticks
+// past 0 do NOT re-dispatch -- the GDD framing is "one dawn per
+// run".
+//
+// Procedure (all in Setup / Step -- no scene-bound entities needed):
+//   1. Subscribe to DP_OnRunLost in Setup; count Dawn-cause events.
+//   2. Load GameLevel so DPPlayerController exists to drive
+//      TickNight from its OnUpdate.
+//   3. Call DP_Night::StartNight(0.5) -- timer counts down for ~0.5 s
+//      of game time. At 60 Hz that's ~30 frames. We tick the harness
+//      ~90 frames to overshoot the dispatch point by a factor of 3
+//      so the "dispatches exactly once" assertion has teeth.
+//   4. After the tick window, assert:
+//        DawnCount == 1                 (fired exactly once)
+//        HasDawnReached() == true       (state flag set)
+//        GetNightTimeRemaining() == 0   (timer pinned at 0)
+//        IsNightActive() == true        (run isn't reset -- only
+//                                        Reset()/StartNight() flips
+//                                        active back)
+//
+// What this catches:
+//   * DP_Night::TickNight wasn't wired into DPPlayerController OnUpdate.
+//   * The cross-zero detection used `< 0` instead of `<= 0` and
+//     missed the exact-frame case.
+//   * No dispatch guard -> Dawn fires every frame after timer hits 0.
+//   * StartNight didn't reset the dispatch flag (second run after a
+//     between-tests reset would not fire).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kDW_Start, kDW_WaitScene, kDW_ArmTimer,
+	                   kDW_TickWindow, kDW_Verify, kDW_Done };
+
+	int                     g_iPhase = kDW_Start;
+	int                     g_iDawnCount = 0;
+	int                     g_iTickFrames = 0;
+	bool                    g_bHasDawnFinal = false;
+	float                   g_fRemainingFinal = -1.0f;
+	bool                    g_bActiveFinal = false;
+	Zenith_EventHandle      g_uHandle = 0;
+
+	// 90 frames at fixed dt 0.01666 = ~1.5 s. Night duration 0.5 s
+	// expires around frame 30. 90 frames overshoots by 60 frames so
+	// "dispatched exactly once" is a meaningful assertion (a missing
+	// dispatch-guard would make it ~60).
+	constexpr int kTICK_WINDOW_FRAMES = 90;
+	constexpr float kNIGHT_DURATION_S = 0.5f;
+
+	void OnRunLost(const DP_OnRunLost& xEvt)
+	{
+		if (xEvt.m_eCause == DP_RunLostCause::Dawn)
+		{
+			++g_iDawnCount;
+		}
+	}
+}
+
+static void Setup_P1DawnDispatch()
+{
+	g_iPhase = kDW_Start;
+	g_iDawnCount = 0;
+	g_iTickFrames = 0;
+	g_bHasDawnFinal = false;
+	g_fRemainingFinal = -1.0f;
+	g_bActiveFinal = false;
+	g_uHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P1DawnDispatch(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kDW_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kDW_WaitScene;
+		return true;
+
+	case kDW_WaitScene:
+		// Wait a few frames for DPPlayerController to have OnUpdate
+		// firing (it needs the scene loaded + script attached).
+		if (iFrame > 5)
+		{
+			g_iPhase = kDW_ArmTimer;
+		}
+		return true;
+
+	case kDW_ArmTimer:
+		DP_Night::StartNight(kNIGHT_DURATION_S);
+		g_iTickFrames = 0;
+		g_iPhase = kDW_TickWindow;
+		return true;
+
+	case kDW_TickWindow:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kTICK_WINDOW_FRAMES)
+		{
+			g_iPhase = kDW_Verify;
+		}
+		return true;
+
+	case kDW_Verify:
+		g_bHasDawnFinal = DP_Night::HasDawnReached();
+		g_fRemainingFinal = DP_Night::GetNightTimeRemaining();
+		g_bActiveFinal = DP_Night::IsNightActive();
+		std::printf("[P1DawnDispatch] dawnCount=%d hasDawn=%d remaining=%.3f active=%d (after %d ticks at duration %.3fs)\n",
+			g_iDawnCount, (int)g_bHasDawnFinal, g_fRemainingFinal,
+			(int)g_bActiveFinal, g_iTickFrames, kNIGHT_DURATION_S);
+		std::fflush(stdout);
+		if (g_uHandle != 0)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_uHandle);
+			g_uHandle = 0;
+		}
+		g_iPhase = kDW_Done;
+		return false;
+
+	case kDW_Done:
+	default:
+		if (g_uHandle != 0)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_uHandle);
+			g_uHandle = 0;
+		}
+		return false;
+	}
+}
+
+static bool Verify_P1DawnDispatch()
+{
+	if (g_iDawnCount != 1)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnDispatch: DP_OnRunLost{Dawn} fired %d times, expected exactly 1. >1 means missing dispatch-guard (TickNight refires every frame after 0); 0 means TickNight isn't wired into DPPlayerController OnUpdate or the cross-zero detection failed",
+			g_iDawnCount);
+		return false;
+	}
+	if (!g_bHasDawnFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnDispatch: HasDawnReached() returned false after dispatch -- m_bDawnDispatched flag isn't being set");
+		return false;
+	}
+	if (g_fRemainingFinal != 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnDispatch: GetNightTimeRemaining() = %.3f, expected 0.0 (pinned at 0 after dispatch)",
+			g_fRemainingFinal);
+		return false;
+	}
+	if (!g_bActiveFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnDispatch: IsNightActive() returned false after dispatch -- only Reset/StartNight should clear active, not dispatch");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1DawnDispatchTest = {
+	"Test_P1Dawn_DispatchesRunLost",
+	&Setup_P1DawnDispatch,
+	&Step_P1DawnDispatch,
+	&Verify_P1DawnDispatch,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1DawnDispatchTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Dawn_NoFireWhenNotStarted.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Dawn_NoFireWhenNotStarted.cpp
@@ -1,0 +1,159 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+
+#include "Source/PublicInterfaces.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Dawn_NoFireWhenNotStarted (MVP-1.3.5 Dawn -- negative control)
+//
+// Sibling to Test_P1Dawn_DispatchesRunLost. Verifies that when the
+// player loads the scene but does NOT trigger StartNight (e.g., a
+// gym scene that just exercises mechanics without the full night
+// loop), the night timer stays inactive and DP_OnRunLost{Dawn}
+// never fires.
+//
+// Procedure:
+//   1. Subscribe to DP_OnRunLost in Setup; count Dawn-cause events.
+//   2. Load GameLevel.
+//   3. Do NOT call DP_Night::StartNight.
+//   4. Tick ~120 frames (~2 s of game time) so TickNight is
+//      definitely called many times.
+//   5. Assert:
+//        DawnCount == 0
+//        IsNightActive() == false
+//        HasDawnReached() == false
+//
+// What this catches:
+//   * A regression where TickNight dispatches even when m_bNightActive
+//     is false (i.e., the active-guard was removed).
+//   * A regression where Reset() leaves m_bNightActive true (a
+//     between-tests reset that left state stale).
+//   * Implicit auto-start regression -- some commit that wired
+//     StartNight into a scene-load hook without the menu being ready,
+//     which would surprise tests that don't expect it.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kDN_Start, kDN_WaitScene, kDN_Tick, kDN_Verify, kDN_Done };
+
+	int                     g_iPhase = kDN_Start;
+	int                     g_iDawnCount = 0;
+	int                     g_iTickFrames = 0;
+	bool                    g_bHasDawnFinal = true;   // sentinel
+	bool                    g_bActiveFinal = true;    // sentinel
+	Zenith_EventHandle      g_uHandle = 0;
+
+	constexpr int kTICK_WINDOW_FRAMES = 120;
+
+	void OnRunLost(const DP_OnRunLost& xEvt)
+	{
+		if (xEvt.m_eCause == DP_RunLostCause::Dawn)
+		{
+			++g_iDawnCount;
+		}
+	}
+}
+
+static void Setup_P1DawnNoFire()
+{
+	g_iPhase = kDN_Start;
+	g_iDawnCount = 0;
+	g_iTickFrames = 0;
+	g_bHasDawnFinal = true;
+	g_bActiveFinal = true;
+	g_uHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P1DawnNoFire(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kDN_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kDN_WaitScene;
+		return true;
+
+	case kDN_WaitScene:
+		if (iFrame > 5)
+		{
+			g_iTickFrames = 0;
+			g_iPhase = kDN_Tick;
+		}
+		return true;
+
+	case kDN_Tick:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kTICK_WINDOW_FRAMES)
+		{
+			g_iPhase = kDN_Verify;
+		}
+		return true;
+
+	case kDN_Verify:
+		g_bHasDawnFinal = DP_Night::HasDawnReached();
+		g_bActiveFinal = DP_Night::IsNightActive();
+		std::printf("[P1DawnNoFire] dawnCount=%d hasDawn=%d active=%d (after %d ticks, NO StartNight called)\n",
+			g_iDawnCount, (int)g_bHasDawnFinal, (int)g_bActiveFinal,
+			g_iTickFrames);
+		std::fflush(stdout);
+		if (g_uHandle != 0)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_uHandle);
+			g_uHandle = 0;
+		}
+		g_iPhase = kDN_Done;
+		return false;
+
+	case kDN_Done:
+	default:
+		if (g_uHandle != 0)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_uHandle);
+			g_uHandle = 0;
+		}
+		return false;
+	}
+}
+
+static bool Verify_P1DawnNoFire()
+{
+	if (g_iDawnCount != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnNoFire: DP_OnRunLost{Dawn} fired %d times without StartNight() being called -- TickNight is missing its active-guard or the between-tests reset is broken",
+			g_iDawnCount);
+		return false;
+	}
+	if (g_bHasDawnFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnNoFire: HasDawnReached() returned true without StartNight + tick-to-zero -- state corrupted between tests");
+		return false;
+	}
+	if (g_bActiveFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1DawnNoFire: IsNightActive() returned true without StartNight -- reset hook isn't clearing the flag, or implicit auto-start regression");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1DawnNoFireTest = {
+	"Test_P1Dawn_NoFireWhenNotStarted",
+	&Setup_P1DawnNoFire,
+	&Step_P1DawnNoFire,
+	&Verify_P1DawnNoFire,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1DawnNoFireTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Closes the **Dawn** half of MVP-1.3.5 — the last actionable Phase-1 deferred item. NoVessels half landed in PR #54; this PR ships the night-countdown that fires `DP_OnRunLost{Dawn}` when the timer expires.

With this, the full `DP_RunLostCause` enum (Apprehended, Dawn, NoVessels) has a live dispatch path. **Phase 1 is now substantively complete** — every remaining gap requires Phase-3 assets or post-MVP UI flow.

## API

New `DP_Night` namespace in `PublicInterfaces.h`:

| Function | Notes |
|---|---|
| `StartNight(durationSec)` | Arms the timer. Idempotent: re-arming during an active night resets the timer (the "new run begins" semantic). |
| `TickNight(fDt)` | Per-frame countdown. Cross-zero dispatch fires **exactly once**. Subsequent ticks pin remaining at 0 without re-dispatch. |
| `GetNightTimeRemaining()` | Read for future HUD timer + tests |
| `IsNightActive()` | True after StartNight until Reset |
| `HasDawnReached()` | True after Dawn dispatch |
| `Reset()` | Between-tests cleanup; hooked into existing reset in DevilsPlayground.cpp |

## Wiring

- `DPPlayerController::OnUpdate → DP_Night::TickNight(fDt)`. Quiet no-op until `StartNight` is called.
- Between-tests hook in `DevilsPlayground.cpp` now calls `DP_Night::Reset()`.
- Production "auto-start night on scene entry" path intentionally **not wired** — that's part of the post-MVP menu→game flow. Tests call StartNight directly.

## Tests

| Test | Pins |
|---|---|
| `Test_P1Dawn_DispatchesRunLost` | StartNight(0.5s), tick 90 frames (~3× overshoot of expected dispatch), assert event fired **exactly once** + state flags correct |
| `Test_P1Dawn_NoFireWhenNotStarted` | Load scene WITHOUT StartNight, tick 120 frames, assert no Dawn event + `IsNightActive() == false`. Gives the "exactly once" assertion its teeth (a regression where TickNight ignored the active-guard would dispatch from idle scene state) |

## Test plan

- [x] Both new tests pass in isolation
- [x] Full DP suite green: **83 passed, 0 failed** (81 + 2 new)

## Roadmap impact

Closes the Phase-1 deferred list **completely** for items not blocked on Phase-3 assets:

| Item | Status |
|---|---|
| MVP-1.3.5 Apprehended | ✅ (PR #41) |
| MVP-1.3.5 NoVessels | ✅ (PR #54) |
| **MVP-1.3.5 Dawn** | **✅ this PR** |
| MVP-1.4.1-3 Faint | ✅ (PR #55) |
| MVP-1.4.6 Drop chain | ✅ (PR #52) |
| MVP-1.7.6 Aelfric hearing | ✅ (PR #53) |
| MVP-1.10 Save/load | ✅ (PR #56) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)