### PR TITLE
refactor(dp): rename DP_Player::ResetForTest -> ResetForNewRun

### DIFF
--- a/Games/DevilsPlayground/Components/DPPauseMenuController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPPauseMenuController_Behaviour.h
@@ -165,9 +165,7 @@ private:
 	void ResetAllRunStateBeforeReload()
 	{
 		ResetVisibleAndUnpause();
-		DP_Player::ResetForTest();      // Despite the name, semantically
-		                                // "reset all per-run player state"
-		                                // -- clears possessed handle,
+		DP_Player::ResetForNewRun();    // Clears possessed handle,
 		                                // held items, cooldown, scent,
 		                                // anchor, channel.
 		DP_Win::Reset();

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -99,7 +99,7 @@ namespace DevilsPlayground
 		// only need to reset state that has no entity owner.
 		Zenith_AutomatedTestRunner::RegisterBetweenTestsHook([]()
 		{
-			DP_Player::ResetForTest();
+			DP_Player::ResetForNewRun();
 			DP_Win::Reset();
 			DP_Fog::ClearAllFogHoles();
 			DP_Fog::ClearAllMemoryReveals();

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -551,7 +551,7 @@ namespace DP_Player
 		g_xHeldItems.erase(it);
 	}
 
-	void ResetForTest()
+	void ResetForNewRun()
 	{
 		g_xPossessedVillager = INVALID_ENTITY_ID;
 		g_xHeldItems.clear();

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -223,10 +223,23 @@ namespace DP_Player
 	void SetHeldItem(Zenith_EntityID xVillager, Zenith_EntityID xItem);
 	void RemoveHeldItem(Zenith_EntityID xVillager);
 
-	// Drop possessed-villager and held-item state. Used by the harness
-	// between batched automated tests; not part of game runtime. Also
-	// resets the possession cooldown so tests start with a clean slate.
-	void ResetForTest();
+	// Drop every per-run DP_Player state owner: possessed villager,
+	// held-item table, possession cooldown, anchor, scent table,
+	// channel state. Used by:
+	//   - DPPauseMenuController::HandleRestart / HandleQuit -- the
+	//     player's permanent run-over -> new-run transition.
+	//   - The harness between batched automated tests -- next test
+	//     starts from a clean slate.
+	// "ForNewRun" reflects the production semantic. The historical
+	// name was ResetForTest (test-only intent); when MVP-2.5.5 ran
+	// the pause-menu restart through it, the name became misleading.
+	void ResetForNewRun();
+
+#ifdef ZENITH_INPUT_SIMULATOR
+	// Backward-compatible alias for tests that pre-date the rename.
+	// New call sites should prefer ResetForNewRun.
+	inline void ResetForTest() { ResetForNewRun(); }
+#endif
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Cleanup the misleading name. MVP-2.5.5 introduced \`DPPauseMenuController::ResetAllRunStateBeforeReload\` which calls \`DP_Player::ResetForTest\` from production code (\`HandleRestart\` + \`HandleQuit\`) -- so the \`ForTest\` suffix became actively wrong. The function is a production primitive for the run-over -> new-run transition, AND happens to be useful between batched automated tests.

\`ResetForTest\` is preserved as an inline alias under \`#ifdef ZENITH_INPUT_SIMULATOR\` so any historical test snippet that uses the old name keeps compiling (no current callers, just a safety net).

## Changes

- \`PublicInterfaces.h/.cpp\`: \`ResetForTest()\` -> \`ResetForNewRun()\`. Comment rewritten to spell out the two callers (\`HandleRestart/Quit\` + harness between-tests hook).
- \`DPPauseMenuController_Behaviour.h\`: \`ResetAllRunStateBeforeReload\` uses the new name; outdated \"Despite the name...\" comment removed.
- \`DevilsPlayground.cpp\`: between-tests hook uses the new name.

## Test plan

- [x] Local: full suite via \`pwsh Tools/run_dp_tests.ps1 -Headless\` -> **106 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)