### PR TITLE
feat(dp): MVP-2.5.{2,4} -- HUD dawn-gauge + scent indicator

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="..\Tests\Test_P2Forge_AudibleAt30m.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_IronToSkeletonKey.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp" />
+    <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BellSoulRingsBell.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BogWaterEvaporates.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -233,6 +233,9 @@
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Reagent_BellSoulRingsBell.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -565,6 +565,7 @@
     <ClCompile Include="..\Tests\Test_P2Forge_AudibleAt30m.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_IronToSkeletonKey.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp" />
+    <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BellSoulRingsBell.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BogWaterEvaporates.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -233,6 +233,9 @@
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2Reagent_BellSoulRingsBell.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
@@ -130,6 +130,57 @@ public:
 			pxObj->SetText(buf);
 			pxObj->SetVisible(true);
 		}
+
+		// MVP-2.5.4: Dawn sun-gauge. Visible while a night is active;
+		// hidden in scenes that haven't called DP_Night::StartNight.
+		if (auto* pxDawn = xUI.FindElement<Zenith_UI::Zenith_UIText>("DawnGauge"))
+		{
+			if (!DP_Night::IsNightActive())
+			{
+				pxDawn->SetVisible(false);
+			}
+			else
+			{
+				char buf[32];
+				BuildDawnText(buf, sizeof(buf), DP_Night::GetNightTimeRemaining());
+				pxDawn->SetText(buf);
+				pxDawn->SetVisible(true);
+			}
+		}
+
+		// MVP-2.5.2: Scent indicator. Reads the possessed villager's
+		// scent value. Hidden when nothing possessed.
+		if (auto* pxScent = xUI.FindElement<Zenith_UI::Zenith_UIText>("ScentIndicator"))
+		{
+			if (!bPossessed)
+			{
+				pxScent->SetVisible(false);
+			}
+			else
+			{
+				const float fScent = DP_Player::GetDemonScent(xV);
+				char buf[32];
+				BuildScentText(buf, sizeof(buf), fScent);
+				pxScent->SetText(buf);
+				pxScent->SetVisible(true);
+			}
+		}
+	}
+
+public:
+	// MVP-2.5.4 + 2.5.2: pure text-formatting helpers exposed for
+	// unit-level tests (Test_P2HUD_*). The real OnUpdate calls them
+	// internally; this lets tests verify the formatting WITHOUT
+	// authoring a full UI subsystem in their scene.
+	static void BuildDawnText(char* szBuf, size_t uBufSize, float fSecondsRemaining)
+	{
+		if (fSecondsRemaining < 0.0f) fSecondsRemaining = 0.0f;
+		std::snprintf(szBuf, uBufSize, "Dawn: %.1f s", fSecondsRemaining);
+	}
+	static void BuildScentText(char* szBuf, size_t uBufSize, float fScent)
+	{
+		if (fScent < 0.0f) fScent = 0.0f;
+		std::snprintf(szBuf, uBufSize, "Scent: %.2f", fScent);
 	}
 
 private:

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -573,6 +573,27 @@ namespace
 		Zenith_EditorAutomation::AddStep_SetUIColor("Status", 0.9f, 0.2f, 0.2f, 1.0f);
 		Zenith_EditorAutomation::AddStep_SetUIVisible("Status", false);
 
+		// MVP-2.5.4: Dawn sun-gauge -- text countdown at top-centre.
+		// Shows "Dawn: 12.3 s" while a night is running; hidden when
+		// no night active. Production polish post-MVP swaps the text
+		// for a graphical sun-arc.
+		Zenith_EditorAutomation::AddStep_CreateUIText("DawnGauge", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("DawnGauge", static_cast<int>(Zenith_UI::AnchorPreset::TopCenter));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("DawnGauge", 0.0f, 30.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("DawnGauge", 36.0f);
+		Zenith_EditorAutomation::AddStep_SetUIColor("DawnGauge", 1.0f, 0.85f, 0.6f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("DawnGauge", false);
+
+		// MVP-2.5.2: Scent indicator -- numeric for now ("Scent: 0.4").
+		// Shows the currently-possessed villager's scent value;
+		// hidden when no villager is possessed.
+		Zenith_EditorAutomation::AddStep_CreateUIText("ScentIndicator", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("ScentIndicator", static_cast<int>(Zenith_UI::AnchorPreset::BottomLeft));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("ScentIndicator", 30.0f, -30.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("ScentIndicator", 28.0f);
+		Zenith_EditorAutomation::AddStep_SetUIColor("ScentIndicator", 0.7f, 0.3f, 0.9f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("ScentIndicator", false);
+
 		// Attach the global coordinators. Each is independent — order doesn't
 		// matter, but Combat-style is to attach the player first.
 		Zenith_EditorAutomation::AddStep_AttachScript("DPPlayerController_Behaviour");

--- a/Games/DevilsPlayground/Tests/Test_P2HUD_DawnAndScentReadouts.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2HUD_DawnAndScentReadouts.cpp
@@ -1,0 +1,143 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPHUDController_Behaviour.h"
+
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P2HUD_DawnAndScentReadouts (MVP-2.5.2 + MVP-2.5.4)
+//
+// Pins the formatting + data-binding contract for the two new HUD
+// readouts:
+//   * DawnGauge -- "Dawn: X.X s" while a night is active. Reads
+//     DP_Night::GetNightTimeRemaining().
+//   * ScentIndicator -- "Scent: X.XX". Reads
+//     DP_Player::GetDemonScent(possessedVillager).
+//
+// The HUD class exposes BuildDawnText / BuildScentText as static
+// helpers. Production OnUpdate uses these to populate
+// Zenith_UIText elements; this test uses them directly so the
+// assertion doesn't depend on the UI/font/render pipeline being
+// active in headless mode.
+//
+// Procedure (no scene needed):
+//   1. BuildDawnText(buf, sizeof(buf), 12.3f). Assert buf starts
+//      with "Dawn: " and contains "12.3".
+//   2. BuildDawnText(buf, sizeof(buf), -5.0f). Assert non-negative
+//      formatting (clamp to 0). Catches a regression where the
+//      formatter prints negative seconds when DP_Night's clamp is
+//      off.
+//   3. BuildScentText(buf, sizeof(buf), 0.42f). Assert "Scent: 0.42".
+//   4. BuildScentText(buf, sizeof(buf), 0.0f). Assert "Scent: 0.00".
+//
+// Why a unit-style test: the actual HUD-element visibility/text
+// flow goes through Zenith_UIText + a real scene + a real UI canvas.
+// Asserting "the UI element's text == 'Dawn: 12.3 s'" requires a
+// scene with the authored UI element. That's a heavier integration
+// test that doesn't add coverage value over the formatter itself.
+// The data path (DP_Night, DP_Player::GetDemonScent) is already
+// covered by Test_P1Dawn_* and Test_P1Scent_*.
+// ============================================================================
+
+namespace
+{
+	bool g_bPassed = false;
+	const char* g_szFailureReason = "";
+
+	bool ContainsSubstring(const char* sz, const char* szNeedle)
+	{
+		return sz != nullptr && std::strstr(sz, szNeedle) != nullptr;
+	}
+}
+
+static void Setup_P2HUDReadouts()
+{
+	g_bPassed = false;
+	g_szFailureReason = "";
+
+	char buf[64];
+
+	// Step 1: positive dawn timer.
+	DPHUDController_Behaviour::BuildDawnText(buf, sizeof(buf), 12.3f);
+	if (!ContainsSubstring(buf, "Dawn: "))
+	{
+		g_szFailureReason = "dawn text missing 'Dawn: ' prefix";
+		return;
+	}
+	if (!ContainsSubstring(buf, "12.3"))
+	{
+		g_szFailureReason = "dawn text missing the 12.3 value";
+		return;
+	}
+	if (!ContainsSubstring(buf, " s"))
+	{
+		g_szFailureReason = "dawn text missing seconds suffix";
+		return;
+	}
+
+	// Step 2: clamp negative input to non-negative output.
+	DPHUDController_Behaviour::BuildDawnText(buf, sizeof(buf), -5.0f);
+	if (ContainsSubstring(buf, "-"))
+	{
+		g_szFailureReason = "dawn text with -5s input contains a minus sign -- clamp missing";
+		return;
+	}
+
+	// Step 3: scent value.
+	DPHUDController_Behaviour::BuildScentText(buf, sizeof(buf), 0.42f);
+	if (!ContainsSubstring(buf, "Scent: "))
+	{
+		g_szFailureReason = "scent text missing 'Scent: ' prefix";
+		return;
+	}
+	if (!ContainsSubstring(buf, "0.42"))
+	{
+		g_szFailureReason = "scent text missing the 0.42 value";
+		return;
+	}
+
+	// Step 4: zero scent.
+	DPHUDController_Behaviour::BuildScentText(buf, sizeof(buf), 0.0f);
+	if (!ContainsSubstring(buf, "0.00"))
+	{
+		g_szFailureReason = "scent text at 0 doesn't render 0.00";
+		return;
+	}
+
+	g_bPassed = true;
+	std::printf("[P2HUDReadouts] all formatter cases passed\n");
+	std::fflush(stdout);
+}
+
+static bool Step_P2HUDReadouts(int /*iFrame*/)
+{
+	return false;
+}
+
+static bool Verify_P2HUDReadouts()
+{
+	if (!g_bPassed)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2HUDReadouts: %s", g_szFailureReason);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2HUDReadoutsTest = {
+	"Test_P2HUD_DawnAndScentReadouts",
+	&Setup_P2HUDReadouts,
+	&Step_P2HUDReadouts,
+	&Verify_P2HUDReadouts,
+	60
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2HUDReadoutsTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Two new GameLevel HUD readouts on top of the existing life-bar / held-item / objectives stack:

| Element | Position | Format | Source |
|---|---|---|---|
| **DawnGauge** | top-centre | `"Dawn: 12.3 s"` while night active | `DP_Night::GetNightTimeRemaining` |
| **ScentIndicator** | bottom-left | `"Scent: 0.42"` for possessed villager | `DP_Player::GetDemonScent` |

Both authored hidden by default — only become visible when the underlying data is meaningful.

## Implementation

| Element | Note |
|---|---|
| `DevilsPlayground.cpp::AuthorGameLevelScene` | New `AddStep_CreateUIText` calls for both elements |
| `DPHUDController::OnUpdate` | Two new update blocks. FindElement returns nullptr for gym scenes → silent no-op |
| `DPHUDController::BuildDawnText` / `BuildScentText` | Static formatter helpers, exposed for unit tests. Clamp negative inputs to 0. |

## Test

`Test_P2HUD_DawnAndScentReadouts` — pure unit test (no scene needed):
- `"Dawn: "` prefix + value + `" s"` suffix
- Negative dawn input clamps (no minus sign in output)
- `"Scent: "` prefix + 2-decimal value
- Zero scent renders as `"0.00"`

The data path (DP_Night ticks, scent accumulation) is already covered by `Test_P1Dawn_*` and `Test_P1Scent_*`. This test pins the formatting contract specifically — orthogonal coverage.

## Test plan

- [x] Test passes in isolation
- [x] Full DP suite green: **99 passed, 0 failed**

## Roadmap impact

Closes **MVP-2.5.2 + MVP-2.5.4**. Remaining Phase-2 HUD items: 2.5.1 Whisper line, 2.5.3 Awareness icon, 2.5.5 Pause menu polish, 2.5.6 Main-menu Quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)