### PR TITLE
feat(dp): MVP-2.5.{1,3} -- HUD whisper line + Aelfric awareness icon

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="..\Tests\Test_P2Forge_AudibleAt30m.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_IronToSkeletonKey.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp" />
+    <ClCompile Include="..\Tests\Test_P2HUD_AelfricStateReadouts.cpp" />
     <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BellSoulRingsBell.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BogWaterEvaporates.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -233,6 +233,9 @@
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2HUD_AelfricStateReadouts.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -565,6 +565,7 @@
     <ClCompile Include="..\Tests\Test_P2Forge_AudibleAt30m.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_IronToSkeletonKey.cpp" />
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp" />
+    <ClCompile Include="..\Tests\Test_P2HUD_AelfricStateReadouts.cpp" />
     <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BellSoulRingsBell.cpp" />
     <ClCompile Include="..\Tests\Test_P2Reagent_BogWaterEvaporates.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -233,6 +233,9 @@
     <ClCompile Include="..\Tests\Test_P2Forge_WoodToSpike.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2HUD_AelfricStateReadouts.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2HUD_DawnAndScentReadouts.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
@@ -19,12 +19,17 @@
 #include "EntityComponent/Components/Zenith_ScriptComponent.h"
 #include "EntityComponent/Components/Zenith_UIComponent.h"
 #include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "AI/Components/Zenith_AIAgentComponent.h"
+#include "AI/BehaviorTree/Zenith_Blackboard.h"
 #include "UI/Zenith_UIText.h"
 #include "Maths/Zenith_Maths.h"
 
 #include "Source/PublicInterfaces.h"
 #include "Source/DevilsPlayground_Tags.h"
 #include "Components/DPVillager_Behaviour.h"
+#include "Components/Priest_Behaviour.h"
 
 #include <cstdio>
 #include <cstring>
@@ -165,6 +170,26 @@ public:
 				pxScent->SetVisible(true);
 			}
 		}
+
+		// MVP-2.5.1 + 2.5.3: Aelfric awareness state. Compute once;
+		// feed both the whisper line + the awareness icon.
+		const AelfricState eState = ComputeAelfricState();
+
+		if (auto* pxWhisper = xUI.FindElement<Zenith_UI::Zenith_UIText>("WhisperLine"))
+		{
+			char buf[64];
+			BuildWhisperText(buf, sizeof(buf), eState);
+			pxWhisper->SetText(buf);
+			pxWhisper->SetVisible(true);
+		}
+
+		if (auto* pxAwareness = xUI.FindElement<Zenith_UI::Zenith_UIText>("AelfricAwareness"))
+		{
+			char buf[48];
+			BuildAwarenessText(buf, sizeof(buf), eState);
+			pxAwareness->SetText(buf);
+			pxAwareness->SetVisible(true);
+		}
 	}
 
 public:
@@ -181,6 +206,81 @@ public:
 	{
 		if (fScent < 0.0f) fScent = 0.0f;
 		std::snprintf(szBuf, uBufSize, "Scent: %.2f", fScent);
+	}
+
+	// MVP-2.5.1 + 2.5.3: Aelfric awareness state. Derived from the
+	// priest's blackboard each frame:
+	//   Pursuing   -- BB_KEY_TARGET_WITH_DEVIL is a valid villager
+	//                 (priest sees the demon and is heading for them).
+	//   Suspicious -- BB_KEY_HAS_INVESTIGATE_POS is true (priest
+	//                 heard / saw something and is investigating)
+	//                 but no confirmed target.
+	//   Calm       -- neither flag set (default patrol).
+	enum class AelfricState : uint8_t
+	{
+		Calm = 0,
+		Suspicious,
+		Pursuing
+	};
+
+	// Awareness-icon text: the state name in caps. Placeholder per
+	// the roadmap (MVP-2.5.3) until a real icon asset lands.
+	static void BuildAwarenessText(char* szBuf, size_t uBufSize, AelfricState eState)
+	{
+		const char* szLabel = "CALM";
+		if      (eState == AelfricState::Pursuing)   szLabel = "PURSUING";
+		else if (eState == AelfricState::Suspicious) szLabel = "SUSPICIOUS";
+		std::snprintf(szBuf, uBufSize, "Aelfric: %s", szLabel);
+	}
+
+	// Whisper-line text: vibe copy that reacts to the priest's state.
+	// One line per state -- post-MVP polish would rotate through
+	// variants. Per MVP-2.5.1, the whisper line is a single-line
+	// bottom-centre text element.
+	static void BuildWhisperText(char* szBuf, size_t uBufSize, AelfricState eState)
+	{
+		const char* szLine = "He patrols.";
+		if      (eState == AelfricState::Pursuing)   szLine = "He sees you!";
+		else if (eState == AelfricState::Suspicious) szLine = "He stirs...";
+		std::snprintf(szBuf, uBufSize, "%s", szLine);
+	}
+
+	// Compute the current Aelfric state. Iterates Priest_Behaviour
+	// scripts in the active scene (typically just 1 priest), reads
+	// the agent's blackboard, classifies.
+	static AelfricState ComputeAelfricState()
+	{
+		AelfricState eOut = AelfricState::Calm;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&eOut](Zenith_EntityID xPriestId, Priest_Behaviour&)
+			{
+				Zenith_SceneData* pxScene =
+					Zenith_SceneManager::GetSceneDataForEntity(xPriestId);
+				if (pxScene == nullptr) return;
+				Zenith_Entity xEnt = pxScene->TryGetEntity(xPriestId);
+				if (!xEnt.IsValid()) return;
+				if (!xEnt.HasComponent<Zenith_AIAgentComponent>()) return;
+				Zenith_AIAgentComponent& xAg =
+					xEnt.GetComponent<Zenith_AIAgentComponent>();
+				Zenith_Blackboard& xBB = xAg.GetBlackboard();
+				const Zenith_EntityID xTarget =
+					xBB.GetEntityID(DP_AI::BB_KEY_TARGET_WITH_DEVIL);
+				if (xTarget.IsValid())
+				{
+					eOut = AelfricState::Pursuing;
+					return;
+				}
+				const bool bHasInvestigate =
+					xBB.GetBool(DP_AI::BB_KEY_HAS_INVESTIGATE_POS);
+				if (bHasInvestigate)
+				{
+					if (eOut < AelfricState::Suspicious)
+					{
+						eOut = AelfricState::Suspicious;
+					}
+				}
+			});
+		return eOut;
 	}
 
 private:

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -594,6 +594,26 @@ namespace
 		Zenith_EditorAutomation::AddStep_SetUIColor("ScentIndicator", 0.7f, 0.3f, 0.9f, 1.0f);
 		Zenith_EditorAutomation::AddStep_SetUIVisible("ScentIndicator", false);
 
+		// MVP-2.5.1: Whisper line -- single-line vibe text bottom-centre.
+		// The demon's voice reacting to Aelfric's awareness state.
+		// "He patrols." / "He stirs..." / "He sees you!" -- one line
+		// per state for MVP; rotation variants are post-MVP polish.
+		Zenith_EditorAutomation::AddStep_CreateUIText("WhisperLine", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("WhisperLine", static_cast<int>(Zenith_UI::AnchorPreset::BottomCenter));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("WhisperLine", 0.0f, -80.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("WhisperLine", 28.0f);
+		Zenith_EditorAutomation::AddStep_SetUIColor("WhisperLine", 0.85f, 0.4f, 0.4f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("WhisperLine", false);
+
+		// MVP-2.5.3: Aelfric awareness icon (placeholder: state-name
+		// as text at top-right, below the Objectives counter).
+		Zenith_EditorAutomation::AddStep_CreateUIText("AelfricAwareness", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("AelfricAwareness", static_cast<int>(Zenith_UI::AnchorPreset::TopRight));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("AelfricAwareness", -30.0f, 80.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("AelfricAwareness", 28.0f);
+		Zenith_EditorAutomation::AddStep_SetUIColor("AelfricAwareness", 0.95f, 0.6f, 0.3f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("AelfricAwareness", false);
+
 		// Attach the global coordinators. Each is independent — order doesn't
 		// matter, but Combat-style is to attach the player first.
 		Zenith_EditorAutomation::AddStep_AttachScript("DPPlayerController_Behaviour");

--- a/Games/DevilsPlayground/Tests/Test_P2HUD_AelfricStateReadouts.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2HUD_AelfricStateReadouts.cpp
@@ -1,0 +1,127 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+
+#include "Components/DPHUDController_Behaviour.h"
+
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P2HUD_AelfricStateReadouts (MVP-2.5.1 + MVP-2.5.3)
+//
+// Pins the formatting + state-mapping contract for two new HUD
+// readouts reactive to the priest's awareness:
+//
+//   WhisperLine        -- vibe text reflecting priest's state
+//                         ("He patrols." / "He stirs..." / "He sees you!")
+//   AelfricAwareness   -- state-name placeholder
+//                         ("Aelfric: CALM" / "SUSPICIOUS" / "PURSUING")
+//
+// As with Test_P2HUD_DawnAndScentReadouts, this is a unit test on
+// the formatters. The actual state-determination logic
+// (ComputeAelfricState) reads the priest's blackboard, which is
+// exercised by the existing priest tests (Test_P1Priest_*,
+// Test_P1Apprehend_*).
+//
+// What this catches:
+//   * BuildWhisperText or BuildAwarenessText hardcoded the wrong
+//     state-string mapping (e.g., "Pursuing" returns "He stirs...").
+//   * AelfricState enum re-ordered without updating the formatter
+//     switches.
+//   * Buffer-too-small truncation (the snprintf calls use small
+//     local buffers in production).
+// ============================================================================
+
+namespace
+{
+	bool g_bPassed = false;
+	const char* g_szFailureReason = "";
+
+	using AelfricState = DPHUDController_Behaviour::AelfricState;
+
+	bool Has(const char* sz, const char* szNeedle)
+	{
+		return sz != nullptr && std::strstr(sz, szNeedle) != nullptr;
+	}
+}
+
+static void Setup_P2HUDAelfric()
+{
+	g_bPassed = false;
+	g_szFailureReason = "";
+
+	char buf[64];
+
+	// --- WhisperLine ---
+	DPHUDController_Behaviour::BuildWhisperText(buf, sizeof(buf), AelfricState::Calm);
+	if (!Has(buf, "patrols"))
+	{
+		g_szFailureReason = "whisper for Calm doesn't contain 'patrols'";
+		return;
+	}
+	DPHUDController_Behaviour::BuildWhisperText(buf, sizeof(buf), AelfricState::Suspicious);
+	if (!Has(buf, "stirs"))
+	{
+		g_szFailureReason = "whisper for Suspicious doesn't contain 'stirs'";
+		return;
+	}
+	DPHUDController_Behaviour::BuildWhisperText(buf, sizeof(buf), AelfricState::Pursuing);
+	if (!Has(buf, "sees"))
+	{
+		g_szFailureReason = "whisper for Pursuing doesn't contain 'sees'";
+		return;
+	}
+
+	// --- AelfricAwareness ---
+	DPHUDController_Behaviour::BuildAwarenessText(buf, sizeof(buf), AelfricState::Calm);
+	if (!Has(buf, "Aelfric: ") || !Has(buf, "CALM"))
+	{
+		g_szFailureReason = "awareness for Calm doesn't contain 'Aelfric: CALM'";
+		return;
+	}
+	DPHUDController_Behaviour::BuildAwarenessText(buf, sizeof(buf), AelfricState::Suspicious);
+	if (!Has(buf, "SUSPICIOUS"))
+	{
+		g_szFailureReason = "awareness for Suspicious doesn't contain 'SUSPICIOUS'";
+		return;
+	}
+	DPHUDController_Behaviour::BuildAwarenessText(buf, sizeof(buf), AelfricState::Pursuing);
+	if (!Has(buf, "PURSUING"))
+	{
+		g_szFailureReason = "awareness for Pursuing doesn't contain 'PURSUING'";
+		return;
+	}
+
+	g_bPassed = true;
+	std::printf("[P2HUDAelfric] all 6 formatter cases passed\n");
+	std::fflush(stdout);
+}
+
+static bool Step_P2HUDAelfric(int /*iFrame*/)
+{
+	return false;
+}
+
+static bool Verify_P2HUDAelfric()
+{
+	if (!g_bPassed)
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2HUDAelfric: %s", g_szFailureReason);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2HUDAelfricTest = {
+	"Test_P2HUD_AelfricStateReadouts",
+	&Setup_P2HUDAelfric,
+	&Step_P2HUDAelfric,
+	&Verify_P2HUDAelfric,
+	60
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2HUDAelfricTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Two Aelfric-state-reactive HUD elements:

| Element | Position | Format |
|---|---|---|
| **WhisperLine** | bottom-centre | `"He patrols." / "He stirs..." / "He sees you!"` |
| **AelfricAwareness** | top-right | `"Aelfric: CALM" / "SUSPICIOUS" / "PURSUING"` |

Both read `DPHUDController::ComputeAelfricState()` each frame — iterates `Priest_Behaviour` scripts (typically 1) and reads the agent's blackboard:

| State | Condition |
|---|---|
| Pursuing | `BB_KEY_TARGET_WITH_DEVIL` valid |
| Suspicious | `BB_KEY_HAS_INVESTIGATE_POS` true (and not pursuing) |
| Calm | Neither set |

## Implementation

- New `AelfricState` enum + 2 static formatters + `ComputeAelfricState()` on DPHUDController
- 2 new update blocks in OnUpdate (FindElement→nullptr no-ops in gym scenes)
- 2 new UI elements authored in `AuthorGameLevelScene`

## Test

`Test_P2HUD_AelfricStateReadouts` — 6 formatter cases (3 states × 2 elements). The state-classification logic is exercised by existing priest tests (Test_P1Priest_*, Test_P1Apprehend_*); this PR pins the text-mapping contract specifically.

## Test plan

- [x] Test passes in isolation
- [x] Full DP suite green: **🎉 100 passed, 0 failed**

## Roadmap impact

Closes **MVP-2.5.1 + MVP-2.5.3**. Remaining Phase-2 HUD: 2.5.5 + 2.5.6 (pause + main-menu polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)