### PR TITLE
feat+test(dp): MVP-2.2.6 -- BellSoul truly map-wide

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -265,6 +265,7 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannelInterrupt.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
+    <ClCompile Include="..\Tests\Test_P2BellSoul_AudibleAcrossMap.cpp" />
     <ClCompile Include="..\Tests\Test_P2BellSoul_PriestHearsTheBell.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -215,6 +215,9 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2BellSoul_AudibleAcrossMap.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2BellSoul_PriestHearsTheBell.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -559,6 +559,7 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannel.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_DevoutChannelInterrupt.cpp" />
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp" />
+    <ClCompile Include="..\Tests\Test_P2BellSoul_AudibleAcrossMap.cpp" />
     <ClCompile Include="..\Tests\Test_P2BellSoul_PriestHearsTheBell.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_AelfricNotRevealed.cpp" />
     <ClCompile Include="..\Tests\Test_P2Fog_LightAddsHole.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -215,6 +215,9 @@
     <ClCompile Include="..\Tests\Test_P2Archetype_TimersMatchSpec.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P2BellSoul_AudibleAcrossMap.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P2BellSoul_PriestHearsTheBell.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPItemBase_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPItemBase_Behaviour.h
@@ -175,9 +175,24 @@ public:
 
 		// MVP-2.2.6: BellSoul rings the bell on pickup -- audible to
 		// every priest on the map. Dispatches DP_OnBellRing (HUD +
-		// state-machine subscribers) and emits a map-wide perception
-		// stimulus (200 m radius, well past the priest's 30 m
-		// hearing range so it's guaranteed to register).
+		// state-machine subscribers) AND triggers the map-wide priest
+		// fanout.
+		//
+		// Two propagation paths run in parallel:
+		//   1. Zenith_PerceptionSystem::EmitSoundStimulus -- the normal
+		//      hearing path. Priests within their own hearing_range_m
+		//      (30 m default) pick it up here. Going through perception
+		//      gives the priest's BridgePerceptionToBlackboard the
+		//      stale-source-entity scrub it needs (the BellSoul entity
+		//      is destroyed on pickup so the perception system would
+		//      otherwise drop the stimulus on its next tick).
+		//   2. DP_AI::NotifyAllPriestsOfInvestigatePos -- direct BB
+		//      write to every priest in the scene, regardless of
+		//      distance. This delivers the GDD's "audible from the
+		//      entire map" intent; the perception system's
+		//      min(emit_radius, agent_max_range) clamp would otherwise
+		//      cap audibility at the 30 m hearing range no matter how
+		//      loud the bell.
 		if (m_strSpecialBehaviour == "rings_bell_on_pickup")
 		{
 			DP_OnBellRing xEvt;
@@ -185,10 +200,12 @@ public:
 			xEvt.m_xBellSoul = m_xParentEntity.GetEntityID();
 			xEvt.m_xPosition = xMyPos;
 			Zenith_EventDispatcher::Get().Dispatch(xEvt);
-			// Perception stimulus: map-wide. Loudness 1.0 (max),
-			// radius 200 m (well past Aelfric's 30 m hearing range).
+			// Perception stimulus: serves priests within hearing range.
 			Zenith_PerceptionSystem::EmitSoundStimulus(
 				xMyPos, 1.0f, 200.0f, m_xParentEntity.GetEntityID());
+			// Direct BB fanout: serves every priest beyond hearing
+			// range. Both paths together = truly map-wide.
+			DP_AI::NotifyAllPriestsOfInvestigatePos(xMyPos);
 		}
 	}
 

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -747,6 +747,34 @@ namespace DP_AI
 		Zenith_PerceptionSystem::EmitSoundStimulus(xPos, fLoudness, fRadius, xSource);
 	}
 
+	void NotifyAllPriestsOfInvestigatePos(Vec3 xPos)
+	{
+		// Direct-BB-write fanout, deliberately bypassing the perception
+		// system. The perception path clamps each agent's hearing radius
+		// at agent_max_range (priest default 30 m) -- so a 200 m bell
+		// emit doesn't reach a priest 100 m away. The GDD intent for
+		// BellSoul is "map-wide" so we iterate every priest in the
+		// active scene and write straight into its BB. The existing
+		// DP_BTAction_ClearInvestigatePos node still owns the slot's
+		// lifetime: the next time the priest reaches xPos and the
+		// wait/clear sequence completes, the slot clears normally.
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xPos](Zenith_EntityID xPriestId, Priest_Behaviour&)
+			{
+				Zenith_SceneData* pxScene =
+					Zenith_SceneManager::GetSceneDataForEntity(xPriestId);
+				if (pxScene == nullptr) return;
+				Zenith_Entity xEnt = pxScene->TryGetEntity(xPriestId);
+				if (!xEnt.IsValid()) return;
+				if (!xEnt.HasComponent<Zenith_AIAgentComponent>()) return;
+				Zenith_AIAgentComponent& xAg =
+					xEnt.GetComponent<Zenith_AIAgentComponent>();
+				Zenith_Blackboard& xBB = xAg.GetBlackboard();
+				xBB.SetVector3(BB_KEY_INVESTIGATE_POS, xPos);
+				xBB.SetBool(BB_KEY_HAS_INVESTIGATE_POS, true);
+			});
+	}
+
 	const Zenith_NavMesh* GetOrBuildLevelNavMesh()
 	{
 		// Cache hit: same build-indexed scene as last call.

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -291,6 +291,19 @@ namespace DP_AI
 
 	void EmitNoise(Vec3 xPos, float fLoudness, float fRadius, Zenith_EntityID xSource);
 
+	// MVP-2.2.6+ map-wide bell broadcast. The perception system clamps each
+	// agent's hearing at min(emit_radius, agent_max_range), so a 200 m
+	// EmitNoise emit still cuts off at the priest's 30 m hearing_range_m --
+	// breaking the GDD's "BellSoul audible from the entire map" promise.
+	// This helper bypasses perception and writes directly to every
+	// Priest_Behaviour agent's blackboard:
+	//   BB_KEY_INVESTIGATE_POS      <- xPos
+	//   BB_KEY_HAS_INVESTIGATE_POS  <- true
+	// The investigate-pos slot is then consumed by the existing
+	// DP_BTAction_ClearInvestigatePos sequence, so the rest of the BT
+	// flow is unchanged.
+	void NotifyAllPriestsOfInvestigatePos(Vec3 xPos);
+
 	// Lazily-built level navmesh. First call generates a synthetic flat
 	// 200m × 200m polygon centred on the priest start (the source UE map
 	// uses rough authoring positions that aren't on a single navmesh

--- a/Games/DevilsPlayground/Tests/Test_P2BellSoul_AudibleAcrossMap.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2BellSoul_AudibleAcrossMap.cpp
@@ -1,0 +1,303 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_ModelComponent.h"
+#include "AI/Components/Zenith_AIAgentComponent.h"
+#include "AI/BehaviorTree/Zenith_Blackboard.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DevilsPlayground_Tags.h"
+#include "Components/DPItemBase_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/Priest_Behaviour.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_P2BellSoul_AudibleAcrossMap (MVP-2.2.6 GDD-PARITY -- INTEGRATION)
+//
+// Test_P2BellSoul_PriestHearsTheBell pins the WITHIN-RANGE perception
+// path (priest 20 m from the bell). The GDD promises BellSoul is
+// audible from the ENTIRE map -- the perception system's
+// min(emit_radius, agent_max_range) clamp breaks that promise at the
+// engine layer (a priest 100+ m away can't hear the bell even though
+// the emit radius is 200 m, because the priest's hearing_range_m
+// caps perception at 30 m).
+//
+// MVP-2.2.6 fix: DPItemBase's BellSoul branch now ALSO calls
+// DP_AI::NotifyAllPriestsOfInvestigatePos which iterates every priest
+// in the scene and writes BB.HasInvestigatePos=true + InvestigatePos
+// directly, bypassing the perception clamp.
+//
+// This test pins THAT path: a priest 120 m away from the BellSoul
+// receives the BB update.
+//
+// Procedure:
+//   1. Load GameLevel; find priest + a villager + build a BellSoul.
+//   2. Teleport priest 120 m EAST of the BellSoul -- well past the
+//      perception clamp (30 m hearing range, 200 m emit). The
+//      perception path would never fire here.
+//   3. Possess the villager, teleport onto the BellSoul.
+//   4. Tick 80 frames so the 1.0 s pickup channel completes AND the
+//      priest's per-frame OnUpdate has had a chance to observe the
+//      BB write.
+//   5. Read priest's BB. HasInvestigatePos must be true, with
+//      InvestigatePos near the BellSoul's world position.
+//
+// What this catches:
+//   * Someone removes the NotifyAllPriestsOfInvestigatePos call from
+//     DPItemBase's BellSoul branch (the "200 m emit covers everything"
+//     comment that was wrong before MVP-2.2.6 returns).
+//   * The helper's per-priest BB iteration regresses (e.g., starts
+//     filtering by perception distance, defeating its purpose).
+//   * The BridgePerceptionToBlackboard call overwrites BB.InvestigatePos
+//     every frame with a default Vector3 when no perception hit lands,
+//     erasing the direct write before the BT can read it.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int {
+		kBA_Start, kBA_WaitScene, kBA_BuildBellSoul, kBA_TeleportPriest,
+		kBA_PossessVillager, kBA_TeleportVillager, kBA_TickPickup,
+		kBA_Snapshot, kBA_Verify, kBA_Done
+	};
+
+	int                     g_iPhase = kBA_Start;
+	Zenith_EntityID         g_xPriest;
+	Zenith_EntityID         g_xVillager;
+	Zenith_EntityID         g_xBellSoul;
+	Zenith_Maths::Vector3   g_xBellSoulPos(0.0f);
+	int                     g_iTickCounter = 0;
+
+	bool                    g_bHasInvestigatePos = false;
+	Zenith_Maths::Vector3   g_xInvestigatePos(0.0f);
+	Zenith_EntityID         g_xHeldAfter;
+
+	constexpr int kPICKUP_TICKS = 80;
+	// 120 m: 4x the priest's 30 m hearing range. If the perception path
+	// were the only one wired up, the bell would be silent here.
+	constexpr float kPRIEST_FAR_DIST = 120.0f;
+
+	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	void TeleportTo(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
+	}
+
+	void ReadPriestBB(Zenith_EntityID xPriestId,
+	                  bool& bHasInvestigatePosOut,
+	                  Zenith_Maths::Vector3& xInvestigatePosOut)
+	{
+		bHasInvestigatePosOut = false;
+		xInvestigatePosOut = Zenith_Maths::Vector3(0.0f);
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xPriestId);
+		if (pxScene == nullptr) return;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xPriestId);
+		if (!xEnt.IsValid() || !xEnt.HasComponent<Zenith_AIAgentComponent>()) return;
+		Zenith_AIAgentComponent& xAg = xEnt.GetComponent<Zenith_AIAgentComponent>();
+		Zenith_Blackboard& xBB = xAg.GetBlackboard();
+		bHasInvestigatePosOut = xBB.GetBool(DP_AI::BB_KEY_HAS_INVESTIGATE_POS);
+		xInvestigatePosOut = xBB.GetVector3(DP_AI::BB_KEY_INVESTIGATE_POS);
+	}
+}
+
+static void Setup_P2BellSoulAudibleAcrossMap()
+{
+	g_iPhase = kBA_Start;
+	g_xPriest = INVALID_ENTITY_ID;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_xBellSoul = INVALID_ENTITY_ID;
+	g_xBellSoulPos = Zenith_Maths::Vector3(0.0f);
+	g_iTickCounter = 0;
+	g_bHasInvestigatePos = false;
+	g_xInvestigatePos = Zenith_Maths::Vector3(0.0f);
+	g_xHeldAfter = INVALID_ENTITY_ID;
+}
+
+static bool Step_P2BellSoulAudibleAcrossMap(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kBA_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kBA_WaitScene;
+		return true;
+
+	case kBA_WaitScene:
+	{
+		Zenith_EntityID xFoundPriest;
+		Zenith_EntityID xFoundVillager;
+		DP_Query::ForEachScriptInActiveScene<Priest_Behaviour>(
+			[&xFoundPriest](Zenith_EntityID xId, Priest_Behaviour&)
+			{ xFoundPriest = xId; });
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFoundVillager](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFoundVillager.IsValid()) xFoundVillager = xId;
+			});
+		if (xFoundPriest.IsValid() && xFoundVillager.IsValid())
+		{
+			g_xPriest = xFoundPriest;
+			g_xVillager = xFoundVillager;
+			g_iPhase = kBA_BuildBellSoul;
+		}
+		else if (iFrame > 60)
+		{
+			g_iPhase = kBA_Done;
+		}
+		return true;
+	}
+
+	case kBA_BuildBellSoul:
+	{
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene == nullptr) { g_iPhase = kBA_Done; return false; }
+		Zenith_Entity xEnt(pxScene, std::string("Test_BellSoul_AudibleAcrossMap"));
+		if (!xEnt.IsValid()) { g_iPhase = kBA_Done; return false; }
+		g_xBellSoul = xEnt.GetEntityID();
+		// Place the BellSoul far from the priest's start spot so the
+		// teleport step (next) has somewhere to go.
+		g_xBellSoulPos = Zenith_Maths::Vector3(500.0f, 0.0f, 500.0f);
+		if (xEnt.HasComponent<Zenith_TransformComponent>())
+		{
+			xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(g_xBellSoulPos);
+		}
+		xEnt.AddComponent<Zenith_ModelComponent>().LoadModel(
+			std::string(GAME_ASSETS_DIR) + "Meshes/LevelPrototyping_Meshes_SM_Cube" ZENITH_MODEL_EXT);
+		DPItemBase_Behaviour* pxBeh = xEnt.AddComponent<Zenith_ScriptComponent>()
+			.AddScript<DPItemBase_Behaviour>();
+		if (pxBeh != nullptr) pxBeh->SetTag(DP_ItemTag::BellSoul);
+		g_iPhase = kBA_TeleportPriest;
+		return true;
+	}
+
+	case kBA_TeleportPriest:
+	{
+		// 120 m from the BellSoul. Priest's hearing_range_m is 30 m;
+		// EmitSoundStimulus's perception path can't deliver here.
+		// Only the direct BB fanout from NotifyAllPriestsOfInvestigatePos
+		// will reach the priest at this distance.
+		Zenith_Maths::Vector3 xFar(g_xBellSoulPos.x + kPRIEST_FAR_DIST,
+		                           g_xBellSoulPos.y,
+		                           g_xBellSoulPos.z);
+		TeleportTo(g_xPriest, xFar);
+		g_iPhase = kBA_PossessVillager;
+		return true;
+	}
+
+	case kBA_PossessVillager:
+		DP_Player::SetPossessedVillager(g_xVillager);
+		g_iPhase = kBA_TeleportVillager;
+		return true;
+
+	case kBA_TeleportVillager:
+		TeleportTo(g_xVillager, g_xBellSoulPos);
+		g_iTickCounter = 0;
+		g_iPhase = kBA_TickPickup;
+		return true;
+
+	case kBA_TickPickup:
+		++g_iTickCounter;
+		if (g_iTickCounter >= kPICKUP_TICKS) g_iPhase = kBA_Snapshot;
+		return true;
+
+	case kBA_Snapshot:
+		g_xHeldAfter = DP_Player::GetHeldItemEntity(g_xVillager);
+		ReadPriestBB(g_xPriest, g_bHasInvestigatePos, g_xInvestigatePos);
+		g_iPhase = kBA_Verify;
+		return true;
+
+	case kBA_Verify:
+		std::printf("[P2BellSoulAudibleAcrossMap] held=(%u/%u) hasInvPos=%d invPos=(%.2f,%.2f,%.2f) expected bellSoulPos=(%.2f,%.2f,%.2f) priestDist=%.1fm\n",
+			g_xHeldAfter.m_uIndex, g_xHeldAfter.m_uGeneration,
+			(int)g_bHasInvestigatePos,
+			g_xInvestigatePos.x, g_xInvestigatePos.y, g_xInvestigatePos.z,
+			g_xBellSoulPos.x, g_xBellSoulPos.y, g_xBellSoulPos.z,
+			kPRIEST_FAR_DIST);
+		std::fflush(stdout);
+		g_iPhase = kBA_Done;
+		return false;
+
+	case kBA_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P2BellSoulAudibleAcrossMap()
+{
+	if (!g_xPriest.IsValid() || !g_xVillager.IsValid() || !g_xBellSoul.IsValid())
+	{
+		Zenith_Log(LOG_CATEGORY_AI, "P2BellSoulAudibleAcrossMap: setup entities missing");
+		return false;
+	}
+	// Precondition: pickup must have completed.
+	if (!g_xHeldAfter.IsValid()
+		|| g_xHeldAfter.m_uIndex != g_xBellSoul.m_uIndex
+		|| g_xHeldAfter.m_uGeneration != g_xBellSoul.m_uGeneration)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2BellSoulAudibleAcrossMap: pickup didn't complete (held=%u/%u, expected BellSoul %u/%u)",
+			g_xHeldAfter.m_uIndex, g_xHeldAfter.m_uGeneration,
+			g_xBellSoul.m_uIndex, g_xBellSoul.m_uGeneration);
+		return false;
+	}
+	// Main assertion: priest 120m away knows the bell rang.
+	if (!g_bHasInvestigatePos)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2BellSoulAudibleAcrossMap: priest at %.0fm did NOT receive the bell's investigate-pos. The map-wide BB fanout (DP_AI::NotifyAllPriestsOfInvestigatePos) regressed or DPItemBase's BellSoul branch stopped calling it -- the GDD's map-wide audibility is broken",
+			kPRIEST_FAR_DIST);
+		return false;
+	}
+	// Sanity: investigate position should be near the BellSoul. The
+	// direct-write path delivers EXACTLY xMyPos so we use a tight
+	// tolerance (the perception path's "last heard" can drift by a
+	// few metres; the direct path doesn't).
+	const float fDx = g_xInvestigatePos.x - g_xBellSoulPos.x;
+	const float fDz = g_xInvestigatePos.z - g_xBellSoulPos.z;
+	const float fDistSq = fDx * fDx + fDz * fDz;
+	if (fDistSq > 1.0f) // 1m tolerance
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P2BellSoulAudibleAcrossMap: priest investigate pos (%.2f,%.2f,%.2f) too far from BellSoul (%.2f,%.2f,%.2f). The direct fanout should write xMyPos exactly; >1m drift implies either the perception path overwrote the direct write, or the helper sourced the position from somewhere other than the BellSoul",
+			g_xInvestigatePos.x, g_xInvestigatePos.y, g_xInvestigatePos.z,
+			g_xBellSoulPos.x, g_xBellSoulPos.y, g_xBellSoulPos.z);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP2BellSoulAudibleAcrossMapTest = {
+	"Test_P2BellSoul_AudibleAcrossMap",
+	&Setup_P2BellSoulAudibleAcrossMap,
+	&Step_P2BellSoulAudibleAcrossMap,
+	&Verify_P2BellSoulAudibleAcrossMap,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP2BellSoulAudibleAcrossMapTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/Tests/Test_P2BellSoul_PriestHearsTheBell.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2BellSoul_PriestHearsTheBell.cpp
@@ -84,15 +84,12 @@ namespace
 	constexpr int kPICKUP_TICKS = 80;  // ~1.33s, well past the 1.0s channel
 	// Priest hearing_range_m defaults to 30. The perception system
 	// CLAMPS at min(emit_radius, agent_max_range), so even though the
-	// BellSoul emits at 200m, the priest can only hear it within 30m.
-	// The GDD's "audible from entire map" promise is a known
-	// limitation -- making the priest's hearing genuinely range-
-	// unlimited for BellSoul-class events requires either an engine
-	// change to the audibility clamp or a direct BB write on every
-	// priest from DPItemBase. Both are post-MVP design questions.
-	// This test pins the chain that DOES work: bell emit ->
-	// perception system -> priest BB bridge, at a distance the
-	// perception system accepts.
+	// BellSoul emits at 200m, the perception path only reaches priests
+	// within 30m. This test exercises that path at 20m -- the GDD's
+	// "audible from entire map" promise is delivered by an additional
+	// direct-BB fanout (DP_AI::NotifyAllPriestsOfInvestigatePos) that
+	// runs alongside the perception emit; the across-map case is pinned
+	// by Test_P2BellSoul_AudibleAcrossMap at 120m.
 	constexpr float kPRIEST_FAR_DIST = 20.0f;
 
 	bool TryGetEntityPos(Zenith_EntityID xId, Zenith_Maths::Vector3& xOut)


### PR DESCRIPTION
## Summary

Closes the documented BellSoul audibility limit. The perception system clamps each agent's hearing at `min(emit_radius, agent_max_range)`, so the 200 m BellSoul emit was previously silent for any priest more than 30 m away -- breaking the GDD's \"audible from the entire map\" intent.

Fix: parallel direct-BB-fanout path. `DPItemBase` BellSoul branch now calls both paths in tandem:
- `Zenith_PerceptionSystem::EmitSoundStimulus` (existing) -- delivers to priests within hearing range, gets the perception system's stale-source-entity scrubbing.
- `DP_AI::NotifyAllPriestsOfInvestigatePos` (new) -- iterates every priest in the active scene, writes `BB_KEY_INVESTIGATE_POS` and `BB_KEY_HAS_INVESTIGATE_POS` directly. Distance-blind. The existing `DP_BTAction_ClearInvestigatePos` sequence handles slot lifetime so no BT changes required.

## What this catches

`Test_P2BellSoul_AudibleAcrossMap` (new) pins the direct-fanout path at **120 m** (4x the priest's 30 m hearing range). Without the fanout, the bell at 120 m is silent at the engine layer; with it, the priest BB reflects the bell's exact position within 1 m tolerance.

Existing `Test_P2BellSoul_PriestHearsTheBell` continues to pin the perception path at 20 m. Comment updated to point to the new test as the map-wide proof.

## Test plan

- [x] Local: `pwsh Tools/run_dp_tests.ps1 -Headless -Filter BellSoul` -> 3/3 PASS.
- [x] Local: full suite via `pwsh Tools/run_dp_tests.ps1 -Headless` -> **107 passed, 0 failed**.

Next on the autonomous-loop queue:
- PR #77: Rename `DP_Player::ResetForTest` -> `ResetForNewRun` (production `HandleRestart` uses it; \"ForTest\" suffix misleads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)