### PR TITLE
feat(dp): MVP-2.1.{1,2} -- Devout possession channel + priest interrupt

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -260,6 +260,8 @@
     <ClCompile Include="..\Tests\Test_P1WalkQuiet_FootstepLoudnessHalved.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_BeggarIgnoredByAelfric.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_ChildCannotCarryTools.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannel.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannelInterrupt.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -203,6 +203,12 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_ChildCannotCarryTools.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannel.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannelInterrupt.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -554,6 +554,8 @@
     <ClCompile Include="..\Tests\Test_P1WalkQuiet_FootstepLoudnessHalved.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_BeggarIgnoredByAelfric.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_ChildCannotCarryTools.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannel.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannelInterrupt.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -203,6 +203,12 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_ChildCannotCarryTools.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannel.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannelInterrupt.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
@@ -58,6 +58,11 @@ public:
 		DP_Player::TickDemonScent(fDt);
 		DP_Player::WriteHighestScentToBlackboard();
 
+		// MVP-2.1.1/2 Devout channel: per-frame countdown + priest
+		// interrupt check. Quiet no-op until TryVoluntaryPossessSwitch
+		// starts a channel onto a Devout target.
+		DP_Player::TickChannel(fDt);
+
 		// MVP-1.3.5 Dawn: tick the night-timer countdown. Quiet
 		// no-op until DP_Night::StartNight has been called (production
 		// path: scene-entry hook or future Begin-Run menu; test path:

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -14,6 +14,7 @@
 
 #include "DP_Tuning.h"
 #include "../Components/DPVillager_Behaviour.h"
+#include "../Components/Priest_Behaviour.h"
 
 #include <unordered_map>
 
@@ -53,6 +54,14 @@ namespace
 	// indices (the generation counter survives the pack). Reads are
 	// done via GetDemonScent which returns 0 for missing entries.
 	std::unordered_map<uint64_t, float> g_xDemonScent;
+
+	// MVP-2.1.1 Devout channel state. Set by TryVoluntaryPossessSwitch
+	// when the target is Devout (and channel_devout_s > 0). Decremented
+	// by TickChannel per frame. Cleared by completion, InterruptChannel,
+	// or ResetForTest.
+	Zenith_EntityID g_xChannelTarget   = INVALID_ENTITY_ID;
+	float           g_fChannelRemaining = 0.0f;
+	bool            g_bChannelActive    = false;
 
 #ifdef ZENITH_INPUT_SIMULATOR
 	// MVP-1.9: test-build omniscient fallback toggle. Default ON so
@@ -148,6 +157,46 @@ namespace DP_Player
 		}
 	}
 
+	// Internal helper used by both the immediate-possession path and
+	// the channel-completion path. Updates possessed handle, sets
+	// anchor, arms cooldown, bumps scent. Caller is responsible for
+	// having already passed the gates (cooldown / state / range).
+	static void CommitVoluntaryPossession(
+		Zenith_EntityID xId,
+		const Zenith_Maths::Vector3& xNewPos,
+		bool bGotNewPos)
+	{
+		g_xPossessedVillager = xId;
+		g_fPossessionCooldownRemaining =
+			DP_Tuning::Get<float>("possession.cooldown_after_voluntary_switch_s");
+
+		if (bGotNewPos)
+		{
+			g_xPossessionAnchor = xNewPos;
+			g_bHasPossessionAnchor = true;
+		}
+		else
+		{
+			g_bHasPossessionAnchor = false;
+		}
+
+		// MVP-1.6 scent: only successful possession bumps. Tuning.json's
+		// scent comment explicitly says channel-interrupted switches
+		// produce no scent -- so the bump lives on this commit path,
+		// not on TryVoluntaryPossessSwitch's entry.
+		if (xId.IsValid())
+		{
+			const float fPerPossession =
+				DP_Tuning::Get<float>("possession.demon_scent_per_possession");
+			const float fMaxScent =
+				DP_Tuning::Get<float>("possession.demon_scent_max");
+			const uint64_t uKey = PackEntityID(xId);
+			float fNew = g_xDemonScent[uKey] + fPerPossession;
+			if (fNew > fMaxScent) fNew = fMaxScent;
+			g_xDemonScent[uKey] = fNew;
+		}
+	}
+
 	bool TryVoluntaryPossessSwitch(Zenith_EntityID xId)
 	{
 		// Idempotent re-click: clicking the same villager you're already
@@ -159,6 +208,23 @@ namespace DP_Player
 			&& xId.m_uGeneration == g_xPossessedVillager.m_uGeneration)
 		{
 			return true;
+		}
+
+		// MVP-2.1.1: refuse a new switch attempt while a Devout channel
+		// is in progress. Idempotent re-click on the SAME channel
+		// target is also a no-op (the channel continues). A different
+		// target is refused so spam-clicks during channel don't
+		// confuse the state machine.
+		if (g_bChannelActive)
+		{
+			if (xId.IsValid()
+				&& g_xChannelTarget.IsValid()
+				&& xId.m_uIndex == g_xChannelTarget.m_uIndex
+				&& xId.m_uGeneration == g_xChannelTarget.m_uGeneration)
+			{
+				return true;
+			}
+			return false;
 		}
 
 		// Cooldown gate. Death/apprehend never set the cooldown, so a
@@ -210,40 +276,129 @@ namespace DP_Player
 			}
 		}
 
-		g_xPossessedVillager = xId;
-		g_fPossessionCooldownRemaining =
-			DP_Tuning::Get<float>("possession.cooldown_after_voluntary_switch_s");
-
-		// Update the anchor to the new villager so the next voluntary
-		// hop's range is measured from where the player jumped TO, not
-		// where they jumped FROM. (Matches "demon-hop chain" semantics:
-		// each successful possession defines a new anchor circle.)
-		if (bGotNewPos)
-		{
-			g_xPossessionAnchor = xNewPos;
-			g_bHasPossessionAnchor = true;
-		}
-		else
-		{
-			g_bHasPossessionAnchor = false;
-		}
-
-		// MVP-1.6: accumulate scent on the freshly-possessed villager.
-		// Saturates at "possession.demon_scent_max" (1.0 default). The
-		// scent decays via TickDemonScent, which DPPlayerController
-		// drives once per frame.
+		// MVP-2.1.1: Devout channel dispatch. If the target's archetype
+		// has a non-zero channel duration, start the channel instead
+		// of committing immediately. The possession stays on the SOURCE
+		// villager until TickChannel completes the timer (and dispatches
+		// to CommitVoluntaryPossession). Non-Devout (channel_default_s
+		// = 0) commits immediately.
+		float fChannelSec = DP_Tuning::Get<float>("possession.channel_default_s");
 		if (xId.IsValid())
 		{
-			const float fPerPossession =
-				DP_Tuning::Get<float>("possession.demon_scent_per_possession");
-			const float fMaxScent =
-				DP_Tuning::Get<float>("possession.demon_scent_max");
-			const uint64_t uKey = PackEntityID(xId);
-			float fNew = g_xDemonScent[uKey] + fPerPossession;
-			if (fNew > fMaxScent) fNew = fMaxScent;
-			g_xDemonScent[uKey] = fNew;
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+			if (pxScene != nullptr)
+			{
+				Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+				if (xEnt.IsValid() && xEnt.HasComponent<Zenith_ScriptComponent>())
+				{
+					DPVillager_Behaviour* pxV =
+						xEnt.GetComponent<Zenith_ScriptComponent>()
+							.GetScript<DPVillager_Behaviour>();
+					if (pxV != nullptr && pxV->GetArchetypeId() == "Devout")
+					{
+						fChannelSec = DP_Tuning::Get<float>("possession.channel_devout_s");
+					}
+				}
+			}
 		}
+
+		if (fChannelSec > 0.0f)
+		{
+			// Start channel; commit deferred to TickChannel. Possession
+			// state stays on the SOURCE villager (g_xPossessedVillager
+			// unchanged) so a priest still pursues the original body.
+			g_xChannelTarget    = xId;
+			g_fChannelRemaining = fChannelSec;
+			g_bChannelActive    = true;
+			return true;
+		}
+
+		// Immediate commit path (non-Devout, channel = 0).
+		CommitVoluntaryPossession(xId, xNewPos, bGotNewPos);
 		return true;
+	}
+
+	// MVP-2.1.1/2 Devout channel API.
+	bool IsChanneling()
+	{
+		return g_bChannelActive;
+	}
+
+	Zenith_EntityID GetChannelTarget()
+	{
+		return g_xChannelTarget;
+	}
+
+	float GetChannelRemaining()
+	{
+		return g_fChannelRemaining;
+	}
+
+	void InterruptChannel()
+	{
+		if (!g_bChannelActive) return;
+		g_bChannelActive    = false;
+		g_xChannelTarget    = INVALID_ENTITY_ID;
+		g_fChannelRemaining = 0.0f;
+		// NOTE: cooldown is NOT armed on interrupt (Tuning.json's
+		// scent comment specifies channel-interrupted switches produce
+		// no scent + no cooldown). The player can immediately retry
+		// onto a different villager.
+	}
+
+	void TickChannel(float fDt)
+	{
+		if (!g_bChannelActive) return;
+
+		// MVP-2.1.2 interrupt check: any priest within
+		// channel_interrupt_distance_m of the channel target cancels
+		// the channel before the timer runs down. The check runs
+		// BEFORE the timer decrement so even the completion frame can
+		// be interrupted.
+		Zenith_Maths::Vector3 xTargetPos(0.0f);
+		const bool bGotTargetPos =
+			g_xChannelTarget.IsValid()
+			&& TryGetVillagerPos(g_xChannelTarget, xTargetPos);
+		if (bGotTargetPos)
+		{
+			const float fInterruptDist =
+				DP_Tuning::Get<float>("possession.channel_interrupt_distance_m");
+			bool bInterrupted = false;
+			DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+				[&bInterrupted, &xTargetPos, fInterruptDist]
+				(Zenith_EntityID xPriestId, Priest_Behaviour&)
+				{
+					if (bInterrupted) return;
+					Zenith_Maths::Vector3 xPriestPos;
+					if (!TryGetVillagerPos(xPriestId, xPriestPos)) return;
+					const float fDx = xPriestPos.x - xTargetPos.x;
+					const float fDz = xPriestPos.z - xTargetPos.z;
+					const float fDistSq = fDx * fDx + fDz * fDz;
+					if (fDistSq < fInterruptDist * fInterruptDist)
+					{
+						bInterrupted = true;
+					}
+				});
+			if (bInterrupted)
+			{
+				InterruptChannel();
+				return;
+			}
+		}
+
+		g_fChannelRemaining -= fDt;
+		if (g_fChannelRemaining <= 0.0f)
+		{
+			// Commit the deferred possession.
+			Zenith_EntityID xTarget = g_xChannelTarget;
+			g_bChannelActive    = false;
+			g_xChannelTarget    = INVALID_ENTITY_ID;
+			g_fChannelRemaining = 0.0f;
+			Zenith_Maths::Vector3 xCommitPos(0.0f);
+			const bool bGotPos =
+				xTarget.IsValid() && TryGetVillagerPos(xTarget, xCommitPos);
+			CommitVoluntaryPossession(xTarget, xCommitPos, bGotPos);
+		}
 	}
 
 	void TickPossessionCooldown(float fDt)
@@ -380,6 +535,10 @@ namespace DP_Player
 		g_xPossessionAnchor = Zenith_Maths::Vector3(0.0f);
 		g_bHasPossessionAnchor = false;
 		g_xDemonScent.clear();
+		// MVP-2.1.1 channel state.
+		g_xChannelTarget    = INVALID_ENTITY_ID;
+		g_fChannelRemaining = 0.0f;
+		g_bChannelActive    = false;
 #ifdef ZENITH_INPUT_SIMULATOR
 		// Restore the omniscient fallback default so each batched
 		// test starts from a known state. MVP-1.9 sight tests

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -153,6 +153,38 @@ namespace DP_Player
 	void  TickDemonScent(float fDt);
 	void  WriteHighestScentToBlackboard();
 
+	// MVP-2.1.1: Devout possession channel.
+	//
+	// Devout-archetype villagers don't possess instantly. When the
+	// player TryVoluntaryPossessSwitch's onto a Devout, the call
+	// returns true but possession is NOT committed yet -- instead a
+	// channel timer (`possession.channel_devout_s`, 0.8 s default)
+	// starts, during which the player's possession stays on the
+	// SOURCE villager. TickChannel (called per-frame by
+	// DPPlayerController) decrements the timer; when it reaches 0
+	// the possession commits onto the Devout.
+	//
+	// MVP-2.1.2 interrupt: each TickChannel iteration also scans for
+	// any priest within `possession.channel_interrupt_distance_m`
+	// (6 m default) of the channel TARGET. If found, the channel is
+	// cancelled (InterruptChannel) -- the demon's faith snaps off
+	// the partial possession. The cooldown is NOT consumed on
+	// interrupt, so the player can immediately retry onto another
+	// villager.
+	//
+	// Non-Devout villagers use `channel_default_s` (0 s) -- the
+	// switch commits immediately as before. The Devout-vs-default
+	// branch is internal to TryVoluntaryPossessSwitch.
+	//
+	// Idempotency: TryVoluntaryPossessSwitch refuses while a channel
+	// is in progress (returns false). Wait for completion or
+	// InterruptChannel().
+	bool            IsChanneling();
+	Zenith_EntityID GetChannelTarget();
+	float           GetChannelRemaining();
+	void            TickChannel(float fDt);
+	void            InterruptChannel();
+
 #ifdef ZENITH_INPUT_SIMULATOR
 	// MVP-1.9: opt-in test-only "omniscient fallback" toggle. Pre-1.9,
 	// `Priest_Behaviour::BridgePerceptionToBlackboard` unconditionally

--- a/Games/DevilsPlayground/Tests/Test_P2Archetype_DevoutChannel.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Archetype_DevoutChannel.cpp
@@ -1,0 +1,336 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/Priest_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P2Archetype_DevoutChannel (MVP-2.1.1)
+//
+// Pins the Devout archetype's possession-channel mechanic:
+// TryVoluntaryPossessSwitch onto a Devout starts a 0.8 s channel
+// (per Tuning.json `possession.channel_devout_s`). During the channel:
+//   * Possession stays on the SOURCE villager.
+//   * IsChanneling() returns true; GetChannelTarget() returns the
+//     Devout's handle.
+//   * GetChannelRemaining() decrements toward 0.
+// When the timer reaches 0, the possession COMMITS onto the Devout.
+//
+// The mechanic interacts with the priest pursuit loop: the demon is
+// vulnerable while channeling (still locked to the SOURCE body, which
+// the priest may still be pursuing). MVP-2.1.2 covers the priest-
+// interrupt half; this test just confirms the channel COMPLETES when
+// no priest is close enough to interrupt.
+//
+// Procedure:
+//   1. Load GameLevel. Find priest.
+//   2. Pick 2 villagers in mutual range (A and B).
+//   3. ApplyArchetype("Devout") on B.
+//   4. Teleport the priest FAR from B so no interrupt can fire.
+//   5. SetPossessedVillager(A); wait one frame.
+//   6. TryVoluntaryPossessSwitch(B). Returns true (channel started).
+//   7. Snapshot mid-channel state:
+//        IsChanneling() == true
+//        GetChannelTarget() == B
+//        GetPossessedVillager() == A   (not committed yet)
+//   8. Tick enough frames to drain channel_devout_s + slack.
+//   9. Snapshot post-channel state:
+//        IsChanneling() == false
+//        GetPossessedVillager() == B   (committed)
+//
+// What this catches:
+//   * Devout archetype is treated as immediate (channel duration not
+//     read; non-Devout default of 0 applied).
+//   * Channel commit forgot to update possessed handle (channel
+//     completes but player still possesses source).
+//   * Channel commit forgot to bump scent / anchor / cooldown (these
+//     would surface in downstream tests, but the commit path is the
+//     same `CommitVoluntaryPossession` helper so we get it for free).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kDC_Start, kDC_WaitScene, kDC_TeleportPriest,
+	                   kDC_ApplyArchetype, kDC_PossessA, kDC_WaitForA,
+	                   kDC_StartChannel, kDC_MidSnapshot, kDC_TickChannel,
+	                   kDC_PostSnapshot, kDC_Verify, kDC_Done };
+
+	int                     g_iPhase = kDC_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	bool                    g_bChannelingMid = false;
+	Zenith_EntityID         g_xTargetMid;
+	Zenith_EntityID         g_xPossessedMid;
+	bool                    g_bChannelingPost = true;
+	Zenith_EntityID         g_xPossessedPost;
+	int                     g_iTickCounter = 0;
+	bool                    g_bSwitchReturnedTrue = false;
+
+	// Channel duration is 0.8s; tick 80 frames at fixed-dt 0.01666 =
+	// ~1.33s. Comfortable overshoot.
+	constexpr int kTICK_FRAMES = 80;
+	// Far enough from the Devout to avoid the 6m interrupt distance.
+	constexpr float kPRIEST_AWAY_X = 200.0f;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+
+	void TeleportTo(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+	}
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P2DevoutChannel()
+{
+	g_iPhase = kDC_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_bChannelingMid = false;
+	g_xTargetMid = INVALID_ENTITY_ID;
+	g_xPossessedMid = INVALID_ENTITY_ID;
+	g_bChannelingPost = true;
+	g_xPossessedPost = INVALID_ENTITY_ID;
+	g_iTickCounter = 0;
+	g_bSwitchReturnedTrue = false;
+}
+
+static bool Step_P2DevoutChannel(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kDC_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kDC_WaitScene;
+		return true;
+
+	case kDC_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest](Zenith_EntityID xId, Priest_Behaviour&)
+			{ xFoundPriest = xId; });
+		PickClosestPair(g_xA, g_xB);
+		if (xFoundPriest.IsValid() && g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_xPriest = xFoundPriest;
+			g_iPhase = kDC_TeleportPriest;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kDC_Done;
+		}
+		return true;
+	}
+
+	case kDC_TeleportPriest:
+	{
+		// Teleport priest FAR from B so the interrupt check in
+		// TickChannel doesn't fire during this positive-case test.
+		Zenith_Maths::Vector3 xBPos;
+		if (TryGetEntityPos(g_xB, xBPos))
+		{
+			Zenith_Maths::Vector3 xFar(xBPos.x + kPRIEST_AWAY_X, xBPos.y, xBPos.z);
+			TeleportTo(g_xPriest, xFar);
+		}
+		g_iPhase = kDC_ApplyArchetype;
+		return true;
+	}
+
+	case kDC_ApplyArchetype:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xB);
+		if (pxV != nullptr) pxV->ApplyArchetype("Devout");
+		g_iPhase = kDC_PossessA;
+		return true;
+	}
+
+	case kDC_PossessA:
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kDC_WaitForA;
+		return true;
+
+	case kDC_WaitForA:
+		g_iPhase = kDC_StartChannel;
+		return true;
+
+	case kDC_StartChannel:
+		g_bSwitchReturnedTrue = DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kDC_MidSnapshot;
+		return true;
+
+	case kDC_MidSnapshot:
+		// Snapshot WITHOUT ticking -- we're on the same frame as the
+		// switch call. The channel state should be active and the
+		// possessed handle should still be A.
+		g_bChannelingMid = DP_Player::IsChanneling();
+		g_xTargetMid = DP_Player::GetChannelTarget();
+		g_xPossessedMid = DP_Player::GetPossessedVillager();
+		g_iTickCounter = 0;
+		g_iPhase = kDC_TickChannel;
+		return true;
+
+	case kDC_TickChannel:
+		++g_iTickCounter;
+		if (g_iTickCounter >= kTICK_FRAMES) g_iPhase = kDC_PostSnapshot;
+		return true;
+
+	case kDC_PostSnapshot:
+		g_bChannelingPost = DP_Player::IsChanneling();
+		g_xPossessedPost = DP_Player::GetPossessedVillager();
+		g_iPhase = kDC_Verify;
+		return true;
+
+	case kDC_Verify:
+		std::printf("[P2DevoutChannel] switch=%d mid:chan=%d target=(%u/%u) poss=(%u/%u) post:chan=%d poss=(%u/%u) (expected post=B=(%u/%u))\n",
+			(int)g_bSwitchReturnedTrue,
+			(int)g_bChannelingMid,
+			g_xTargetMid.m_uIndex, g_xTargetMid.m_uGeneration,
+			g_xPossessedMid.m_uIndex, g_xPossessedMid.m_uGeneration,
+			(int)g_bChannelingPost,
+			g_xPossessedPost.m_uIndex, g_xPossessedPost.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		std::fflush(stdout);
+		g_iPhase = kDC_Done;
+		return false;
+
+	case kDC_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P2DevoutChannel()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid() || !g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2DevoutChannel: precondition (priest/villagers) failed");
+		return false;
+	}
+	if (!g_bSwitchReturnedTrue)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutChannel: TryVoluntaryPossessSwitch returned false -- gates rejected the Devout target. Check archetype lookup + cooldown");
+		return false;
+	}
+	// Mid-channel assertions.
+	if (!g_bChannelingMid)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutChannel: IsChanneling() returned false immediately after switch -- channel didn't start. Archetype lookup is failing, or channel_devout_s is 0");
+		return false;
+	}
+	if (g_xTargetMid.m_uIndex != g_xB.m_uIndex
+		|| g_xTargetMid.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutChannel: GetChannelTarget=%u/%u but expected B=%u/%u",
+			g_xTargetMid.m_uIndex, g_xTargetMid.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		return false;
+	}
+	if (g_xPossessedMid.m_uIndex != g_xA.m_uIndex
+		|| g_xPossessedMid.m_uGeneration != g_xA.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutChannel: GetPossessedVillager during channel is %u/%u, expected A=%u/%u -- channel committed prematurely",
+			g_xPossessedMid.m_uIndex, g_xPossessedMid.m_uGeneration,
+			g_xA.m_uIndex, g_xA.m_uGeneration);
+		return false;
+	}
+	// Post-channel assertions.
+	if (g_bChannelingPost)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutChannel: IsChanneling() still true after %d ticks (~%.2fs at fixed-dt) -- TickChannel didn't decrement, or threshold is wrong",
+			kTICK_FRAMES, kTICK_FRAMES * 0.01666f);
+		return false;
+	}
+	if (g_xPossessedPost.m_uIndex != g_xB.m_uIndex
+		|| g_xPossessedPost.m_uGeneration != g_xB.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutChannel: GetPossessedVillager after channel is %u/%u, expected B=%u/%u -- channel timer expired but commit didn't run (or priest interrupted unexpectedly)",
+			g_xPossessedPost.m_uIndex, g_xPossessedPost.m_uGeneration,
+			g_xB.m_uIndex, g_xB.m_uGeneration);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2DevoutChannelTest = {
+	"Test_P2Archetype_DevoutChannel",
+	&Setup_P2DevoutChannel,
+	&Step_P2DevoutChannel,
+	&Verify_P2DevoutChannel,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2DevoutChannelTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P2Archetype_DevoutChannelInterrupt.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Archetype_DevoutChannelInterrupt.cpp
@@ -1,0 +1,313 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DP_Tuning.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/Priest_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P2Archetype_DevoutChannelInterrupt (MVP-2.1.2)
+//
+// Pins the priest-interrupt half of the Devout channel mechanic:
+// while channeling onto a Devout, if a priest is within
+// `possession.channel_interrupt_distance_m` (6 m default) of the
+// channel TARGET, the channel is cancelled and possession stays on
+// the source villager.
+//
+// Procedure:
+//   1. Load GameLevel. Find priest + 2 villagers (A and B).
+//   2. ApplyArchetype("Devout") on B.
+//   3. Teleport priest FAR (200 m away) initially so the channel
+//      starts cleanly.
+//   4. SetPossessedVillager(A); wait one frame.
+//   5. TryVoluntaryPossessSwitch(B). Channel starts.
+//   6. Wait one frame so the channel is mid-flight.
+//   7. Teleport priest to within 1 m of B (well inside the 6 m
+//      interrupt distance).
+//   8. Tick a few frames so TickChannel runs and detects the priest.
+//   9. Assert:
+//        IsChanneling() == false       (channel cancelled)
+//        GetPossessedVillager() == A   (possession DIDN'T commit)
+//        GetChannelTarget() == INVALID (state cleared)
+//
+// What this catches:
+//   * TickChannel doesn't run the priest-distance check.
+//   * Distance check uses the wrong tuning key (or hardcoded value).
+//   * InterruptChannel clears state but leaves m_bChannelActive
+//     true (state inconsistency).
+//   * Interrupt accidentally commits possession (the wrong code
+//     path on cancellation).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kDI_Start, kDI_WaitScene, kDI_TeleportPriestFar,
+	                   kDI_ApplyArchetype, kDI_PossessA, kDI_WaitForA,
+	                   kDI_StartChannel, kDI_WaitOneFrame,
+	                   kDI_TeleportPriestClose, kDI_TickForInterrupt,
+	                   kDI_Snapshot, kDI_Verify, kDI_Done };
+
+	int                     g_iPhase = kDI_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xA;
+	Zenith_EntityID         g_xB;
+	bool                    g_bChannelingFinal = true;  // sentinel: must become false
+	Zenith_EntityID         g_xPossessedFinal;
+	Zenith_EntityID         g_xChannelTargetFinal;
+	int                     g_iTickCounter = 0;
+
+	// 6m default interrupt distance; teleport priest within 1m of B.
+	constexpr float kPRIEST_CLOSE_X = 1.0f;
+	constexpr float kPRIEST_FAR_X = 200.0f;
+	constexpr int kTICK_FRAMES_FOR_INTERRUPT = 5;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	void PickClosestPair(Zenith_EntityID& xA, Zenith_EntityID& xB)
+	{
+		struct VPos { Zenith_EntityID xId; Zenith_Maths::Vector3 xPos; };
+		Zenith_Vector<VPos> axVs;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVs](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				VPos xV; xV.xId = xId;
+				if (TryGetEntityPos(xId, xV.xPos)) axVs.PushBack(xV);
+			});
+		if (axVs.GetSize() < 2) return;
+		float fMin = 1e30f;
+		for (uint32_t i = 0; i < axVs.GetSize(); ++i)
+		for (uint32_t j = i + 1; j < axVs.GetSize(); ++j)
+		{
+			const float fD = HorizontalDistance(axVs.Get(i).xPos, axVs.Get(j).xPos);
+			if (fD < fMin) { fMin = fD; xA = axVs.Get(i).xId; xB = axVs.Get(j).xId; }
+		}
+	}
+
+	void TeleportTo(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+	}
+
+	DPVillager_Behaviour* GetVillagerBehaviour(Zenith_EntityID xId)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return nullptr;
+		if (!xEnt.HasComponent<Zenith_ScriptComponent>()) return nullptr;
+		return xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+	}
+}
+
+static void Setup_P2DevoutInterrupt()
+{
+	g_iPhase = kDI_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xA = INVALID_ENTITY_ID;
+	g_xB = INVALID_ENTITY_ID;
+	g_bChannelingFinal = true;
+	g_xPossessedFinal = INVALID_ENTITY_ID;
+	g_xChannelTargetFinal = INVALID_ENTITY_ID;
+	g_iTickCounter = 0;
+}
+
+static bool Step_P2DevoutInterrupt(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kDI_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kDI_WaitScene;
+		return true;
+
+	case kDI_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest](Zenith_EntityID xId, Priest_Behaviour&)
+			{ xFoundPriest = xId; });
+		PickClosestPair(g_xA, g_xB);
+		if (xFoundPriest.IsValid() && g_xA.IsValid() && g_xB.IsValid())
+		{
+			g_xPriest = xFoundPriest;
+			g_iPhase = kDI_TeleportPriestFar;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kDI_Done;
+		}
+		return true;
+	}
+
+	case kDI_TeleportPriestFar:
+	{
+		// Far enough that the channel starts without immediate interrupt.
+		Zenith_Maths::Vector3 xBPos;
+		if (TryGetEntityPos(g_xB, xBPos))
+		{
+			Zenith_Maths::Vector3 xFar(xBPos.x + kPRIEST_FAR_X, xBPos.y, xBPos.z);
+			TeleportTo(g_xPriest, xFar);
+		}
+		g_iPhase = kDI_ApplyArchetype;
+		return true;
+	}
+
+	case kDI_ApplyArchetype:
+	{
+		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xB);
+		if (pxV != nullptr) pxV->ApplyArchetype("Devout");
+		g_iPhase = kDI_PossessA;
+		return true;
+	}
+
+	case kDI_PossessA:
+		DP_Player::SetPossessedVillager(g_xA);
+		g_iPhase = kDI_WaitForA;
+		return true;
+
+	case kDI_WaitForA:
+		g_iPhase = kDI_StartChannel;
+		return true;
+
+	case kDI_StartChannel:
+		DP_Player::TryVoluntaryPossessSwitch(g_xB);
+		g_iPhase = kDI_WaitOneFrame;
+		return true;
+
+	case kDI_WaitOneFrame:
+		// One frame of channel ticked but not completed (0.8s timer
+		// is ~48 frames at fixed-dt). Verify mid-flight state is sane
+		// by checking we're still channeling -- otherwise the
+		// interrupt would be vacuous.
+		if (!DP_Player::IsChanneling())
+		{
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P2DevoutInterrupt: channel ended before we could teleport priest in -- test scaffolding broken (priest already too close on first tick, or channel didn't start)");
+			g_iPhase = kDI_Done;
+			return false;
+		}
+		g_iPhase = kDI_TeleportPriestClose;
+		return true;
+
+	case kDI_TeleportPriestClose:
+	{
+		// Teleport priest to within 1m of B -- well inside the 6m
+		// interrupt distance.
+		Zenith_Maths::Vector3 xBPos;
+		if (TryGetEntityPos(g_xB, xBPos))
+		{
+			Zenith_Maths::Vector3 xClose(xBPos.x + kPRIEST_CLOSE_X, xBPos.y, xBPos.z);
+			TeleportTo(g_xPriest, xClose);
+		}
+		g_iTickCounter = 0;
+		g_iPhase = kDI_TickForInterrupt;
+		return true;
+	}
+
+	case kDI_TickForInterrupt:
+		++g_iTickCounter;
+		if (g_iTickCounter >= kTICK_FRAMES_FOR_INTERRUPT)
+		{
+			g_iPhase = kDI_Snapshot;
+		}
+		return true;
+
+	case kDI_Snapshot:
+		g_bChannelingFinal = DP_Player::IsChanneling();
+		g_xPossessedFinal = DP_Player::GetPossessedVillager();
+		g_xChannelTargetFinal = DP_Player::GetChannelTarget();
+		g_iPhase = kDI_Verify;
+		return true;
+
+	case kDI_Verify:
+		std::printf("[P2DevoutInterrupt] channeling=%d possessed=(%u/%u) channelTarget=(%u/%u) (expected: channeling=0 possessed=A=(%u/%u) target=INVALID)\n",
+			(int)g_bChannelingFinal,
+			g_xPossessedFinal.m_uIndex, g_xPossessedFinal.m_uGeneration,
+			g_xChannelTargetFinal.m_uIndex, g_xChannelTargetFinal.m_uGeneration,
+			g_xA.m_uIndex, g_xA.m_uGeneration);
+		std::fflush(stdout);
+		g_iPhase = kDI_Done;
+		return false;
+
+	case kDI_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P2DevoutInterrupt()
+{
+	if (!g_xA.IsValid() || !g_xB.IsValid() || !g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2DevoutInterrupt: precondition failed");
+		return false;
+	}
+	if (g_bChannelingFinal)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutInterrupt: IsChanneling() still true after priest got within 1m of channel target -- TickChannel's priest-distance check isn't firing");
+		return false;
+	}
+	if (g_xPossessedFinal.m_uIndex != g_xA.m_uIndex
+		|| g_xPossessedFinal.m_uGeneration != g_xA.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutInterrupt: GetPossessedVillager = %u/%u, expected A=%u/%u -- the channel either committed onto B before interrupt (bad order) or InterruptChannel mutated the possessed handle (bad implementation)",
+			g_xPossessedFinal.m_uIndex, g_xPossessedFinal.m_uGeneration,
+			g_xA.m_uIndex, g_xA.m_uGeneration);
+		return false;
+	}
+	if (g_xChannelTargetFinal.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2DevoutInterrupt: GetChannelTarget returns (%u/%u) after interrupt, expected INVALID -- state not fully cleared",
+			g_xChannelTargetFinal.m_uIndex, g_xChannelTargetFinal.m_uGeneration);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2DevoutInterruptTest = {
+	"Test_P2Archetype_DevoutChannelInterrupt",
+	&Setup_P2DevoutInterrupt,
+	&Step_P2DevoutInterrupt,
+	&Verify_P2DevoutInterrupt,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2DevoutInterruptTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

The Devout archetype's signature mechanic. Switching onto a Devout villager doesn't possess instantly — a **0.8 s channel** (`possession.channel_devout_s`) runs first; possession commits when the timer expires. If a priest gets within **6 m** (`possession.channel_interrupt_distance_m`) of the channel TARGET during the window, the channel is cancelled and possession stays on the source.

This is the demon's ritual vulnerability against pious vessels — mechanically it forces the player to time Devout possessions when the priest is engaged elsewhere. A high-risk / high-flavor trade since Devout villagers have the longest life timer (40 s per Archetypes.json).

## API

| Function | Notes |
|---|---|
| `DP_Player::IsChanneling()` | True while a channel is in flight |
| `DP_Player::GetChannelTarget()` | Channel destination's EntityID |
| `DP_Player::GetChannelRemaining()` | Seconds left on the timer |
| `DP_Player::TickChannel(fDt)` | Per-frame countdown + priest interrupt scan. Wired into DPPlayerController. |
| `DP_Player::InterruptChannel()` | Cancels active channel; public for priest path + tests |

## Implementation highlights

- **Extracted `CommitVoluntaryPossession()` helper** from `TryVoluntaryPossessSwitch` so the immediate-commit path and the channel-completion path share one code path (anchor + cooldown + scent bump).
- **Channel-or-commit dispatch**: TryVoluntaryPossessSwitch looks up the target's archetype. Devout → start channel; everyone else → immediate commit.
- **Refuse-during-channel**: TryVoluntaryPossessSwitch returns false (or idempotent-true if same target) while a channel is active.
- **Interrupt scan**: TickChannel runs `DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>` before the timer decrement; any priest within `channel_interrupt_distance_m` of the channel target triggers `InterruptChannel`.

## Tests

| Test | Scenario | Pins |
|---|---|---|
| `Test_P2Archetype_DevoutChannel` | Priest 200m away, ApplyArchetype("Devout"), TryVoluntary, snapshot mid-channel + tick 80 frames + snapshot post | Mid: channeling=true, target=B, possessed=A. Post: channeling=false, possessed=B. |
| `Test_P2Archetype_DevoutChannelInterrupt` | Same setup, then teleport priest to 1m from B after 1 frame of channel + tick a few more frames | Channeling=false (cancelled), possessed=A (NOT committed), target=INVALID (state cleared) |

The interrupt test has a precondition check that catches the "priest accidentally started in range" scaffolding break.

## Test plan

- [x] Both new tests pass in isolation
- [x] Full DP suite green: **91 passed, 0 failed**

## Roadmap impact

Closes **MVP-2.1.1 + MVP-2.1.2**. Phase 2.1 archetype mechanics are now ✅ complete (Devout, Child no tools, Beggar ignored, Child half-timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)