### PR TITLE
test(dp): MVP-2.4.{3,4} -- fog GDD-contract regression guards

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -261,6 +261,8 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_BeggarIgnoredByAelfric.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_ChildCannotCarryTools.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -206,6 +206,12 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -555,6 +555,8 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_BeggarIgnoredByAelfric.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_ChildCannotCarryTools.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -206,6 +206,12 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Tests/Test_P2Fog_AelfricNotRevealed.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Fog_AelfricNotRevealed.cpp
@@ -1,0 +1,197 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/Priest_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P2Fog_AelfricNotRevealed (MVP-2.4.3)
+//
+// Pins the GDD §4.6 contract: "Aelfric does not carve a fog hole."
+// The fog system reveals the area around possessed/un-possessed
+// villagers and around lights -- but the priest (Aelfric) must
+// remain invisible in fog, so the player can't read the priest's
+// position through fog when he's outside their direct sight cone.
+// This is a core piece of the horror loop: the priest hunts you in
+// the dark.
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Find the priest entity.
+//   3. Tick a few frames so DPFogPass_Behaviour::OnUpdate runs at
+//      least once (which clears + rebuilds the fog hole table).
+//   4. Snapshot the priest's world position.
+//   5. Gather every fog hole's position via DP_Fog::GatherFogHolePositions.
+//   6. Assert: no fog hole is centered within 0.5 m of the priest's
+//      position (i.e., no fog hole was registered for the priest
+//      entity).
+//
+// What this catches:
+//   * A regression where DPFogPass starts iterating Priest_Behaviour
+//     scripts in the same loop as DPVillager_Behaviour and registers
+//     a hole for the priest.
+//   * A regression where the priest is given a light component (e.g.,
+//     a lantern in a future visual polish pass) and the light-fog-hole
+//     code path accidentally also reveals the priest's silhouette.
+//     If/when the priest legitimately gets a lantern, the fog system
+//     needs explicit logic to size the lantern hole conservatively or
+//     skip it entirely -- this test surfaces that decision rather
+//     than letting it slip in silently.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kFR_Start, kFR_WaitScene, kFR_Tick, kFR_Snapshot,
+	                   kFR_Verify, kFR_Done };
+
+	int                     g_iPhase = kFR_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_Maths::Vector3   g_xPriestPos(0.0f);
+	uint32_t                g_uHoleCount = 0;
+	float                   g_fClosestHoleDist = 1e30f;
+	int                     g_iTickFrames = 0;
+
+	// 10 frames is plenty for DPFogPass::OnUpdate to run at least
+	// once. The fog hole table is cleared-and-rebuilt each frame so
+	// we only need one OnUpdate firing.
+	constexpr int kTICK_FRAMES = 10;
+	// 64 covers GameLevel's 17 villagers + ~30 lights with margin.
+	constexpr uint32_t kMAX_HOLES = 64;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+}
+
+static void Setup_P2FogAelfricNotRevealed()
+{
+	g_iPhase = kFR_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xPriestPos = Zenith_Maths::Vector3(0.0f);
+	g_uHoleCount = 0;
+	g_fClosestHoleDist = 1e30f;
+	g_iTickFrames = 0;
+}
+
+static bool Step_P2FogAelfricNotRevealed(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kFR_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kFR_WaitScene;
+		return true;
+
+	case kFR_WaitScene:
+	{
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFound](Zenith_EntityID xId, Priest_Behaviour&)
+			{ xFound = xId; });
+		if (xFound.IsValid())
+		{
+			g_xPriest = xFound;
+			g_iPhase = kFR_Tick;
+			g_iTickFrames = 0;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kFR_Done;
+		}
+		return true;
+	}
+
+	case kFR_Tick:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kTICK_FRAMES) g_iPhase = kFR_Snapshot;
+		return true;
+
+	case kFR_Snapshot:
+	{
+		TryGetEntityPos(g_xPriest, g_xPriestPos);
+		Zenith_Maths::Vector4 axHoles[kMAX_HOLES];
+		g_uHoleCount = DP_Fog::GatherFogHolePositions(axHoles, kMAX_HOLES);
+		// For every hole, compute horizontal distance to priest.
+		// Track the closest one; the assertion checks it against a
+		// "is this centered ON the priest?" threshold.
+		for (uint32_t u = 0; u < g_uHoleCount; ++u)
+		{
+			const float fDx = axHoles[u].x - g_xPriestPos.x;
+			const float fDz = axHoles[u].z - g_xPriestPos.z;
+			const float fDist = std::sqrt(fDx * fDx + fDz * fDz);
+			if (fDist < g_fClosestHoleDist) g_fClosestHoleDist = fDist;
+		}
+		std::printf("[P2FogAelfricNotRevealed] priestPos=(%.2f,%.2f,%.2f) holes=%u closestHoleDist=%.3f\n",
+			g_xPriestPos.x, g_xPriestPos.y, g_xPriestPos.z,
+			g_uHoleCount, g_fClosestHoleDist);
+		std::fflush(stdout);
+		g_iPhase = kFR_Verify;
+		return true;
+	}
+
+	case kFR_Verify:
+		g_iPhase = kFR_Done;
+		return false;
+
+	case kFR_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P2FogAelfricNotRevealed()
+{
+	if (!g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2FogAelfricNotRevealed: priest not found in GameLevel");
+		return false;
+	}
+	if (g_uHoleCount == 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2FogAelfricNotRevealed: no fog holes registered at all -- DPFogPass_Behaviour didn't OnUpdate, or there are no villagers/lights in GameLevel. Test pre-condition failed");
+		return false;
+	}
+	// 0.5 m threshold: if a fog hole's CENTER is within half a metre
+	// of the priest, that hole is "on" the priest. The closest other
+	// villager / light is much farther (smallest authored spacing
+	// is several metres). A regression that registered a hole for
+	// the priest entity would put distance == 0 -- well below 0.5.
+	const float fAelfricRevealedThreshold = 0.5f;
+	if (g_fClosestHoleDist < fAelfricRevealedThreshold)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2FogAelfricNotRevealed: a fog hole was registered within %.3f m of the priest (threshold %.3f). DPFogPass_Behaviour is revealing the priest, breaking the GDD's 'Aelfric does not carve a hole' contract",
+			g_fClosestHoleDist, fAelfricRevealedThreshold);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2FogAelfricNotRevealedTest = {
+	"Test_P2Fog_AelfricNotRevealed",
+	&Setup_P2FogAelfricNotRevealed,
+	&Step_P2FogAelfricNotRevealed,
+	&Verify_P2FogAelfricNotRevealed,
+	120
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2FogAelfricNotRevealedTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P2Fog_LightAddsHole.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Fog_LightAddsHole.cpp
@@ -1,0 +1,174 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_LightComponent.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_P2Fog_LightAddsHole (MVP-2.4.4)
+//
+// Pins the "lights contribute fog holes" half of the GDD §4.6 fog
+// contract. After DPFogPass_Behaviour::OnUpdate runs, the registered
+// fog hole count equals (villager count) + (light count) -- no more,
+// no less. Counts are taken from the active scene.
+//
+// Procedure:
+//   1. Load GameLevel.
+//   2. Tick a few frames so DPFogPass_Behaviour::OnUpdate runs at
+//      least once (rebuilds the table from scratch each frame).
+//   3. Count villagers via DP_Query::ForEachScriptInActiveScene.
+//   4. Count lights via the scene's Query<Zenith_LightComponent>.
+//   5. Get DP_Fog::GetFogHoleCount().
+//   6. Assert holeCount == villagerCount + lightCount.
+//
+// Why exact equality (not >=): excess holes mean something is being
+// added that shouldn't be. The priest entity would show up here if
+// `Test_P2Fog_AelfricNotRevealed`'s assertion failed -- but that
+// test catches the priest case specifically. This test catches:
+//   * A bug where the same entity gets registered twice in one frame
+//     (loop without `if not already there` guard, OR the produced-
+//     hole-table not getting cleared each frame).
+//   * A future entity type (e.g., flames, traps) being added to the
+//     rebuild loop without intent. Surface those decisions in PRs
+//     rather than letting them silently inflate the count.
+//
+// What this does NOT pin (deferred to MVP-2.4.5 Memory Fog work):
+//   * Hole RADIUS per producer. The current code uses 3 m for every
+//     villager (possessed or not) and `light.Range + slop` for lights.
+//     The GDD spec is 8m possessed / 1.5m un-possessed -- that's
+//     MVP-2.4.3 follow-up work, not a regression guard.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kFL_Start, kFL_WaitScene, kFL_Tick, kFL_Count,
+	                   kFL_Verify, kFL_Done };
+
+	int                     g_iPhase = kFL_Start;
+	int                     g_iVillagerCount = 0;
+	int                     g_iLightCount = 0;
+	uint32_t                g_uHoleCount = 0;
+	int                     g_iTickFrames = 0;
+
+	constexpr int kTICK_FRAMES = 10;
+}
+
+static void Setup_P2FogLightAddsHole()
+{
+	g_iPhase = kFL_Start;
+	g_iVillagerCount = 0;
+	g_iLightCount = 0;
+	g_uHoleCount = 0;
+	g_iTickFrames = 0;
+}
+
+static bool Step_P2FogLightAddsHole(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kFL_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kFL_WaitScene;
+		return true;
+
+	case kFL_WaitScene:
+	{
+		// Wait until at least one villager exists (proxy for "scene
+		// fully OnAwoken").
+		int iCount = 0;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&iCount](Zenith_EntityID, DPVillager_Behaviour&) { ++iCount; });
+		if (iCount > 0)
+		{
+			g_iPhase = kFL_Tick;
+			g_iTickFrames = 0;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kFL_Done;
+		}
+		return true;
+	}
+
+	case kFL_Tick:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kTICK_FRAMES) g_iPhase = kFL_Count;
+		return true;
+
+	case kFL_Count:
+	{
+		// Count villagers and lights using the same loops DPFogPass
+		// uses internally, so a mismatch means producers <-> consumer
+		// disagree on what's in scope.
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[](Zenith_EntityID, DPVillager_Behaviour&) { ++g_iVillagerCount; });
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene != nullptr)
+		{
+			pxScene->Query<Zenith_LightComponent>().ForEach(
+				[](Zenith_EntityID, Zenith_LightComponent&) { ++g_iLightCount; });
+		}
+		g_uHoleCount = DP_Fog::GetFogHoleCount();
+		std::printf("[P2FogLightAddsHole] villagers=%d lights=%d holes=%u (expected %d)\n",
+			g_iVillagerCount, g_iLightCount, g_uHoleCount,
+			g_iVillagerCount + g_iLightCount);
+		std::fflush(stdout);
+		g_iPhase = kFL_Verify;
+		return true;
+	}
+
+	case kFL_Verify:
+		g_iPhase = kFL_Done;
+		return false;
+
+	case kFL_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P2FogLightAddsHole()
+{
+	if (g_iVillagerCount == 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2FogLightAddsHole: no villagers iterated -- scene precondition failed");
+		return false;
+	}
+	if (g_iLightCount == 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2FogLightAddsHole: no lights iterated in GameLevel -- the test premise (lights contribute holes) can't be verified without at least one light. Check scene authoring");
+		return false;
+	}
+	const uint32_t uExpected =
+		static_cast<uint32_t>(g_iVillagerCount + g_iLightCount);
+	if (g_uHoleCount != uExpected)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2FogLightAddsHole: GetFogHoleCount=%u, expected %u (villagers=%d + lights=%d). Excess holes implies an unintended producer (e.g., priest leaked in); fewer holes implies a producer dropped entries (e.g., light loop bailed early)",
+			g_uHoleCount, uExpected, g_iVillagerCount, g_iLightCount);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2FogLightAddsHoleTest = {
+	"Test_P2Fog_LightAddsHole",
+	&Setup_P2FogLightAddsHole,
+	&Step_P2FogLightAddsHole,
+	&Verify_P2FogLightAddsHole,
+	120
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2FogLightAddsHoleTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

`DPFogPass_Behaviour` was substantively complete from earlier work — the prototype's fog system already maintains the per-frame hole table for villagers + lights. The roadmap-listed audit (2.4.3 / 2.4.4) was test-coverage-only, deferred until now. This PR adds the regression guards.

## What lands

| Test | MVP-Roadmap | Pins |
|---|---|---|
| `Test_P2Fog_AelfricNotRevealed` | 2.4.3 | GDD §4.6: "Aelfric does not carve a fog hole." Find priest, gather every fog hole position, assert closest hole to priest is ≥ 0.5 m away. |
| `Test_P2Fog_LightAddsHole` | 2.4.4 | `GetFogHoleCount() == villagers + lights` **exactly**. Catches double-registration AND unintended new producers (e.g., a future entity type added to the rebuild loop without intent). |

## What's NOT pinned by this PR

Hole **radius** per producer. Current code uses 3 m fixed for every villager; GDD spec is 8 m possessed / 1.5 m un-possessed. That's a tuning change, not a regression-guard test, so it lives in its own follow-up PR.

## Test plan

- [x] Both tests pass in isolation
- [x] Full DP suite green: **88 passed, 0 failed**

## Roadmap impact

Closes MVP-2.4.3 + MVP-2.4.4. Remaining Phase-2 fog item: 2.4.5 Memory fog (substantive new code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)