### PR TITLE
test(dp): close MVP-1.4 faint state machine recovery coverage gap

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -225,6 +225,8 @@
     <ClCompile Include="..\Tests\Test_P1Dawn_NoFireWhenNotStarted.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_GoesToGroundAtBodyPosition.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_PickupChainHandoff.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Faint_RecoversToIdle.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Faint_SystemPossessBypassesGate.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -98,6 +98,12 @@
     <ClCompile Include="..\Tests\Test_P1Drop_PickupChainHandoff.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Faint_RecoversToIdle.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Faint_SystemPossessBypassesGate.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -519,6 +519,8 @@
     <ClCompile Include="..\Tests\Test_P1Dawn_NoFireWhenNotStarted.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_GoesToGroundAtBodyPosition.cpp" />
     <ClCompile Include="..\Tests\Test_P1Drop_PickupChainHandoff.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Faint_RecoversToIdle.cpp" />
+    <ClCompile Include="..\Tests\Test_P1Faint_SystemPossessBypassesGate.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_PathRespectsWalls.cpp" />
     <ClCompile Include="..\Tests\Test_P1NavMesh_RegenerationOnSceneSwap.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -98,6 +98,12 @@
     <ClCompile Include="..\Tests\Test_P1Drop_PickupChainHandoff.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Faint_RecoversToIdle.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P1Faint_SystemPossessBypassesGate.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P1NavMesh_ClosedDoorBlocksPath.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
@@ -348,6 +348,14 @@ public:
 	// once at authoring and never touches it again.
 	void SetRemainingLifeForTest(float fSeconds) { m_fRemainingLife = fSeconds; }
 
+	// MVP-1.4 test accessor: shortcut the 10s faint-recovery countdown
+	// so Test_P1Faint_RecoversToIdle can verify the Fainted->Idle
+	// transition without ticking 600 frames. The OnUpdate state machine
+	// reads m_fFaintRecoveryRemaining and transitions to Idle on the
+	// frame it reaches 0; the test sets it close to 0 and confirms the
+	// next-frame OnUpdate makes the transition.
+	void SetFaintRecoveryForTest(float fSeconds) { m_fFaintRecoveryRemaining = fSeconds; }
+
 private:
 	void TickLife(float fDt)
 	{

--- a/Games/DevilsPlayground/Tests/Test_P1Faint_RecoversToIdle.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Faint_RecoversToIdle.cpp
@@ -1,0 +1,280 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Faint_RecoversToIdle (MVP-1.4.2 follow-up coverage gap)
+//
+// Test_P1Switch_FaintNotDie proves the Possessed -> Fainted transition
+// fires on voluntary switch. It does NOT prove the Fainted -> Idle
+// recovery (after `possession.voluntary_switch_faint_recovery_s` has
+// elapsed). Without this test, a regression that leaves villagers
+// permanently fainted (timer never decrements, or threshold check
+// inverted) would break the GDD's "demon revisits exhausted vessels"
+// mechanic and slip past CI.
+//
+// Procedure:
+//   1. Load GameLevel; pick two villagers in mutual range.
+//   2. SetPossessedVillager(A); switch to B via TryVoluntary. A goes
+//      Fainted with ~10 s recovery timer.
+//   3. Snapshot A's state (assert Fainted).
+//   4. Shortcut the recovery timer with SetFaintRecoveryForTest(0.005)
+//      -- one frame's tick of fDt (~0.01666) drains it past 0.
+//   5. Wait one frame so the OnUpdate switch's `case Fainted` decrement
+//      runs and transitions A to Idle.
+//   6. Snapshot A's state (assert Idle).
+//   7. Also assert: TryVoluntaryPossessSwitch(A) is now ALLOWED -- the
+//      cooldown has expired (we waited 110+ frames implicitly via the
+//      cooldown wait between SetPossessed and TryVoluntary in step 2).
+//
+// What this catches:
+//   * The Fainted state machine never decrements the timer (timer
+//     stays at 10s forever).
+//   * The Fainted->Idle threshold check uses `>` instead of `<=` (the
+//     transition fires only when fully past 0).
+//   * IsPossessable() still returns false for Idle villagers (the
+//     state-machine transition fired but the gate didn't update).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kFR_Start, kFR_WaitScene, kFR_PossessA, kFR_WaitForA,
+	                   kFR_SwitchToB, kFR_WaitForFaint, kFR_SnapshotFainted,
+	                   kFR_ShortcutTimer, kFR_WaitForRecovery,
+	                   kFR_SnapshotIdle, kFR_TryRepossess, kFR_Verify, kFR_Done };
+
+	int                     g_iPhase = kFR_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	DPVillagerState         g_eAFaintedSnapshot = DPVillagerState::Idle;
+	DPVillagerState         g_eAIdleSnapshot = DPVillagerState::Fainted; // sentinel: must become Idle
+	bool                    g_bRepossessOk = false;
+	int                     g_iCooldownWait = 0;
+
+	// 110 frames * 0.01666s = ~1.83s, just past the 1.5s
+	// voluntary-switch cooldown. We need cooldown clear for the
+	// final repossess-A attempt to pass on a state-only-refusal
+	// rather than a cooldown-refusal.
+	constexpr int kCOOLDOWN_FRAMES = 110;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1FaintRecovers()
+{
+	g_iPhase = kFR_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_eAFaintedSnapshot = DPVillagerState::Idle;
+	g_eAIdleSnapshot = DPVillagerState::Fainted;
+	g_bRepossessOk = false;
+	g_iCooldownWait = 0;
+}
+
+static bool Step_P1FaintRecovers(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kFR_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kFR_WaitScene;
+		return true;
+
+	case kFR_WaitScene:
+		PickClosestPair(g_xA, g_xB);
+		if (g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_iPhase = kFR_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kFR_Done;
+		}
+		return true;
+
+	case kFR_PossessA:
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kFR_WaitForA;
+		return true;
+
+	case kFR_WaitForA:
+		// One frame for A's OnUpdate to run Idle -> Possessed.
+		g_iPhase = kFR_SwitchToB;
+		return true;
+
+	case kFR_SwitchToB:
+		// Player-driven voluntary switch. A becomes Fainted.
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kFR_WaitForFaint;
+		return true;
+
+	case kFR_WaitForFaint:
+		// One frame for A's OnUpdate to run Possessed -> Fainted.
+		g_iPhase = kFR_SnapshotFainted;
+		return true;
+
+	case kFR_SnapshotFainted:
+	{
+		DPVillager_Behaviour* pxA = GetVillagerBehaviour(g_xA);
+		if (pxA != nullptr) g_eAFaintedSnapshot = pxA->GetState();
+		g_iPhase = kFR_ShortcutTimer;
+		return true;
+	}
+
+	case kFR_ShortcutTimer:
+	{
+		// Shortcut: set the recovery timer near 0 so the next frame's
+		// OnUpdate (which decrements fDt of game time) crosses zero.
+		// This avoids ticking 600 frames of real time -- the test
+		// pins the STATE TRANSITION, not the timer duration (which
+		// the tuning test pins separately).
+		DPVillager_Behaviour* pxA = GetVillagerBehaviour(g_xA);
+		if (pxA != nullptr) pxA->SetFaintRecoveryForTest(0.005f);
+		// Also wait out the cooldown from the original switch (we
+		// want the final TryVoluntary to be refused by state, not
+		// cooldown, to prove the assertion has teeth).
+		g_iCooldownWait = 0;
+		g_iPhase = kFR_WaitForRecovery;
+		return true;
+	}
+
+	case kFR_WaitForRecovery:
+		// Tick frames until cooldown is cleared AND recovery fired.
+		// Cooldown clears at ~110 frames; recovery fires on the very
+		// next OnUpdate after kFR_ShortcutTimer, well before then.
+		++g_iCooldownWait;
+		if (g_iCooldownWait >= kCOOLDOWN_FRAMES)
+		{
+			g_iPhase = kFR_SnapshotIdle;
+		}
+		return true;
+
+	case kFR_SnapshotIdle:
+	{
+		DPVillager_Behaviour* pxA = GetVillagerBehaviour(g_xA);
+		if (pxA != nullptr) g_eAIdleSnapshot = pxA->GetState();
+		g_iPhase = kFR_TryRepossess;
+		return true;
+	}
+
+	case kFR_TryRepossess:
+		// Cooldown is clear (waited > 1.5s). A's state is hopefully
+		// Idle. Voluntary switch should succeed if both gates pass.
+		g_bRepossessOk = DP_Player::TryVoluntaryPossessSwitch(g_xA);
+		g_iPhase = kFR_Verify;
+		return true;
+
+	case kFR_Verify:
+		std::printf("[P1FaintRecovers] eAFainted=%d eAIdle=%d repossessOk=%d\n",
+			(int)g_eAFaintedSnapshot, (int)g_eAIdleSnapshot,
+			(int)g_bRepossessOk);
+		std::fflush(stdout);
+		g_iPhase = kFR_Done;
+		return false;
+
+	case kFR_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1FaintRecovers()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1FaintRecovers: villager pair not picked");
+		return false;
+	}
+	if (g_eAFaintedSnapshot != DPVillagerState::Fainted)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintRecovers: A's state after voluntary switch is %d, expected Fainted (precondition for the recovery test)",
+			(int)g_eAFaintedSnapshot);
+		return false;
+	}
+	if (g_eAIdleSnapshot != DPVillagerState::Idle)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintRecovers: A's state after timer shortcut + tick is %d, expected Idle. The Fainted->Idle transition didn't fire -- check the OnUpdate state machine's timer decrement and threshold (must be <= 0, not < 0)",
+			(int)g_eAIdleSnapshot);
+		return false;
+	}
+	if (!g_bRepossessOk)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintRecovers: TryVoluntaryPossessSwitch(A) refused after recovery -- IsPossessable() still returns false for an Idle villager, or the state didn't actually flip");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1FaintRecoversTest = {
+	"Test_P1Faint_RecoversToIdle",
+	&Setup_P1FaintRecovers,
+	&Step_P1FaintRecovers,
+	&Verify_P1FaintRecovers,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1FaintRecoversTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P1Faint_SystemPossessBypassesGate.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Faint_SystemPossessBypassesGate.cpp
@@ -1,0 +1,265 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P1Faint_SystemPossessBypassesGate (MVP-1.4.2 follow-up coverage gap)
+//
+// Sibling to Test_P1Faint_RecoversToIdle. Pins the SYSTEM-PATH bypass
+// of the faint gate: SetPossessedVillager(faintedV) -- a direct write
+// used by tests, editor automation, and future "respawn from save"
+// flows -- wakes the fainted villager into Possessed regardless of
+// the recovery timer.
+//
+// This is intentional asymmetry between paths:
+//   * TryVoluntaryPossessSwitch (player-driven) -- refuses fainted
+//     targets (IsPossessable() gate).
+//   * SetPossessedVillager (system path) -- bypasses the gate. The
+//     OnUpdate state machine's `case Fainted` branch handles the
+//     bIsPossessedThisFrame=true case by transitioning straight to
+//     Possessed and bumping life.
+//
+// Tests pinning the asymmetry catch:
+//   * A regression where SetPossessedVillager picks up the same
+//     IsPossessable check that TryVoluntary uses (which would make
+//     editor automation / save-load unable to restore a possession
+//     where the previous possessed villager was fainted).
+//   * The state-machine OnUpdate handler for `case Fainted` +
+//     bIsPossessedThisFrame missing entirely (in which case the
+//     villager's state stays Fainted, TickLife/TickMovement don't
+//     run, and the player thinks they're possessing a non-functional
+//     body).
+//
+// Procedure:
+//   1. Load GameLevel; pick two villagers in mutual range.
+//   2. SetPossessedVillager(A); switch to B via TryVoluntary. A goes
+//      Fainted.
+//   3. Wait one frame for A's OnUpdate to set state=Fainted.
+//   4. SetPossessedVillager(A) -- system path bypass.
+//   5. Wait one frame so A's OnUpdate `case Fainted +
+//      bIsPossessedThisFrame=true` branch runs.
+//   6. Assert:
+//        A.state == Possessed       (transitioned)
+//        A.life == m_fMaxLife       (life bumped on transition)
+//        A.faintTimer == 0          (timer cleared)
+//        IsPossessed() == true      (legacy flag updated)
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kBP_Start, kBP_WaitScene, kBP_PossessA, kBP_WaitForA,
+	                   kBP_SwitchToB, kBP_WaitForFaint, kBP_PossessAViaSystem,
+	                   kBP_WaitForWake, kBP_Verify, kBP_Done };
+
+	int                     g_iPhase = kBP_Start;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	DPVillagerState         g_eAStateFinal = DPVillagerState::Idle;
+	float                   g_fALifeFinal = 0.0f;
+	float                   g_fAMaxLifeFinal = 0.0f;
+	float                   g_fAFaintTimerFinal = -1.0f;
+	bool                    g_bAIsPossessedFinal = false;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P1FaintBypass()
+{
+	g_iPhase = kBP_Start;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_eAStateFinal = DPVillagerState::Idle;
+	g_fALifeFinal = 0.0f;
+	g_fAMaxLifeFinal = 0.0f;
+	g_fAFaintTimerFinal = -1.0f;
+	g_bAIsPossessedFinal = false;
+}
+
+static bool Step_P1FaintBypass(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kBP_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kBP_WaitScene;
+		return true;
+
+	case kBP_WaitScene:
+		PickClosestPair(g_xA, g_xB);
+		if (g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_iPhase = kBP_PossessA;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kBP_Done;
+		}
+		return true;
+
+	case kBP_PossessA:
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kBP_WaitForA;
+		return true;
+
+	case kBP_WaitForA:
+		g_iPhase = kBP_SwitchToB;
+		return true;
+
+	case kBP_SwitchToB:
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kBP_WaitForFaint;
+		return true;
+
+	case kBP_WaitForFaint:
+		// One frame for A's OnUpdate to run Possessed -> Fainted.
+		g_iPhase = kBP_PossessAViaSystem;
+		return true;
+
+	case kBP_PossessAViaSystem:
+		// SYSTEM PATH bypass. A is Fainted; SetPossessedVillager
+		// should overwrite DP_Player's possessed handle to A. On the
+		// next OnUpdate, A's state-machine `case Fainted +
+		// bIsPossessedThisFrame=true` branch transitions to Possessed
+		// and bumps life.
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kBP_WaitForWake;
+		return true;
+
+	case kBP_WaitForWake:
+		// One frame for A's OnUpdate to observe possession and run the
+		// Fainted -> Possessed transition (system bypass branch).
+		g_iPhase = kBP_Verify;
+		return true;
+
+	case kBP_Verify:
+	{
+		DPVillager_Behaviour* pxA = GetVillagerBehaviour(g_xA);
+		if (pxA != nullptr)
+		{
+			g_eAStateFinal = pxA->GetState();
+			g_fALifeFinal = pxA->GetRemainingLife();
+			g_fAMaxLifeFinal = pxA->GetMaxLife();
+			g_fAFaintTimerFinal = pxA->GetFaintRecoveryRemaining();
+			g_bAIsPossessedFinal = pxA->IsPossessed();
+		}
+		std::printf("[P1FaintBypass] state=%d life=%.2f/%.2f faintTimer=%.3f isPossessed=%d\n",
+			(int)g_eAStateFinal, g_fALifeFinal, g_fAMaxLifeFinal,
+			g_fAFaintTimerFinal, (int)g_bAIsPossessedFinal);
+		std::fflush(stdout);
+		g_iPhase = kBP_Done;
+		return false;
+	}
+
+	case kBP_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P1FaintBypass()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P1FaintBypass: villager pair not picked");
+		return false;
+	}
+	if (g_eAStateFinal != DPVillagerState::Possessed)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintBypass: A's state after system-path SetPossessedVillager is %d, expected Possessed. Either the state-machine `case Fainted + bIsPossessedThisFrame=true` branch is missing, or SetPossessedVillager itself failed",
+			(int)g_eAStateFinal);
+		return false;
+	}
+	if (g_fALifeFinal < g_fAMaxLifeFinal - 0.05f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintBypass: A's life after wake is %.2f but maxLife is %.2f -- the Fainted->Possessed transition forgot to bump life. (Tolerance 0.05 absorbs one frame of TickLife drain after the bump.)",
+			g_fALifeFinal, g_fAMaxLifeFinal);
+		return false;
+	}
+	if (g_fAFaintTimerFinal != 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintBypass: A's faint timer after wake is %.3f, expected 0 (timer should clear on Fainted->Possessed bypass)",
+			g_fAFaintTimerFinal);
+		return false;
+	}
+	if (!g_bAIsPossessedFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P1FaintBypass: IsPossessed() returns false but state is Possessed -- the m_bIsPossessed legacy flag sync after the state-machine update is broken");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP1FaintBypassTest = {
+	"Test_P1Faint_SystemPossessBypassesGate",
+	&Setup_P1FaintBypass,
+	&Step_P1FaintBypass,
+	&Verify_P1FaintBypass,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP1FaintBypassTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Audit identified two untested transitions in the faint state machine landed by PR #55:

1. **`Fainted → Idle`** on timer expiry (10 s recovery)
2. **`Fainted → Possessed`** via `SetPossessedVillager` (system bypass)

Without these tests:
- A regression that never decrements `m_fFaintRecoveryRemaining` would leave villagers permanently fainted (breaks GDD's "demon revisits exhausted vessels" mechanic)
- A regression that adds an `IsPossessable` gate to the system path would break editor automation + future save-load restore

## Changes

| Element | Note |
|---|---|
| `DPVillager_Behaviour::SetFaintRecoveryForTest(float)` | Test-only setter — lets the recovery test shortcut the 10 s wait without ticking 600 frames. Matches the existing `SetRemainingLifeForTest` pattern. |
| `Test_P1Faint_RecoversToIdle` | Voluntary-switch A away → A is Fainted → set timer near 0 → tick one frame → A is Idle AND `TryVoluntaryPossessSwitch(A)` succeeds. Full round-trip through the state transition AND the `IsPossessable` gate update. |
| `Test_P1Faint_SystemPossessBypassesGate` | Voluntary-switch A away → A is Fainted → `SetPossessedVillager(A)` → state=Possessed AND life bumped AND faintTimer cleared AND `IsPossessed()` true. Pins the intentional asymmetry. |

## Test plan

- [x] Both new tests pass in isolation
- [x] Full DP suite green: **86 passed, 0 failed**

## Why this matters

The state machine has 4 transitions. With this PR, all 4 are tested:

| Transition | Tested by |
|---|---|
| Idle → Possessed | LifeTimer_Test, Possession_RoundTrip_Test |
| Possessed → Fainted | Test_P1Switch_FaintNotDie |
| Possessed → Dead | Test_P1Switch_BurnOutDoesDie, VillagerDeath_Test |
| **Fainted → Idle** | **Test_P1Faint_RecoversToIdle (this PR)** |
| **Fainted → Possessed** | **Test_P1Faint_SystemPossessBypassesGate (this PR)** |
| Dead → * | (terminal — no transition) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)