### PR TITLE
feat(dp): MVP-2.2.{1,2,3} -- reagent registry + per-tag pickup channel

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="..\Source\DPMaterials.h" />
     <ClInclude Include="..\Source\DP_Archetypes.h" />
     <ClInclude Include="..\Source\DP_LevelData.h" />
+    <ClInclude Include="..\Source\DP_Reagents.h" />
     <ClInclude Include="..\Source\DP_Save.h" />
     <ClInclude Include="..\Source\DP_Tuning.h" />
     <ClInclude Include="..\Source\PublicInterfaces.h" />
@@ -196,6 +197,7 @@
     <ClCompile Include="..\Source\DPFogPass.cpp" />
     <ClCompile Include="..\Source\DPMaterials.cpp" />
     <ClCompile Include="..\Source\DP_Archetypes.cpp" />
+    <ClCompile Include="..\Source\DP_Reagents.cpp" />
     <ClCompile Include="..\Source\DP_Save.cpp" />
     <ClCompile Include="..\Source\DP_Tuning.cpp" />
     <ClCompile Include="..\Source\PublicInterfaces.cpp" />
@@ -267,6 +269,7 @@
     <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_IronToSkeletonKey.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -11,6 +11,9 @@
     <ClCompile Include="..\Source\DP_Archetypes.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\DP_Reagents.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source\DP_Save.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -224,6 +227,9 @@
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
@@ -344,6 +350,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DP_LevelData.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DP_Reagents.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DP_Save.h">

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -481,6 +481,7 @@
     <ClInclude Include="..\Source\DPMaterials.h" />
     <ClInclude Include="..\Source\DP_Archetypes.h" />
     <ClInclude Include="..\Source\DP_LevelData.h" />
+    <ClInclude Include="..\Source\DP_Reagents.h" />
     <ClInclude Include="..\Source\DP_Save.h" />
     <ClInclude Include="..\Source\DP_Tuning.h" />
     <ClInclude Include="..\Source\PublicInterfaces.h" />
@@ -490,6 +491,7 @@
     <ClCompile Include="..\Source\DPFogPass.cpp" />
     <ClCompile Include="..\Source\DPMaterials.cpp" />
     <ClCompile Include="..\Source\DP_Archetypes.cpp" />
+    <ClCompile Include="..\Source\DP_Reagents.cpp" />
     <ClCompile Include="..\Source\DP_Save.cpp" />
     <ClCompile Include="..\Source\DP_Tuning.cpp" />
     <ClCompile Include="..\Source\PublicInterfaces.cpp" />
@@ -561,6 +563,7 @@
     <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_IronToSkeletonKey.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp" />
+    <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -11,6 +11,9 @@
     <ClCompile Include="..\Source\DP_Archetypes.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\DP_Reagents.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source\DP_Save.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -224,6 +227,9 @@
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
@@ -344,6 +350,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DP_LevelData.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DP_Reagents.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\DP_Save.h">

--- a/Games/DevilsPlayground/Components/DPItemBase_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPItemBase_Behaviour.h
@@ -20,6 +20,7 @@
 
 #include "Source/PublicInterfaces.h"
 #include "Source/DPMaterials.h"
+#include "Source/DP_Reagents.h"
 #include "Components/DPVillager_Behaviour.h"
 
 class DPItemBase_Behaviour ZENITH_FINAL : Zenith_ScriptBehaviour
@@ -35,6 +36,7 @@ public:
 	{
 		DP_Items::Internal_RegisterItemTag(m_xParentEntity.GetEntityID(), m_eTag);
 		ApplyTagTint();
+		ResolveReagentChannelFromRegistry();
 	}
 
 	void OnStart() ZENITH_FINAL override
@@ -106,6 +108,43 @@ public:
 			}
 		}
 
+		// MVP-2.2.2: per-tag pickup channel. For reagents,
+		// m_fPickupChannelDuration > 0 (loaded from DP_Reagents at
+		// OnAwake); pickup only fires after the villager stays in
+		// range for the full channel duration. For tools / objectives
+		// (channel duration 0), pickup fires immediately.
+		//
+		// State machine on the ITEM:
+		//   * No channel yet: start one with the current villager.
+		//   * Same villager in range: tick down. On 0, fire pickup.
+		//   * Same villager OUT of range: reset (player can walk away
+		//     to cancel mid-channel).
+		//   * Different villager: not a real concern in MVP (only one
+		//     possessed villager at a time); treated as restart.
+		if (m_fPickupChannelDuration > 0.0f)
+		{
+			const bool bSameVillager = m_xChannelingVillager.IsValid()
+				&& m_xChannelingVillager.m_uIndex == xVillager.m_uIndex
+				&& m_xChannelingVillager.m_uGeneration == xVillager.m_uGeneration;
+			if (!bSameVillager)
+			{
+				// Fresh channel.
+				m_xChannelingVillager = xVillager;
+				m_fChannelRemaining = m_fPickupChannelDuration;
+				return;
+			}
+			m_fChannelRemaining -= fDt;
+			if (m_fChannelRemaining > 0.0f)
+			{
+				return; // still channeling
+			}
+			// Channel complete: fall through to the SetHeldItem block
+			// below. Reset state so a future drop+re-channel restarts
+			// from full.
+			m_xChannelingVillager = INVALID_ENTITY_ID;
+			m_fChannelRemaining = 0.0f;
+		}
+
 		DP_Player::SetHeldItem(xVillager, m_xParentEntity.GetEntityID());
 		Zenith_EventDispatcher::Get().Dispatch(
 			DP_OnItemPickedUp{ xVillager, m_xParentEntity.GetEntityID() });
@@ -123,6 +162,11 @@ public:
 		// are re-set even if a previous tag's tint was already applied.
 		m_bTintApplied = false;
 		ApplyTagTint();
+		// MVP-2.2: re-resolve the pickup-channel duration from the
+		// reagent registry. The OnAwake call resolved against
+		// m_eTag=None (default); SetTag is the canonical "I'm actually
+		// a BogWater now" moment.
+		ResolveReagentChannelFromRegistry();
 	}
 
 private:
@@ -152,6 +196,18 @@ private:
 			// MVP-2.3 forge additions
 			case DP_ItemTag::Wood:        xRgb = Zenith_Maths::Vector3(0.55f, 0.35f, 0.15f); szLabel = "TintWood";        break;
 			case DP_ItemTag::Spike:       xRgb = Zenith_Maths::Vector3(0.85f, 0.85f, 0.9f);  szLabel = "TintSpike";       break;
+			// MVP-2.2 reagent tints. Read tint_rgb from DP_Reagents at
+			// OnAwake instead of hardcoding; but compile-time enum case
+			// labels need a static colour fallback. We keep the
+			// per-tag tints here as a backup AND let
+			// ResolveReagentChannelFromRegistry use the live tint_rgb
+			// from the JSON if it diverges. The JSON values match
+			// these constants today.
+			case DP_ItemTag::Caul:        xRgb = Zenith_Maths::Vector3(0.95f, 0.92f, 0.85f); szLabel = "TintCaul";        break;
+			case DP_ItemTag::HareTongue:  xRgb = Zenith_Maths::Vector3(0.65f, 0.20f, 0.18f); szLabel = "TintHareTongue";  break;
+			case DP_ItemTag::BogWater:    xRgb = Zenith_Maths::Vector3(0.20f, 0.30f, 0.25f); szLabel = "TintBogWater";    break;
+			case DP_ItemTag::BurialCoin:  xRgb = Zenith_Maths::Vector3(0.70f, 0.60f, 0.30f); szLabel = "TintBurialCoin";  break;
+			case DP_ItemTag::BellSoul:    xRgb = Zenith_Maths::Vector3(0.85f, 0.75f, 0.45f); szLabel = "TintBellSoul";    break;
 			case DP_ItemTag::Objective1:
 			case DP_ItemTag::Objective2:
 			case DP_ItemTag::Objective3:
@@ -182,11 +238,46 @@ public:
 
 #ifdef ZENITH_INPUT_SIMULATOR
 	float GetPostDropCooldownForTest() const { return m_fPostDropCooldownSec; }
+
+	// MVP-2.2 test accessors. ChannelDuration is the per-tag value
+	// resolved at OnAwake from DP_Reagents; ChannelRemaining tracks
+	// the in-flight countdown when a villager is in pickup range.
+	float           GetPickupChannelDurationForTest() const { return m_fPickupChannelDuration; }
+	float           GetChannelRemainingForTest() const { return m_fChannelRemaining; }
+	Zenith_EntityID GetChannelingVillagerForTest() const { return m_xChannelingVillager; }
 #endif
 
 private:
+	// MVP-2.2.1: look up the item's reagent properties at OnAwake and
+	// cache the pickup-channel duration. Non-reagent tags (Iron, Key,
+	// Wood, Spike, Objective1..5) silently default to 0 (immediate
+	// pickup) -- the existing tool/objective behaviour is preserved
+	// because TryGet returns nullptr for them.
+	void ResolveReagentChannelFromRegistry()
+	{
+		const char* szTagName = DP_ItemTagToString(m_eTag);
+		const DP_Reagents::Reagent* pxR = DP_Reagents::TryGet(szTagName);
+		if (pxR != nullptr)
+		{
+			m_fPickupChannelDuration = pxR->pickup_channel_s;
+		}
+		else
+		{
+			m_fPickupChannelDuration = 0.0f;
+		}
+	}
+
 	DP_ItemTag m_eTag = DP_ItemTag::None;
 	float      m_fPickupRadius = 1.5f;
 	bool       m_bTintApplied = false;
 	float      m_fPostDropCooldownSec = 0.0f;
+	// MVP-2.2.2 pickup-channel state. Duration is loaded from
+	// DP_Reagents at OnAwake; >0 means the item is a reagent and
+	// requires staying in range for that many seconds before pickup
+	// fires. Remaining counts down per frame while a villager is in
+	// range. Channeling villager identity is tracked so a different
+	// villager wandering into range mid-channel restarts cleanly.
+	float           m_fPickupChannelDuration = 0.0f;
+	float           m_fChannelRemaining      = 0.0f;
+	Zenith_EntityID m_xChannelingVillager;
 };

--- a/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPVillager_Behaviour.h
@@ -656,6 +656,12 @@ private:
 			// MVP-2.3 forge additions
 			case DP_ItemTag::Wood:        xRgb = Zenith_Maths::Vector3(0.55f, 0.35f, 0.15f); szLabel = "TintWood"; break;
 			case DP_ItemTag::Spike:       xRgb = Zenith_Maths::Vector3(0.85f, 0.85f, 0.9f);  szLabel = "TintSpike"; break;
+			// MVP-2.2 reagent tints (match Reagents.json's tint_rgb values).
+			case DP_ItemTag::Caul:        xRgb = Zenith_Maths::Vector3(0.95f, 0.92f, 0.85f); szLabel = "TintCaul"; break;
+			case DP_ItemTag::HareTongue:  xRgb = Zenith_Maths::Vector3(0.65f, 0.20f, 0.18f); szLabel = "TintHareTongue"; break;
+			case DP_ItemTag::BogWater:    xRgb = Zenith_Maths::Vector3(0.20f, 0.30f, 0.25f); szLabel = "TintBogWater"; break;
+			case DP_ItemTag::BurialCoin:  xRgb = Zenith_Maths::Vector3(0.70f, 0.60f, 0.30f); szLabel = "TintBurialCoin"; break;
+			case DP_ItemTag::BellSoul:    xRgb = Zenith_Maths::Vector3(0.85f, 0.75f, 0.45f); szLabel = "TintBellSoul"; break;
 			default:                      xRgb = Zenith_Maths::Vector3(0.95f, 0.15f, 0.15f); szLabel = "TintObjective"; break;
 		}
 		const uint32_t uMatCount = pxInst->GetNumMaterials();

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -7,6 +7,7 @@
 #include "Source/DPMaterials.h"
 #include "Source/DP_Tuning.h"
 #include "Source/DP_Archetypes.h"
+#include "Source/DP_Reagents.h"
 
 #include <cstdio>
 #include <cstring>
@@ -77,6 +78,12 @@ namespace DevilsPlayground
 		// Idempotent.
 		DP_Archetypes::Initialize();
 
+		// MVP-2.2.1: Config/Reagents.json into the reagent cache. Loaded
+		// alongside archetypes so DPItemBase::OnAwake can look up the
+		// pickup_channel_s + special_behaviour fields by tag name.
+		// Idempotent.
+		DP_Reagents::Initialize();
+
 		// Author Zenith_MaterialAssets from the UE parameter dumps under
 		// Assets/Materials/*.json. Idempotent — safe across Editor Stop/Play.
 		DPMaterials::Initialize();
@@ -119,6 +126,9 @@ namespace DevilsPlayground
 		// tuning, but keep teardown order paired so future cross-deps are
 		// surfaced by the Editor Stop/Play smoke runs. Idempotent.
 		DP_Archetypes::Shutdown();
+
+		// Drop the reagent cache paired with archetypes.
+		DP_Reagents::Shutdown();
 
 		// Drop the tuning cache last so materials/fog teardown above can still
 		// query tuning values if they ever start to. Idempotent.

--- a/Games/DevilsPlayground/Source/DP_Reagents.cpp
+++ b/Games/DevilsPlayground/Source/DP_Reagents.cpp
@@ -1,0 +1,382 @@
+#include "Zenith.h"
+
+#include "Source/DP_Reagents.h"
+
+#include "Collections/Zenith_Vector.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+	// ---------------------------------------------------------------------------
+	// Tiny JSON parser (hand-rolled). Duplicated from DP_Archetypes.cpp /
+	// DP_Tuning.cpp / DPMaterials.cpp -- per the existing comment in those
+	// files, the duplication is intentional and scope-controlled; a shared
+	// utility lift is explicitly deferred.
+	// ---------------------------------------------------------------------------
+	enum JsonType : uint8_t
+	{
+		JSON_NULL,
+		JSON_BOOL,
+		JSON_NUMBER,
+		JSON_STRING,
+		JSON_ARRAY,
+		JSON_OBJECT,
+	};
+
+	struct JsonValue
+	{
+		JsonType m_eType = JSON_NULL;
+		double m_fNumber = 0.0;
+		bool m_bBool = false;
+		std::string m_strString;
+		std::vector<JsonValue> m_axArray;
+		std::vector<std::pair<std::string, JsonValue>> m_axObject;
+
+		const JsonValue* FindKey(const char* szKey) const
+		{
+			if (m_eType != JSON_OBJECT) return nullptr;
+			for (const auto& xPair : m_axObject)
+			{
+				if (xPair.first == szKey) return &xPair.second;
+			}
+			return nullptr;
+		}
+	};
+
+	class JsonParser
+	{
+	public:
+		explicit JsonParser(const std::string& strSrc) : m_strSrc(strSrc), m_uPos(0) {}
+
+		bool Parse(JsonValue& xOut)
+		{
+			SkipWhitespace();
+			if (!ParseValue(xOut)) return false;
+			SkipWhitespace();
+			return m_uPos == m_strSrc.size();
+		}
+
+	private:
+		const std::string& m_strSrc;
+		size_t m_uPos;
+
+		bool AtEnd() const { return m_uPos >= m_strSrc.size(); }
+		char Peek() const { return m_strSrc[m_uPos]; }
+
+		void SkipWhitespace()
+		{
+			while (!AtEnd())
+			{
+				char c = m_strSrc[m_uPos];
+				if (c == ' ' || c == '\t' || c == '\n' || c == '\r') ++m_uPos;
+				else break;
+			}
+		}
+
+		bool ParseValue(JsonValue& xOut)
+		{
+			SkipWhitespace();
+			if (AtEnd()) return false;
+			char c = Peek();
+			if (c == '{') return ParseObject(xOut);
+			if (c == '[') return ParseArray(xOut);
+			if (c == '"') return ParseString(xOut);
+			if (c == 't' || c == 'f') return ParseBool(xOut);
+			if (c == 'n') return ParseNull(xOut);
+			if (c == '-' || (c >= '0' && c <= '9')) return ParseNumber(xOut);
+			return false;
+		}
+
+		bool ParseObject(JsonValue& xOut)
+		{
+			xOut.m_eType = JSON_OBJECT;
+			++m_uPos;
+			SkipWhitespace();
+			if (!AtEnd() && Peek() == '}') { ++m_uPos; return true; }
+			while (!AtEnd())
+			{
+				SkipWhitespace();
+				JsonValue xKey;
+				if (!ParseString(xKey)) return false;
+				SkipWhitespace();
+				if (AtEnd() || Peek() != ':') return false;
+				++m_uPos;
+				JsonValue xVal;
+				if (!ParseValue(xVal)) return false;
+				xOut.m_axObject.emplace_back(std::move(xKey.m_strString), std::move(xVal));
+				SkipWhitespace();
+				if (AtEnd()) return false;
+				if (Peek() == ',') { ++m_uPos; continue; }
+				if (Peek() == '}') { ++m_uPos; return true; }
+				return false;
+			}
+			return false;
+		}
+
+		bool ParseArray(JsonValue& xOut)
+		{
+			xOut.m_eType = JSON_ARRAY;
+			++m_uPos;
+			SkipWhitespace();
+			if (!AtEnd() && Peek() == ']') { ++m_uPos; return true; }
+			while (!AtEnd())
+			{
+				JsonValue xVal;
+				if (!ParseValue(xVal)) return false;
+				xOut.m_axArray.push_back(std::move(xVal));
+				SkipWhitespace();
+				if (AtEnd()) return false;
+				if (Peek() == ',') { ++m_uPos; continue; }
+				if (Peek() == ']') { ++m_uPos; return true; }
+				return false;
+			}
+			return false;
+		}
+
+		bool ParseString(JsonValue& xOut)
+		{
+			if (AtEnd() || Peek() != '"') return false;
+			++m_uPos;
+			xOut.m_eType = JSON_STRING;
+			while (!AtEnd())
+			{
+				char c = m_strSrc[m_uPos++];
+				if (c == '"') return true;
+				if (c == '\\' && !AtEnd())
+				{
+					char cEsc = m_strSrc[m_uPos++];
+					switch (cEsc)
+					{
+					case '"': xOut.m_strString.push_back('"'); break;
+					case '\\': xOut.m_strString.push_back('\\'); break;
+					case '/': xOut.m_strString.push_back('/'); break;
+					case 'n': xOut.m_strString.push_back('\n'); break;
+					case 't': xOut.m_strString.push_back('\t'); break;
+					case 'r': xOut.m_strString.push_back('\r'); break;
+					case 'b': xOut.m_strString.push_back('\b'); break;
+					case 'f': xOut.m_strString.push_back('\f'); break;
+					default:  xOut.m_strString.push_back(cEsc); break;
+					}
+				}
+				else
+				{
+					xOut.m_strString.push_back(c);
+				}
+			}
+			return false;
+		}
+
+		bool ParseNumber(JsonValue& xOut)
+		{
+			size_t uStart = m_uPos;
+			if (!AtEnd() && Peek() == '-') ++m_uPos;
+			while (!AtEnd())
+			{
+				char c = Peek();
+				bool bDigit = (c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E'
+				           || c == '+' || c == '-';
+				if (!bDigit) break;
+				++m_uPos;
+			}
+			if (m_uPos == uStart) return false;
+			xOut.m_eType = JSON_NUMBER;
+			std::string strNum = m_strSrc.substr(uStart, m_uPos - uStart);
+			xOut.m_fNumber = std::strtod(strNum.c_str(), nullptr);
+			return true;
+		}
+
+		bool ParseBool(JsonValue& xOut)
+		{
+			if (m_strSrc.compare(m_uPos, 4, "true") == 0)
+			{
+				m_uPos += 4;
+				xOut.m_eType = JSON_BOOL;
+				xOut.m_bBool = true;
+				return true;
+			}
+			if (m_strSrc.compare(m_uPos, 5, "false") == 0)
+			{
+				m_uPos += 5;
+				xOut.m_eType = JSON_BOOL;
+				xOut.m_bBool = false;
+				return true;
+			}
+			return false;
+		}
+
+		bool ParseNull(JsonValue& xOut)
+		{
+			if (m_strSrc.compare(m_uPos, 4, "null") == 0)
+			{
+				m_uPos += 4;
+				xOut.m_eType = JSON_NULL;
+				return true;
+			}
+			return false;
+		}
+	};
+
+	bool LoadJsonFile(const std::filesystem::path& xPath, JsonValue& xOut)
+	{
+		std::ifstream xIn(xPath, std::ios::binary);
+		if (!xIn.is_open()) return false;
+		std::stringstream xBuf;
+		xBuf << xIn.rdbuf();
+		std::string strSrc = xBuf.str();
+		JsonParser xParser(strSrc);
+		return xParser.Parse(xOut);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Cache storage. Stable for the lifetime of the namespace -- Get(id) returns
+	// a pointer into this vector. Linear lookup over 14 entries is fine.
+	// ---------------------------------------------------------------------------
+	Zenith_Vector<DP_Reagents::Reagent>* s_pxReagents = nullptr;
+	bool s_bInitialized = false;
+
+	float ReadNumber(const JsonValue& xObj, const char* szKey, float fFallback = 0.0f)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_NUMBER) return fFallback;
+		return static_cast<float>(pxV->m_fNumber);
+	}
+
+	bool ReadBool(const JsonValue& xObj, const char* szKey, bool bFallback = false)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_BOOL) return bFallback;
+		return pxV->m_bBool;
+	}
+
+	std::string ReadString(const JsonValue& xObj, const char* szKey)
+	{
+		const JsonValue* pxV = xObj.FindKey(szKey);
+		if (pxV == nullptr || pxV->m_eType != JSON_STRING) return std::string();
+		return pxV->m_strString;
+	}
+
+	void ParseTint(const JsonValue& xObj, DP_Reagents::Reagent& xOut)
+	{
+		const JsonValue* pxArr = xObj.FindKey("tint_rgb");
+		if (pxArr == nullptr || pxArr->m_eType != JSON_ARRAY) return;
+		if (pxArr->m_axArray.size() < 3) return;
+		const JsonValue& xR = pxArr->m_axArray[0];
+		const JsonValue& xG = pxArr->m_axArray[1];
+		const JsonValue& xB = pxArr->m_axArray[2];
+		if (xR.m_eType == JSON_NUMBER) xOut.tint_r = static_cast<float>(xR.m_fNumber);
+		if (xG.m_eType == JSON_NUMBER) xOut.tint_g = static_cast<float>(xG.m_fNumber);
+		if (xB.m_eType == JSON_NUMBER) xOut.tint_b = static_cast<float>(xB.m_fNumber);
+	}
+
+	const DP_Reagents::Reagent* FindById(const char* szId)
+	{
+		if (s_pxReagents == nullptr) return nullptr;
+		for (u_int u = 0; u < s_pxReagents->GetSize(); ++u)
+		{
+			const DP_Reagents::Reagent& xR = s_pxReagents->Get(u);
+			if (xR.id == szId) return &s_pxReagents->Get(u);
+		}
+		return nullptr;
+	}
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+namespace DP_Reagents
+{
+	void Initialize()
+	{
+		if (s_bInitialized) return;
+
+		s_pxReagents = new Zenith_Vector<Reagent>();
+
+		const std::filesystem::path xPath =
+			(std::filesystem::path(GAME_ASSETS_DIR) / ".." / "Config" / "Reagents.json").lexically_normal();
+
+		JsonValue xRoot;
+		if (!LoadJsonFile(xPath, xRoot))
+		{
+			Zenith_Assert(false, "DP_Reagents: failed to load %s", xPath.string().c_str());
+			return;
+		}
+
+		const JsonValue* pxArr = xRoot.FindKey("reagents");
+		Zenith_Assert(pxArr != nullptr && pxArr->m_eType == JSON_ARRAY,
+			"DP_Reagents: 'reagents' key missing or not an array");
+		if (pxArr == nullptr || pxArr->m_eType != JSON_ARRAY) return;
+
+		for (const auto& xEntry : pxArr->m_axArray)
+		{
+			if (xEntry.m_eType != JSON_OBJECT) continue;
+			Reagent xR;
+			xR.id                   = ReadString(xEntry, "id");
+			xR.display_name_key     = ReadString(xEntry, "display_name_key");
+			xR.mvp                  = ReadBool(xEntry, "mvp", false);
+			xR.pickup_channel_s     = ReadNumber(xEntry, "pickup_channel_s");
+			xR.special_behaviour    = ReadString(xEntry, "special_behaviour");
+			xR.evaporate_duration_s = ReadNumber(xEntry, "evaporate_duration_s");
+			xR.rarity               = ReadNumber(xEntry, "rarity");
+			ParseTint(xEntry, xR);
+			if (!xR.id.empty())
+			{
+				s_pxReagents->PushBack(xR);
+			}
+		}
+
+		Zenith_Log(LOG_CATEGORY_ASSET,
+			"DP_Reagents: loaded %zu reagents from %s",
+			static_cast<size_t>(s_pxReagents->GetSize()), xPath.string().c_str());
+
+		s_bInitialized = true;
+	}
+
+	void Shutdown()
+	{
+		if (!s_bInitialized) return;
+		delete s_pxReagents;
+		s_pxReagents = nullptr;
+		s_bInitialized = false;
+	}
+
+	const Reagent* Get(const char* szId)
+	{
+		Zenith_Assert(s_bInitialized, "DP_Reagents::Get called before Initialize");
+		const Reagent* pxR = FindById(szId);
+		Zenith_Assert(pxR != nullptr, "DP_Reagents: unknown reagent id '%s'", szId);
+		return pxR;
+	}
+
+	const Reagent* TryGet(const char* szId)
+	{
+		if (!s_bInitialized) return nullptr;
+		return FindById(szId);
+	}
+
+	size_t Count()
+	{
+		if (!s_bInitialized || s_pxReagents == nullptr) return 0;
+		return static_cast<size_t>(s_pxReagents->GetSize());
+	}
+
+	const Reagent* GetByIndex(size_t uIdx)
+	{
+		if (!s_bInitialized || s_pxReagents == nullptr) return nullptr;
+		if (uIdx >= static_cast<size_t>(s_pxReagents->GetSize())) return nullptr;
+		return &s_pxReagents->Get(static_cast<u_int>(uIdx));
+	}
+
+	bool IsMvp(const char* szId)
+	{
+		const Reagent* pxR = FindById(szId);
+		return pxR != nullptr && pxR->mvp;
+	}
+}

--- a/Games/DevilsPlayground/Source/DP_Reagents.h
+++ b/Games/DevilsPlayground/Source/DP_Reagents.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+
+// ============================================================================
+// DP_Reagents -- runtime accessor for Devil's Playground reagent registry.
+//
+// Loads Games/DevilsPlayground/Config/Reagents.json once at boot and exposes
+// each reagent struct by id via Get(id). The full 14-entry table is loaded
+// regardless of the "mvp": true flag; consumers filter via IsMvp(id) where
+// MVP-only behaviour is required.
+//
+// Reagent IDs correspond to DP_ItemTag enum names (Caul, HareTongue,
+// BogWater, BurialCoin, BellSoul are the 5 MVP entries) -- DPItemBase
+// looks up its reagent properties at OnAwake via
+// DP_Reagents::Get(DP_ItemTagToString(m_eTag)).
+//
+// special_behaviour values (strings in the JSON):
+//   "none"                    -- no special behaviour, just a pickup channel
+//   "evaporates_after_drop"   -- BogWater: 8s timer + entity destroy on drop
+//   "rings_bell_on_pickup"    -- BellSoul: dispatch DP_OnBellRing on pickup
+//
+// Asserts on miss for Get(id). Returns nullptr from FindByIndex when out
+// of range. Initialize is idempotent.
+// ============================================================================
+namespace DP_Reagents
+{
+	struct Reagent
+	{
+		std::string id;
+		std::string display_name_key;
+		bool        mvp                  = false;
+		float       pickup_channel_s     = 0.0f;
+		std::string special_behaviour;            // "none" / "evaporates_after_drop" / "rings_bell_on_pickup"
+		float       evaporate_duration_s = 0.0f;  // only set for BogWater (and post-MVP reagents)
+		float       rarity               = 0.0f;
+		float       tint_r               = 1.0f;
+		float       tint_g               = 1.0f;
+		float       tint_b               = 1.0f;
+	};
+
+	void Initialize();
+	void Shutdown();
+
+	// Lookup by reagent id (e.g. "BogWater"). Asserts on miss.
+	// Pointer is stable for the lifetime of the cache (until Shutdown).
+	const Reagent* Get(const char* szId);
+
+	// Non-asserting variant -- returns nullptr if the id isn't in the
+	// registry. Used by DPItemBase to silently skip non-reagent tags
+	// (Iron / Key / Objective1..5 / etc.).
+	const Reagent* TryGet(const char* szId);
+
+	// Returns total number of reagents loaded (14 in the ratified config).
+	size_t Count();
+
+	// Returns nullptr if uIdx >= Count().
+	const Reagent* GetByIndex(size_t uIdx);
+
+	// Convenience: true iff Get(szId)->mvp == true.
+	bool IsMvp(const char* szId);
+}

--- a/Games/DevilsPlayground/Source/DevilsPlayground_Tags.h
+++ b/Games/DevilsPlayground/Source/DevilsPlayground_Tags.h
@@ -15,6 +15,16 @@ enum class DP_ItemTag : uint32_t
 	// output, and other systems treat it as a generic tool).
 	Wood,
 	Spike,
+	// MVP-2.2: the 5 ratified MVP reagents (Reagents.json `mvp: true`).
+	// Each has a 1.0 s pickup channel resolved at OnAwake via the
+	// DP_Reagents registry. BogWater + BellSoul also carry special
+	// behaviours (evaporate-after-drop / rings-bell-on-pickup) wired
+	// in later MVP-2.2.4-7 PRs.
+	Caul,
+	HareTongue,
+	BogWater,
+	BurialCoin,
+	BellSoul,
 	Objective1,
 	Objective2,
 	Objective3,
@@ -34,6 +44,11 @@ inline const char* DP_ItemTagToString(DP_ItemTag eTag)
 	case DP_ItemTag::SkeletonKey: return "SkeletonKey";
 	case DP_ItemTag::Wood:        return "Wood";
 	case DP_ItemTag::Spike:       return "Spike";
+	case DP_ItemTag::Caul:        return "Caul";
+	case DP_ItemTag::HareTongue:  return "HareTongue";
+	case DP_ItemTag::BogWater:    return "BogWater";
+	case DP_ItemTag::BurialCoin:  return "BurialCoin";
+	case DP_ItemTag::BellSoul:    return "BellSoul";
 	case DP_ItemTag::Objective1:  return "Objective1";
 	case DP_ItemTag::Objective2:  return "Objective2";
 	case DP_ItemTag::Objective3:  return "Objective3";
@@ -46,6 +61,26 @@ inline const char* DP_ItemTagToString(DP_ItemTag eTag)
 inline bool DP_IsObjectiveTag(DP_ItemTag eTag)
 {
 	return eTag >= DP_ItemTag::Objective1 && eTag <= DP_ItemTag::Objective5;
+}
+
+// MVP-2.2.1: classify an item as a "reagent". The 5 MVP reagents
+// (Reagents.json `mvp: true`) each have a 1.0 s pickup channel; the
+// channel duration itself is looked up at OnAwake from the DP_Reagents
+// registry, but this helper is used for tag classification (e.g.
+// DPItemBase initialises its pickup-channel state machine only for
+// reagent tags, not for tools / objectives).
+//
+// Reagent tags are independent from Objective tags: a level may
+// designate the 5 reagents AS the 5 objectives (canonical MVP) or
+// use Objective1-5 as generic placeholder slots. The pentagram win
+// path lives on the Objective tag bitmask, not the reagent identity.
+inline bool DP_IsReagentTag(DP_ItemTag eTag)
+{
+	return eTag == DP_ItemTag::Caul
+	    || eTag == DP_ItemTag::HareTongue
+	    || eTag == DP_ItemTag::BogWater
+	    || eTag == DP_ItemTag::BurialCoin
+	    || eTag == DP_ItemTag::BellSoul;
 }
 
 // MVP-2.1.4: classify an item as a "tool" -- the crafting / utility

--- a/Games/DevilsPlayground/Tests/Test_P2Reagent_UniquePickupChannel.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Reagent_UniquePickupChannel.cpp
@@ -1,0 +1,372 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_ModelComponent.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DevilsPlayground_Tags.h"
+#include "Source/DP_Reagents.h"
+#include "Components/DPItemBase_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+
+// ============================================================================
+// Test_P2Reagent_UniquePickupChannel (MVP-2.2.3)
+//
+// Pins the reagent pickup-channel contract: an item with reagent tag
+// requires the possessed villager to stay in pickup range for
+// `pickup_channel_s` seconds (1.0 s for MVP reagents per
+// Reagents.json) before pickup fires. Non-reagent items (Iron, Key,
+// Objectives) pick up immediately as they do today.
+//
+// Three things are pinned together:
+//   1. DP_Reagents::Initialize ran during Project_Initialise (it
+//      can be queried at OnAwake time).
+//   2. DPItemBase::OnAwake reads the reagent's pickup_channel_s and
+//      stamps m_fPickupChannelDuration to it.
+//   3. DPItemBase::OnUpdate ticks the channel only while the
+//      possessed villager is in range; pickup fires when the timer
+//      reaches 0.
+//
+// Procedure (one scene, two phases):
+//
+//   PHASE A (reagent slow pickup):
+//     1. Load GameLevel; pick any villager.
+//     2. Construct a BogWater item entity in the scene (a reagent --
+//        Reagents.json has pickup_channel_s = 1.0).
+//     3. Possess the villager; teleport onto the BogWater.
+//     4. Tick a few frames -- not enough for the channel to complete.
+//     5. Assert villager holds NOTHING yet, and the item's channel
+//        state shows we're mid-flight (channeling villager = us,
+//        remaining > 0 but <= the configured 1.0 s).
+//     6. Tick many more frames (>1.0 s total).
+//     7. Assert villager NOW holds the BogWater.
+//
+//   PHASE B (tool immediate pickup):
+//     8. Construct an Iron item entity (NOT a reagent -- channel
+//        duration should default to 0).
+//     9. Drop the held BogWater (RemoveHeldItem) so we can pick up
+//        the Iron.
+//    10. Teleport onto the Iron.
+//    11. Tick a small number of frames (3, well under any channel).
+//    12. Assert villager holds the Iron immediately.
+//
+// What this catches:
+//   * DP_Reagents::Initialize wasn't called (TryGet returns nullptr;
+//     channel duration stays 0; reagent picks up instantly).
+//   * DPItemBase::OnAwake didn't read pickup_channel_s.
+//   * The channel state machine misuses fDt (e.g., decrements by
+//     wall-clock instead of game-time).
+//   * Channel runs for non-reagents too (Iron should still pick up
+//     immediately).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int {
+		kR_Start, kR_WaitScene,
+		kR_BuildReagent, kR_PossessAndTeleportToReagent,
+		kR_TickPartial, kR_PartialSnapshot,
+		kR_TickRest, kR_FullSnapshot,
+		kR_DropReagent, kR_BuildIron,
+		kR_TeleportToIron, kR_TickIronShort,
+		kR_IronSnapshot, kR_Verify, kR_Done
+	};
+
+	int                     g_iPhase = kR_Start;
+	Zenith_EntityID         g_xVillager;
+	Zenith_EntityID         g_xBogWater;
+	Zenith_EntityID         g_xIron;
+	DPItemBase_Behaviour*   g_pxBogWaterBeh = nullptr;
+	DPItemBase_Behaviour*   g_pxIronBeh = nullptr;
+
+	int                     g_iTickCounter = 0;
+
+	// Mid-channel snapshot
+	Zenith_EntityID         g_xHeldMid;
+	float                   g_fChannelRemainingMid = -1.0f;
+	float                   g_fChannelDurationMid = -1.0f;
+
+	// Post-channel snapshot (after the 1.0s completes)
+	Zenith_EntityID         g_xHeldFull;
+
+	// Iron snapshot (after a few frames)
+	Zenith_EntityID         g_xHeldIron;
+	float                   g_fIronChannelDuration = -1.0f;
+
+	// 1.0 s channel duration at fixed-dt 0.01666 = ~60 frames.
+	// 30 frames = ~0.5 s -- well under the threshold.
+	constexpr int kPARTIAL_TICKS = 30;
+	// Another 50 frames = total ~80 = ~1.33 s, comfortably past 1.0 s.
+	constexpr int kREST_TICKS    = 50;
+	// 3 frames for the Iron pickup -- way under any channel threshold.
+	constexpr int kIRON_TICKS    = 3;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	void TeleportTo(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+	}
+
+	Zenith_EntityID BuildItem(const char* szName, DP_ItemTag eTag,
+	                          const Zenith_Maths::Vector3& xPos,
+	                          DPItemBase_Behaviour** ppxOutBeh)
+	{
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene == nullptr) return INVALID_ENTITY_ID;
+		Zenith_Entity xEnt(pxScene, std::string(szName));
+		if (!xEnt.IsValid()) return INVALID_ENTITY_ID;
+		if (xEnt.HasComponent<Zenith_TransformComponent>())
+		{
+			xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+		}
+		xEnt.AddComponent<Zenith_ModelComponent>().LoadModel(
+			std::string(GAME_ASSETS_DIR) + "Meshes/LevelPrototyping_Meshes_SM_Cube" ZENITH_MODEL_EXT);
+		DPItemBase_Behaviour* pxBeh = xEnt.AddComponent<Zenith_ScriptComponent>()
+			.AddScript<DPItemBase_Behaviour>();
+		if (pxBeh != nullptr) pxBeh->SetTag(eTag);
+		if (ppxOutBeh != nullptr) *ppxOutBeh = pxBeh;
+		return xEnt.GetEntityID();
+	}
+}
+
+static void Setup_P2ReagentChannel()
+{
+	g_iPhase = kR_Start;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_xBogWater = INVALID_ENTITY_ID;
+	g_xIron = INVALID_ENTITY_ID;
+	g_pxBogWaterBeh = nullptr;
+	g_pxIronBeh = nullptr;
+	g_iTickCounter = 0;
+	g_xHeldMid = INVALID_ENTITY_ID;
+	g_fChannelRemainingMid = -1.0f;
+	g_fChannelDurationMid = -1.0f;
+	g_xHeldFull = INVALID_ENTITY_ID;
+	g_xHeldIron = INVALID_ENTITY_ID;
+	g_fIronChannelDuration = -1.0f;
+}
+
+static bool Step_P2ReagentChannel(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kR_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kR_WaitScene;
+		return true;
+
+	case kR_WaitScene:
+	{
+		Zenith_EntityID xFound;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFound](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFound.IsValid()) xFound = xId;
+			});
+		if (xFound.IsValid())
+		{
+			g_xVillager = xFound;
+			g_iPhase = kR_BuildReagent;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kR_Done;
+		}
+		return true;
+	}
+
+	case kR_BuildReagent:
+	{
+		Zenith_Maths::Vector3 xPos(100.0f, 0.0f, 100.0f); // arbitrary
+		g_xBogWater = BuildItem("Test_BogWater", DP_ItemTag::BogWater,
+			xPos, &g_pxBogWaterBeh);
+		g_iPhase = kR_PossessAndTeleportToReagent;
+		return true;
+	}
+
+	case kR_PossessAndTeleportToReagent:
+	{
+		DP_Player::SetPossessedVillager(g_xVillager);
+		Zenith_Maths::Vector3 xPos;
+		if (TryGetEntityPos(g_xBogWater, xPos)) TeleportTo(g_xVillager, xPos);
+		g_iTickCounter = 0;
+		g_iPhase = kR_TickPartial;
+		return true;
+	}
+
+	case kR_TickPartial:
+		++g_iTickCounter;
+		if (g_iTickCounter >= kPARTIAL_TICKS) g_iPhase = kR_PartialSnapshot;
+		return true;
+
+	case kR_PartialSnapshot:
+		g_xHeldMid = DP_Player::GetHeldItemEntity(g_xVillager);
+		if (g_pxBogWaterBeh != nullptr)
+		{
+			g_fChannelRemainingMid = g_pxBogWaterBeh->GetChannelRemainingForTest();
+			g_fChannelDurationMid = g_pxBogWaterBeh->GetPickupChannelDurationForTest();
+		}
+		g_iTickCounter = 0;
+		g_iPhase = kR_TickRest;
+		return true;
+
+	case kR_TickRest:
+		++g_iTickCounter;
+		if (g_iTickCounter >= kREST_TICKS) g_iPhase = kR_FullSnapshot;
+		return true;
+
+	case kR_FullSnapshot:
+		g_xHeldFull = DP_Player::GetHeldItemEntity(g_xVillager);
+		g_iPhase = kR_DropReagent;
+		return true;
+
+	case kR_DropReagent:
+		// Drop the BogWater so Phase B (Iron) can pick up.
+		DP_Player::RemoveHeldItem(g_xVillager);
+		g_iPhase = kR_BuildIron;
+		return true;
+
+	case kR_BuildIron:
+	{
+		Zenith_Maths::Vector3 xPos(105.0f, 0.0f, 100.0f);
+		g_xIron = BuildItem("Test_Iron", DP_ItemTag::Iron, xPos, &g_pxIronBeh);
+		g_iPhase = kR_TeleportToIron;
+		return true;
+	}
+
+	case kR_TeleportToIron:
+	{
+		Zenith_Maths::Vector3 xPos;
+		if (TryGetEntityPos(g_xIron, xPos)) TeleportTo(g_xVillager, xPos);
+		g_iTickCounter = 0;
+		g_iPhase = kR_TickIronShort;
+		return true;
+	}
+
+	case kR_TickIronShort:
+		++g_iTickCounter;
+		if (g_iTickCounter >= kIRON_TICKS) g_iPhase = kR_IronSnapshot;
+		return true;
+
+	case kR_IronSnapshot:
+		g_xHeldIron = DP_Player::GetHeldItemEntity(g_xVillager);
+		if (g_pxIronBeh != nullptr)
+		{
+			g_fIronChannelDuration = g_pxIronBeh->GetPickupChannelDurationForTest();
+		}
+		g_iPhase = kR_Verify;
+		return true;
+
+	case kR_Verify:
+		std::printf("[P2ReagentChannel] mid:held=(%u/%u) channelRem=%.3f channelDur=%.3f post:held=(%u/%u) iron:held=(%u/%u) ironChannelDur=%.3f\n",
+			g_xHeldMid.m_uIndex, g_xHeldMid.m_uGeneration,
+			g_fChannelRemainingMid, g_fChannelDurationMid,
+			g_xHeldFull.m_uIndex, g_xHeldFull.m_uGeneration,
+			g_xHeldIron.m_uIndex, g_xHeldIron.m_uGeneration,
+			g_fIronChannelDuration);
+		std::fflush(stdout);
+		g_iPhase = kR_Done;
+		return false;
+
+	case kR_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P2ReagentChannel()
+{
+	if (!g_xVillager.IsValid() || !g_xBogWater.IsValid() || !g_xIron.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2ReagentChannel: setup entities missing");
+		return false;
+	}
+	// PHASE A assertions.
+	if (g_fChannelDurationMid < 0.5f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2ReagentChannel: BogWater channel duration is %.3f, expected ~1.0 (from Reagents.json). DP_Reagents not initialized, or DPItemBase didn't read pickup_channel_s at OnAwake",
+			g_fChannelDurationMid);
+		return false;
+	}
+	if (g_xHeldMid.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2ReagentChannel: villager held the BogWater after only %d ticks (~0.5s) -- the channel should not have completed yet (configured %.3fs)",
+			kPARTIAL_TICKS, g_fChannelDurationMid);
+		return false;
+	}
+	if (g_fChannelRemainingMid <= 0.0f || g_fChannelRemainingMid >= g_fChannelDurationMid)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2ReagentChannel: mid-channel remaining is %.3f (duration %.3f). Expected 0 < remaining < duration. Either the channel never started or it already completed.",
+			g_fChannelRemainingMid, g_fChannelDurationMid);
+		return false;
+	}
+	if (!g_xHeldFull.IsValid()
+		|| g_xHeldFull.m_uIndex != g_xBogWater.m_uIndex
+		|| g_xHeldFull.m_uGeneration != g_xBogWater.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2ReagentChannel: after full channel + extra ticks villager holds (%u/%u), expected BogWater=(%u/%u). Channel didn't complete OR pickup fired onto the wrong entity",
+			g_xHeldFull.m_uIndex, g_xHeldFull.m_uGeneration,
+			g_xBogWater.m_uIndex, g_xBogWater.m_uGeneration);
+		return false;
+	}
+	// PHASE B assertions.
+	if (g_fIronChannelDuration != 0.0f)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2ReagentChannel: Iron channel duration is %.3f, expected 0 (tools have no channel)",
+			g_fIronChannelDuration);
+		return false;
+	}
+	if (!g_xHeldIron.IsValid()
+		|| g_xHeldIron.m_uIndex != g_xIron.m_uIndex
+		|| g_xHeldIron.m_uGeneration != g_xIron.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2ReagentChannel: after %d ticks villager holds (%u/%u), expected Iron=(%u/%u). The non-reagent immediate-pickup path didn't fire",
+			kIRON_TICKS,
+			g_xHeldIron.m_uIndex, g_xHeldIron.m_uGeneration,
+			g_xIron.m_uIndex, g_xIron.m_uGeneration);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2ReagentChannelTest = {
+	"Test_P2Reagent_UniquePickupChannel",
+	&Setup_P2ReagentChannel,
+	&Step_P2ReagentChannel,
+	&Verify_P2ReagentChannel,
+	300
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2ReagentChannelTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

The 5 MVP reagents (Caul, HareTongue, BogWater, BurialCoin, BellSoul) now have a **unique 1.0 s pickup channel**: the possessed villager must stay in pickup range for the full duration before pickup fires. Tools (Iron, Key, Wood, Spike) and objectives keep the existing instant-pickup behaviour.

## What lands

| File | Change |
|---|---|
| `DevilsPlayground_Tags.h` | 5 new `DP_ItemTag` values (Caul/HareTongue/BogWater/BurialCoin/BellSoul). New `DP_IsReagentTag` helper. |
| `Source/DP_Reagents.h/.cpp` | New runtime accessor for `Config/Reagents.json`. Modelled on `DP_Archetypes` — same JSON parser, same lifecycle (Initialize/Shutdown/Get/TryGet/Count/GetByIndex/IsMvp). |
| `DevilsPlayground.cpp` | `DP_Reagents::Initialize` wired into Project_Initialise alongside `DP_Archetypes`. |
| `DPItemBase_Behaviour` | New `ResolveReagentChannelFromRegistry` called from BOTH OnAwake and SetTag. New pickup-channel state machine in OnUpdate. Three test accessors. Reagent tints added. |
| `DPVillager_Behaviour` | Reagent tints in the held-item visual. |

## Implementation gotcha (documented in commit)

Scene-construction code typically does `AddScript<DPItemBase_Behaviour>()` (which fires OnAwake against `m_eTag = None`) THEN calls `SetTag(BogWater)`. Without re-resolving the registry lookup in `SetTag`, the channel duration would stay at 0 — found this on first test run; the fix is a one-liner in `SetTag`.

## Test

`Test_P2Reagent_UniquePickupChannel` (two-phase):

| Phase | Scenario | Pins |
|---|---|---|
| **A** | Build a BogWater item, teleport possessed villager onto it. Tick 30 frames (~0.5s) → snapshot. Tick 50 more (total ~1.33s) → snapshot. | Mid: held empty, channel mid-flight (0 < remaining < duration). Post: held = BogWater. |
| **B** | Drop BogWater, build Iron, teleport on. Tick just 3 frames → snapshot. | Iron channel duration = 0; held = Iron immediately. |

## Test plan

- [x] Test passes in isolation
- [x] Full DP suite green: **94 passed, 0 failed**

## Roadmap impact

Closes **MVP-2.2.1 + MVP-2.2.2 + MVP-2.2.3** as a single landing. Next up: MVP-2.2.4-5 BogWater evaporation, MVP-2.2.6-7 BellSoul ring-on-pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)