### PR TITLE
feat+test(dp): MVP-4.2 -- run-lost HUD banner + 3 loss-state playthroughs

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -284,6 +284,9 @@
     <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByApprehend.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByDawn.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -272,6 +272,15 @@
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByApprehend.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByDawn.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -578,6 +578,9 @@
     <ClCompile Include="..\Tests\Test_P2Reagent_UniquePickupChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P2Villager_ArchetypeStatsApplied.cpp" />
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByApprehend.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByDawn.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -272,6 +272,15 @@
     <ClCompile Include="..\Tests\Test_P3Inventory_ArchetypeCount.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByApprehend.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByDawn.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
@@ -62,6 +62,20 @@ public:
 					Zenith_Maths::Vector4(0.9f, 0.2f, 0.2f, 1.0f),
 					/*fHoldSeconds=*/2.5f);
 			});
+		// MVP-4.2 / 4.3.2: run-lost banner. Each cause has its own
+		// copy line that hangs permanently (run is over). The pause-
+		// menu R / Q shortcuts still work to restart / quit.
+		m_xRunLostHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnRunLost>(
+			[this](const DP_OnRunLost& xEvt)
+			{
+				m_bRunLostReceived = true;
+				m_eLastRunLostCause = xEvt.m_eCause;
+				char buf[64];
+				BuildRunLostText(buf, sizeof(buf), xEvt.m_eCause);
+				SetStatusText(buf,
+					Zenith_Maths::Vector4(0.9f, 0.2f, 0.2f, 1.0f),
+					/*fHoldSeconds=*/0.0f /* permanent */);
+			});
 	}
 
 	void OnDisable() ZENITH_FINAL override { TearDown(); }
@@ -245,6 +259,33 @@ public:
 		std::snprintf(szBuf, uBufSize, "%s", szLine);
 	}
 
+	// MVP-4.2 / 4.3.2: run-lost banner copy. One line per cause from
+	// DP_RunLostCause. Permanent display (run is over); the pause
+	// menu's R / Q shortcuts continue to work for restart / quit.
+	static void BuildRunLostText(char* szBuf, size_t uBufSize, DP_RunLostCause eCause)
+	{
+		const char* szLine = "RUN LOST";
+		switch (eCause)
+		{
+		case DP_RunLostCause::Apprehended: szLine = "CAUGHT BY AELFRIC"; break;
+		case DP_RunLostCause::Dawn:        szLine = "DAWN BREAKS"; break;
+		case DP_RunLostCause::NoVessels:   szLine = "NO VESSELS REMAIN"; break;
+		}
+		std::snprintf(szBuf, uBufSize, "%s", szLine);
+	}
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// MVP-4.2 test accessors: did the run-lost subscriber fire? Used
+	// by Phase-4 loss playthrough tests to verify the HUD reacted.
+	bool DidRunLostHandlerFireForTest() const { return m_bRunLostReceived; }
+	DP_RunLostCause LastRunLostCauseForTest() const { return m_eLastRunLostCause; }
+	void ResetRunLostForTest()
+	{
+		m_bRunLostReceived = false;
+		m_eLastRunLostCause = DP_RunLostCause::Apprehended;
+	}
+#endif
+
 	// Compute the current Aelfric state. Iterates Priest_Behaviour
 	// scripts in the active scene (typically just 1 priest), reads
 	// the agent's blackboard, classifies.
@@ -373,9 +414,17 @@ private:
 			Zenith_EventDispatcher::Get().Unsubscribe(m_xDeathHandle);
 			m_xDeathHandle = INVALID_EVENT_HANDLE;
 		}
+		if (m_xRunLostHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(m_xRunLostHandle);
+			m_xRunLostHandle = INVALID_EVENT_HANDLE;
+		}
 	}
 
 	Zenith_EventHandle m_xVictoryHandle       = INVALID_EVENT_HANDLE;
 	Zenith_EventHandle m_xDeathHandle         = INVALID_EVENT_HANDLE;
+	Zenith_EventHandle m_xRunLostHandle       = INVALID_EVENT_HANDLE;
 	float              m_fStatusHoldRemaining = -1.0f;  // <0 = permanent / not set
+	bool               m_bRunLostReceived     = false;
+	DP_RunLostCause    m_eLastRunLostCause    = DP_RunLostCause::Apprehended;
 };

--- a/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByApprehend.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByApprehend.cpp
@@ -1,0 +1,350 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_UIComponent.h"
+#include "UI/Zenith_UIText.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/Priest_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/DPHUDController_Behaviour.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P4Playthrough_LossByApprehend (MVP-4.2 -- Apprehend playthrough)
+//
+// Test_P1Apprehend_PriestCatchesPlayer already pins the priest's BT
+// Apprehend branch + DP_OnRunLost{Apprehended} dispatch. This test
+// pins the FULL playthrough chain: the dispatch reaches the HUD
+// subscriber and the HUD writes the correct run-lost banner copy.
+//
+// Procedure:
+//   1. Load GameLevel + subscribe to DP_OnRunLost.
+//   2. Pick the priest + the closest villager (matches the Phase 1
+//      apprehend test's selection so the scene state is identical).
+//   3. Possess the villager via DP_Player::SetPossessedVillager.
+//   4. Teleport the priest to ~1.5 m from the villager -- inside the
+//      2 m apprehend range default.
+//   5. Run frames until DP_OnRunLost fires (or 360-frame timeout).
+//   6. Verify:
+//        DP_OnRunLost fired with cause = Apprehended
+//        HUD's DidRunLostHandlerFireForTest() returns true
+//        HUD's LastRunLostCauseForTest() returns Apprehended
+//        HUD "Status" UI element text == "CAUGHT BY AELFRIC"
+//
+// What this catches (vs the Phase 1 unit test):
+//   * DPHUDController didn't subscribe to DP_OnRunLost.
+//   * HUD subscriber subscribed but didn't write the banner text.
+//   * BuildRunLostText returned the wrong string for Apprehended cause.
+//   * Status element wasn't authored on the HUD entity (the SetStatusText
+//     code path silently no-ops if the element is missing).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kLA_Start, kLA_WaitScene, kLA_Possess, kLA_TeleportPriest,
+	                   kLA_RunChannel, kLA_Snapshot, kLA_Verify, kLA_Done };
+
+	int                     g_iPhase = kLA_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xVillager;
+	Zenith_EventHandle      g_xRunLostHandle = INVALID_EVENT_HANDLE;
+	bool                    g_bRunLostFired = false;
+	DP_RunLostCause         g_eRunLostCause = DP_RunLostCause::Apprehended;
+	int                     g_iRunFrames = 0;
+	bool                    g_bHudFired = false;
+	DP_RunLostCause         g_eHudCause = DP_RunLostCause::Apprehended;
+	char                    g_szHudStatusText[128] = "<unset>";
+	bool                    g_bHudStatusVisible = false;
+
+	void OnRunLost(const DP_OnRunLost& xEvt)
+	{
+		g_bRunLostFired = true;
+		g_eRunLostCause = xEvt.m_eCause;
+	}
+
+	float HorizontalDistance(const Zenith_Maths::Vector3& xA,
+	                         const Zenith_Maths::Vector3& xB)
+	{
+		const float fDx = xA.x - xB.x;
+		const float fDz = xA.z - xB.z;
+		return std::sqrt(fDx * fDx + fDz * fDz);
+	}
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	bool TrySetEntityPos(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+		return true;
+	}
+
+	DPHUDController_Behaviour* FindHud()
+	{
+		DPHUDController_Behaviour* pxHud = nullptr;
+		DP_Query::ForEachScriptInActiveScene<DPHUDController_Behaviour>(
+			[&pxHud](Zenith_EntityID, DPHUDController_Behaviour& xH)
+			{
+				if (pxHud == nullptr) pxHud = &xH;
+			});
+		return pxHud;
+	}
+
+	Zenith_UI::Zenith_UIText* FindHudStatus()
+	{
+		Zenith_Scene xActive = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xActive);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_UI::Zenith_UIText* pxResult = nullptr;
+		pxScene->Query<Zenith_UIComponent>().ForEach(
+			[&pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
+			{
+				if (pxResult != nullptr) return;
+				pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>("Status");
+			});
+		return pxResult;
+	}
+}
+
+static void Setup_P4LossApprehend()
+{
+	g_iPhase = kLA_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_bRunLostFired = false;
+	g_eRunLostCause = DP_RunLostCause::Apprehended;
+	g_iRunFrames = 0;
+	g_bHudFired = false;
+	g_eHudCause = DP_RunLostCause::Apprehended;
+	std::snprintf(g_szHudStatusText, sizeof(g_szHudStatusText), "<unset>");
+	g_bHudStatusVisible = false;
+	g_xRunLostHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P4LossApprehend(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kLA_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kLA_WaitScene;
+		return true;
+
+	case kLA_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		Zenith_EntityID xFoundVillager;
+		float fClosestDist = 1e30f;
+
+		Zenith_Maths::Vector3 xPriestPos(0.0f);
+		bool bGotPriestPos = false;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest, &xPriestPos, &bGotPriestPos]
+			(Zenith_EntityID xId, Priest_Behaviour&)
+			{
+				xFoundPriest = xId;
+				bGotPriestPos = TryGetEntityPos(xId, xPriestPos);
+			});
+
+		if (xFoundPriest.IsValid() && bGotPriestPos)
+		{
+			DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+				[&xFoundVillager, &fClosestDist, &xPriestPos]
+				(Zenith_EntityID xId, DPVillager_Behaviour&)
+				{
+					Zenith_Maths::Vector3 xVPos;
+					if (!TryGetEntityPos(xId, xVPos)) return;
+					const float fD = HorizontalDistance(xPriestPos, xVPos);
+					if (fD < fClosestDist)
+					{
+						fClosestDist = fD;
+						xFoundVillager = xId;
+					}
+				});
+		}
+
+		// Wait for HUD to exist too -- it's authored alongside the GameManager.
+		DPHUDController_Behaviour* pxHud = FindHud();
+		if (xFoundPriest.IsValid() && xFoundVillager.IsValid() && pxHud != nullptr)
+		{
+			// Reset HUD run-lost flag so we observe this run's dispatch, not a
+			// stale one from a previous batched test that may have leaked.
+			pxHud->ResetRunLostForTest();
+			g_xPriest   = xFoundPriest;
+			g_xVillager = xFoundVillager;
+			g_iPhase    = kLA_Possess;
+		}
+		else if (iFrame > 90)
+		{
+			g_iPhase = kLA_Done;
+		}
+		return true;
+	}
+
+	case kLA_Possess:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kLA_TeleportPriest;
+		return true;
+
+	case kLA_TeleportPriest:
+	{
+		Zenith_Maths::Vector3 xVillagerPos;
+		if (!TryGetEntityPos(g_xVillager, xVillagerPos)) { g_iPhase = kLA_Done; return false; }
+		const Zenith_Maths::Vector3 xPriestPos(
+			xVillagerPos.x + 1.5f, xVillagerPos.y, xVillagerPos.z);
+		TrySetEntityPos(g_xPriest, xPriestPos);
+		g_iRunFrames = 0;
+		g_iPhase = kLA_RunChannel;
+		return true;
+	}
+
+	case kLA_RunChannel:
+		++g_iRunFrames;
+		// Channel default 3 s; allow 360 frames (~6 s) for BT reset latency.
+		// After dispatch, wait an additional 3 frames for the HUD's
+		// SetStatusText to make it through the dispatcher invocation.
+		if (g_bRunLostFired && g_iRunFrames >= 5)
+		{
+			// Allow at least 5 frames AND dispatch fired -- the dispatcher
+			// is synchronous so by next frame the HUD subscriber will have
+			// written the text.
+			g_iPhase = kLA_Snapshot;
+		}
+		else if (g_iRunFrames >= 360)
+		{
+			g_iPhase = kLA_Snapshot;
+		}
+		return true;
+
+	case kLA_Snapshot:
+	{
+		DPHUDController_Behaviour* pxHud = FindHud();
+		if (pxHud != nullptr)
+		{
+			g_bHudFired = pxHud->DidRunLostHandlerFireForTest();
+			g_eHudCause = pxHud->LastRunLostCauseForTest();
+		}
+		Zenith_UI::Zenith_UIText* pxStatus = FindHudStatus();
+		if (pxStatus != nullptr)
+		{
+			const std::string& strText = pxStatus->GetText();
+			std::snprintf(g_szHudStatusText, sizeof(g_szHudStatusText),
+				"%s", strText.c_str());
+			g_bHudStatusVisible = pxStatus->IsVisible();
+		}
+		g_iPhase = kLA_Verify;
+		return true;
+	}
+
+	case kLA_Verify:
+		std::printf("[P4LossApprehend] dispatched=%d cause=%d hudFired=%d hudCause=%d "
+			"hudStatusText=%s hudStatusVisible=%d frames=%d\n",
+			(int)g_bRunLostFired, (int)g_eRunLostCause,
+			(int)g_bHudFired, (int)g_eHudCause,
+			g_szHudStatusText, (int)g_bHudStatusVisible, g_iRunFrames);
+		std::fflush(stdout);
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+		g_xRunLostHandle = INVALID_EVENT_HANDLE;
+		g_iPhase = kLA_Done;
+		return false;
+
+	case kLA_Done:
+	default:
+		if (g_xRunLostHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+			g_xRunLostHandle = INVALID_EVENT_HANDLE;
+		}
+		return false;
+	}
+}
+
+static bool Verify_P4LossApprehend()
+{
+	if (!g_xPriest.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P4LossApprehend: priest entity not found");
+		return false;
+	}
+	if (!g_xVillager.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P4LossApprehend: villager entity not found");
+		return false;
+	}
+	if (!g_bRunLostFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossApprehend: DP_OnRunLost never fired (frames=%d) -- the priest's apprehend channel didn't complete, OR the apprehend action regressed and stopped dispatching DP_OnRunLost",
+			g_iRunFrames);
+		return false;
+	}
+	if (g_eRunLostCause != DP_RunLostCause::Apprehended)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossApprehend: DP_OnRunLost fired with cause=%d (expected %d=Apprehended)",
+			(int)g_eRunLostCause, (int)DP_RunLostCause::Apprehended);
+		return false;
+	}
+	if (!g_bHudFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossApprehend: HUD's DidRunLostHandlerFireForTest() returned false -- DPHUDController didn't subscribe to DP_OnRunLost, OR the subscription handle was unsubscribed prematurely (check TearDown)");
+		return false;
+	}
+	if (g_eHudCause != DP_RunLostCause::Apprehended)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossApprehend: HUD recorded cause=%d (expected %d=Apprehended) -- subscriber lambda forgot to cache xEvt.m_eCause",
+			(int)g_eHudCause, (int)DP_RunLostCause::Apprehended);
+		return false;
+	}
+	if (std::strcmp(g_szHudStatusText, "CAUGHT BY AELFRIC") != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossApprehend: HUD Status text is '%s', expected 'CAUGHT BY AELFRIC' -- BuildRunLostText returned wrong string for Apprehended cause, OR the SetStatusText call path failed",
+			g_szHudStatusText);
+		return false;
+	}
+	if (!g_bHudStatusVisible)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossApprehend: HUD Status text not visible -- SetStatusText's SetVisible(true) didn't take");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP4LossApprehendTest = {
+	"Test_P4Playthrough_LossByApprehend",
+	&Setup_P4LossApprehend,
+	&Step_P4LossApprehend,
+	&Verify_P4LossApprehend,
+	500
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP4LossApprehendTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByDawn.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByDawn.cpp
@@ -1,0 +1,248 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_UIComponent.h"
+#include "UI/Zenith_UIText.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPHUDController_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P4Playthrough_LossByDawn (MVP-4.2 -- Dawn playthrough)
+//
+// Test_P1Dawn_DispatchesRunLost pins the night timer + dispatch
+// mechanism. This test pins the FULL playthrough: the dispatch
+// reaches DPHUDController and the HUD writes "DAWN BREAKS".
+//
+// Procedure:
+//   1. Load GameLevel + subscribe to DP_OnRunLost.
+//   2. Wait for HUD controller to be authored.
+//   3. Reset HUD run-lost flag (clear any leak from previous batched test).
+//   4. Call DP_Night::StartNight(0.5) -- short night that expires in ~30
+//      frames at 60 Hz. DPPlayerController::OnUpdate calls TickNight each
+//      frame; the cross-zero detection fires DP_OnRunLost{Dawn} once.
+//   5. Tick ~90 frames so the dispatch has time to land AND the HUD's
+//      subscriber lambda runs.
+//   6. Verify:
+//        DP_OnRunLost fired with cause = Dawn
+//        HUD's DidRunLostHandlerFireForTest() returns true
+//        HUD's LastRunLostCauseForTest() returns Dawn
+//        HUD "Status" UI element text == "DAWN BREAKS"
+//
+// What this catches (vs Phase 1 unit test):
+//   * HUD's BuildRunLostText returned wrong string for Dawn cause.
+//   * HUD's subscriber switch-case missed the Dawn variant.
+//   * Status element was hidden by another writer between the dispatch
+//     and our snapshot (e.g., death timer fired during the test wait).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kLD_Start, kLD_WaitScene, kLD_ArmTimer,
+	                   kLD_TickWindow, kLD_Snapshot, kLD_Verify, kLD_Done };
+
+	int                     g_iPhase = kLD_Start;
+	int                     g_iTickFrames = 0;
+	Zenith_EventHandle      g_xRunLostHandle = INVALID_EVENT_HANDLE;
+	int                     g_iRunLostDawnCount = 0;
+	bool                    g_bHudFired = false;
+	DP_RunLostCause         g_eHudCause = DP_RunLostCause::Apprehended;
+	char                    g_szHudStatusText[128] = "<unset>";
+	bool                    g_bHudStatusVisible = false;
+
+	constexpr int kTICK_WINDOW_FRAMES = 90;
+	constexpr float kNIGHT_DURATION_S = 0.5f;
+
+	void OnRunLost(const DP_OnRunLost& xEvt)
+	{
+		if (xEvt.m_eCause == DP_RunLostCause::Dawn)
+		{
+			++g_iRunLostDawnCount;
+		}
+	}
+
+	DPHUDController_Behaviour* FindHud()
+	{
+		DPHUDController_Behaviour* pxHud = nullptr;
+		DP_Query::ForEachScriptInActiveScene<DPHUDController_Behaviour>(
+			[&pxHud](Zenith_EntityID, DPHUDController_Behaviour& xH)
+			{
+				if (pxHud == nullptr) pxHud = &xH;
+			});
+		return pxHud;
+	}
+
+	Zenith_UI::Zenith_UIText* FindHudStatus()
+	{
+		Zenith_Scene xActive = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xActive);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_UI::Zenith_UIText* pxResult = nullptr;
+		pxScene->Query<Zenith_UIComponent>().ForEach(
+			[&pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
+			{
+				if (pxResult != nullptr) return;
+				pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>("Status");
+			});
+		return pxResult;
+	}
+}
+
+static void Setup_P4LossDawn()
+{
+	g_iPhase = kLD_Start;
+	g_iTickFrames = 0;
+	g_iRunLostDawnCount = 0;
+	g_bHudFired = false;
+	g_eHudCause = DP_RunLostCause::Apprehended;
+	std::snprintf(g_szHudStatusText, sizeof(g_szHudStatusText), "<unset>");
+	g_bHudStatusVisible = false;
+	g_xRunLostHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P4LossDawn(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kLD_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kLD_WaitScene;
+		return true;
+
+	case kLD_WaitScene:
+	{
+		// Wait for HUD + at least one villager (so DPPlayerController is
+		// guaranteed to be ticking TickNight from OnUpdate -- it only fires
+		// when the controller exists, which happens after scene authoring).
+		DPHUDController_Behaviour* pxHud = FindHud();
+		int iVillagerCount = 0;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&iVillagerCount](Zenith_EntityID, DPVillager_Behaviour&)
+			{
+				++iVillagerCount;
+			});
+		if (pxHud != nullptr && iVillagerCount > 0)
+		{
+			pxHud->ResetRunLostForTest();
+			g_iPhase = kLD_ArmTimer;
+		}
+		else if (iFrame > 90)
+		{
+			g_iPhase = kLD_Done;
+		}
+		return true;
+	}
+
+	case kLD_ArmTimer:
+		DP_Night::StartNight(kNIGHT_DURATION_S);
+		g_iTickFrames = 0;
+		g_iPhase = kLD_TickWindow;
+		return true;
+
+	case kLD_TickWindow:
+		++g_iTickFrames;
+		if (g_iTickFrames >= kTICK_WINDOW_FRAMES) g_iPhase = kLD_Snapshot;
+		return true;
+
+	case kLD_Snapshot:
+	{
+		DPHUDController_Behaviour* pxHud = FindHud();
+		if (pxHud != nullptr)
+		{
+			g_bHudFired = pxHud->DidRunLostHandlerFireForTest();
+			g_eHudCause = pxHud->LastRunLostCauseForTest();
+		}
+		Zenith_UI::Zenith_UIText* pxStatus = FindHudStatus();
+		if (pxStatus != nullptr)
+		{
+			const std::string& strText = pxStatus->GetText();
+			std::snprintf(g_szHudStatusText, sizeof(g_szHudStatusText),
+				"%s", strText.c_str());
+			g_bHudStatusVisible = pxStatus->IsVisible();
+		}
+		g_iPhase = kLD_Verify;
+		return true;
+	}
+
+	case kLD_Verify:
+		std::printf("[P4LossDawn] dispatched=%d hudFired=%d hudCause=%d "
+			"hudStatusText=%s hudStatusVisible=%d ticks=%d\n",
+			g_iRunLostDawnCount,
+			(int)g_bHudFired, (int)g_eHudCause,
+			g_szHudStatusText, (int)g_bHudStatusVisible, g_iTickFrames);
+		std::fflush(stdout);
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+		g_xRunLostHandle = INVALID_EVENT_HANDLE;
+		// Reset DP_Night so the next batched test starts clean.
+		DP_Night::Reset();
+		g_iPhase = kLD_Done;
+		return false;
+
+	case kLD_Done:
+	default:
+		if (g_xRunLostHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+			g_xRunLostHandle = INVALID_EVENT_HANDLE;
+		}
+		return false;
+	}
+}
+
+static bool Verify_P4LossDawn()
+{
+	if (g_iRunLostDawnCount != 1)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossDawn: DP_OnRunLost{Dawn} fired %d times, expected exactly 1 -- the cross-zero detection failed, OR DP_Night::Reset() between tests didn't clear m_bDawnDispatched so a duplicate fired",
+			g_iRunLostDawnCount);
+		return false;
+	}
+	if (!g_bHudFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossDawn: HUD's DidRunLostHandlerFireForTest() returned false -- DPHUDController didn't subscribe to DP_OnRunLost, OR ResetRunLostForTest() ran AFTER the dispatch (timing bug)");
+		return false;
+	}
+	if (g_eHudCause != DP_RunLostCause::Dawn)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossDawn: HUD recorded cause=%d (expected %d=Dawn) -- subscriber lambda forgot to cache xEvt.m_eCause, OR a stale Apprehended dispatch from an earlier test polluted the state",
+			(int)g_eHudCause, (int)DP_RunLostCause::Dawn);
+		return false;
+	}
+	if (std::strcmp(g_szHudStatusText, "DAWN BREAKS") != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossDawn: HUD Status text is '%s', expected 'DAWN BREAKS' -- BuildRunLostText returned wrong string for Dawn cause",
+			g_szHudStatusText);
+		return false;
+	}
+	if (!g_bHudStatusVisible)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossDawn: HUD Status text not visible -- SetStatusText's SetVisible(true) didn't take");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP4LossDawnTest = {
+	"Test_P4Playthrough_LossByDawn",
+	&Setup_P4LossDawn,
+	&Step_P4LossDawn,
+	&Verify_P4LossDawn,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP4LossDawnTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByNoVessels.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByNoVessels.cpp
@@ -1,0 +1,271 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_UIComponent.h"
+#include "Collections/Zenith_Vector.h"
+#include "UI/Zenith_UIText.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/DPHUDController_Behaviour.h"
+
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P4Playthrough_LossByNoVessels (MVP-4.2 -- NoVessels playthrough)
+//
+// Test_P1NoVessels_DispatchesRunLost pins the Kill()-driven NoVessels
+// dispatch. This test pins the FULL playthrough: the dispatch reaches
+// DPHUDController and the HUD writes "NO VESSELS REMAIN".
+//
+// Procedure:
+//   1. Load GameLevel + subscribe to DP_OnRunLost.
+//   2. Wait for HUD + at least 2 villagers.
+//   3. Reset HUD run-lost flag (clear any leak from previous batched test).
+//   4. Collect every villager EntityID, then call Kill() on each.
+//      Kill()'s alive-count scan dispatches DP_OnRunLost{NoVessels} on
+//      the last villager.
+//   5. Wait one tick for the dispatch to land at the HUD subscriber.
+//   6. Verify:
+//        DP_OnRunLost fired with cause = NoVessels
+//        HUD's DidRunLostHandlerFireForTest() returns true
+//        HUD's LastRunLostCauseForTest() returns NoVessels
+//        HUD "Status" UI element text == "NO VESSELS REMAIN"
+//
+// What this catches (vs Phase 1 unit test):
+//   * HUD's BuildRunLostText returned wrong string for NoVessels cause.
+//   * HUD's subscriber switch-case missed the NoVessels variant.
+//   * Per-villager DP_OnVillagerDied "Possess another villager" status
+//     update fired AFTER the run-lost status, overwriting it (banner
+//     should be permanent when the run is over -- the most-recent dead
+//     villager status would still show otherwise).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kLNV_Start, kLNV_WaitScene, kLNV_KillAll,
+	                   kLNV_WaitDispatch, kLNV_Snapshot, kLNV_Verify, kLNV_Done };
+
+	int                     g_iPhase = kLNV_Start;
+	int                     g_iVillagerCountAtStart = 0;
+	int                     g_iWait = 0;
+	Zenith_EventHandle      g_xRunLostHandle = INVALID_EVENT_HANDLE;
+	int                     g_iRunLostNoVesselsCount = 0;
+	bool                    g_bHudFired = false;
+	DP_RunLostCause         g_eHudCause = DP_RunLostCause::Apprehended;
+	char                    g_szHudStatusText[128] = "<unset>";
+	bool                    g_bHudStatusVisible = false;
+
+	void OnRunLost(const DP_OnRunLost& xEvt)
+	{
+		if (xEvt.m_eCause == DP_RunLostCause::NoVessels)
+		{
+			++g_iRunLostNoVesselsCount;
+		}
+	}
+
+	DPHUDController_Behaviour* FindHud()
+	{
+		DPHUDController_Behaviour* pxHud = nullptr;
+		DP_Query::ForEachScriptInActiveScene<DPHUDController_Behaviour>(
+			[&pxHud](Zenith_EntityID, DPHUDController_Behaviour& xH)
+			{
+				if (pxHud == nullptr) pxHud = &xH;
+			});
+		return pxHud;
+	}
+
+	Zenith_UI::Zenith_UIText* FindHudStatus()
+	{
+		Zenith_Scene xActive = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xActive);
+		if (pxScene == nullptr) return nullptr;
+		Zenith_UI::Zenith_UIText* pxResult = nullptr;
+		pxScene->Query<Zenith_UIComponent>().ForEach(
+			[&pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
+			{
+				if (pxResult != nullptr) return;
+				pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>("Status");
+			});
+		return pxResult;
+	}
+}
+
+static void Setup_P4LossNoVessels()
+{
+	g_iPhase = kLNV_Start;
+	g_iVillagerCountAtStart = 0;
+	g_iWait = 0;
+	g_iRunLostNoVesselsCount = 0;
+	g_bHudFired = false;
+	g_eHudCause = DP_RunLostCause::Apprehended;
+	std::snprintf(g_szHudStatusText, sizeof(g_szHudStatusText), "<unset>");
+	g_bHudStatusVisible = false;
+	g_xRunLostHandle = Zenith_EventDispatcher::Get().Subscribe<DP_OnRunLost>(&OnRunLost);
+}
+
+static bool Step_P4LossNoVessels(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kLNV_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kLNV_WaitScene;
+		return true;
+
+	case kLNV_WaitScene:
+	{
+		int iCount = 0;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&iCount](Zenith_EntityID, DPVillager_Behaviour&) { ++iCount; });
+		DPHUDController_Behaviour* pxHud = FindHud();
+		if (iCount >= 2 && pxHud != nullptr)
+		{
+			pxHud->ResetRunLostForTest();
+			g_iVillagerCountAtStart = iCount;
+			g_iPhase = kLNV_KillAll;
+		}
+		else if (iFrame > 90)
+		{
+			g_iPhase = kLNV_Done;
+		}
+		return true;
+	}
+
+	case kLNV_KillAll:
+	{
+		Zenith_Vector<Zenith_EntityID> axVillagers;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&axVillagers](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				axVillagers.PushBack(xId);
+			});
+		for (uint32_t u = 0; u < axVillagers.GetSize(); ++u)
+		{
+			Zenith_EntityID xId = axVillagers.Get(u);
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+			if (pxScene == nullptr) continue;
+			Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+			if (!xEnt.IsValid()) continue;
+			if (!xEnt.HasComponent<Zenith_ScriptComponent>()) continue;
+			DPVillager_Behaviour* pxV =
+				xEnt.GetComponent<Zenith_ScriptComponent>().GetScript<DPVillager_Behaviour>();
+			if (pxV != nullptr) pxV->Kill();
+		}
+		g_iWait = 0;
+		g_iPhase = kLNV_WaitDispatch;
+		return true;
+	}
+
+	case kLNV_WaitDispatch:
+		++g_iWait;
+		// One frame for the dispatch chain (Kill() is synchronous so the
+		// HUD has already received the event, but the test status text
+		// readback wants a clean OnUpdate cycle to be safe).
+		if (g_iWait >= 3) g_iPhase = kLNV_Snapshot;
+		return true;
+
+	case kLNV_Snapshot:
+	{
+		DPHUDController_Behaviour* pxHud = FindHud();
+		if (pxHud != nullptr)
+		{
+			g_bHudFired = pxHud->DidRunLostHandlerFireForTest();
+			g_eHudCause = pxHud->LastRunLostCauseForTest();
+		}
+		Zenith_UI::Zenith_UIText* pxStatus = FindHudStatus();
+		if (pxStatus != nullptr)
+		{
+			const std::string& strText = pxStatus->GetText();
+			std::snprintf(g_szHudStatusText, sizeof(g_szHudStatusText),
+				"%s", strText.c_str());
+			g_bHudStatusVisible = pxStatus->IsVisible();
+		}
+		g_iPhase = kLNV_Verify;
+		return true;
+	}
+
+	case kLNV_Verify:
+		std::printf("[P4LossNoVessels] villagers=%d noVesselsCount=%d hudFired=%d hudCause=%d "
+			"hudStatusText=%s hudStatusVisible=%d\n",
+			g_iVillagerCountAtStart, g_iRunLostNoVesselsCount,
+			(int)g_bHudFired, (int)g_eHudCause,
+			g_szHudStatusText, (int)g_bHudStatusVisible);
+		std::fflush(stdout);
+		Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+		g_xRunLostHandle = INVALID_EVENT_HANDLE;
+		g_iPhase = kLNV_Done;
+		return false;
+
+	case kLNV_Done:
+	default:
+		if (g_xRunLostHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(g_xRunLostHandle);
+			g_xRunLostHandle = INVALID_EVENT_HANDLE;
+		}
+		return false;
+	}
+}
+
+static bool Verify_P4LossNoVessels()
+{
+	if (g_iVillagerCountAtStart < 2)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossNoVessels: only %d villagers found in GameLevel (need >= 2 for the test to be meaningful)",
+			g_iVillagerCountAtStart);
+		return false;
+	}
+	if (g_iRunLostNoVesselsCount != 1)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossNoVessels: DP_OnRunLost{NoVessels} fired %d times, expected exactly 1",
+			g_iRunLostNoVesselsCount);
+		return false;
+	}
+	if (!g_bHudFired)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossNoVessels: HUD's DidRunLostHandlerFireForTest() returned false -- DPHUDController didn't subscribe to DP_OnRunLost");
+		return false;
+	}
+	if (g_eHudCause != DP_RunLostCause::NoVessels)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossNoVessels: HUD recorded cause=%d (expected %d=NoVessels) -- subscriber lambda forgot to cache xEvt.m_eCause",
+			(int)g_eHudCause, (int)DP_RunLostCause::NoVessels);
+		return false;
+	}
+	if (std::strcmp(g_szHudStatusText, "NO VESSELS REMAIN") != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossNoVessels: HUD Status text is '%s', expected 'NO VESSELS REMAIN' -- BuildRunLostText returned wrong string for NoVessels cause, OR a per-villager death-status update fired AFTER and overwrote the permanent run-lost banner",
+			g_szHudStatusText);
+		return false;
+	}
+	if (!g_bHudStatusVisible)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4LossNoVessels: HUD Status text not visible -- SetStatusText's SetVisible(true) didn't take");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP4LossNoVesselsTest = {
+	"Test_P4Playthrough_LossByNoVessels",
+	&Setup_P4LossNoVessels,
+	&Step_P4LossNoVessels,
+	&Verify_P4LossNoVessels,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP4LossNoVesselsTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

Phase-1 tests pinned the **dispatch** of every `DP_OnRunLost{cause}` variant (Apprehend / Dawn / NoVessels). They never verified the HUD reacted -- and it didn't, because `DPHUDController_Behaviour` only subscribed to `DP_OnVictory` and `DP_OnVillagerDied`. A player losing a run saw nothing in the UI.

This PR:
- Wires `DPHUDController` to `DP_OnRunLost` with permanent banner copy per cause (`CAUGHT BY AELFRIC` / `DAWN BREAKS` / `NO VESSELS REMAIN`).
- Adds 3 Phase-4 integration tests that pin the **full** chain dispatch -> subscriber -> Status text -> visibility.

## What this catches (vs Phase-1 unit tests)

- HUD didn't subscribe to `DP_OnRunLost` at all (orphan dispatch).
- `BuildRunLostText` returns the wrong string per cause.
- HUD's per-villager death-status update (2.5s hold) fires AFTER the permanent run-lost banner, overwriting it (NoVessels test exercises this -- 17 sequential `Kill()` calls means 17 death-banner writes followed by the run-lost write).
- `SetVisible(true)` doesn't take in `SetStatusText`.

## Test plan

- [x] Local: `pwsh Tools/run_dp_tests.ps1 -Headless -Filter Test_P4Playthrough` -> 3/3 PASS.
- [x] Local: full suite via `pwsh Tools/run_dp_tests.ps1 -Headless` -> **109 passed, 0 failed**.

Next on the autonomous-loop queue:
- PR #76: BellSoul truly map-wide (fix the documented 30 m hearing-range clamp).
- PR #77: Rename `DP_Player::ResetForTest` -> `ResetForNewRun` (production `HandleRestart` uses it -- the `ForTest` suffix is misleading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)