### PR TITLE
docs(dp): exhaustive audit of DP/Docs against current master state

### DIFF
--- a/Games/DevilsPlayground/CLAUDE.md
+++ b/Games/DevilsPlayground/CLAUDE.md
@@ -42,7 +42,7 @@ Components/
   DPMainMenuController_Behaviour.h   # Front-end Play button → LoadSceneByIndex(1)
   DPPauseMenuController_Behaviour.h  # Esc-toggle overlay
   DPFogPass_Behaviour.h              # Per-frame fog-hole rebuild
-Tests/                                 (34 registered tests across 24 .cpp files; full list via --list-automated-tests)
+Tests/                                 (110 registered tests across 100 .cpp files as of 2026-05-15; full list via --list-automated-tests)
   Test_Hello.cpp                     # Harness smoke
   Test_MouseWheel.cpp                # EXT-4 simulator round-trip
   Test_PublicInterfaces.cpp          # 5 namespace-API tests + source-bug guards

--- a/Games/DevilsPlayground/Docs/AgentBriefing.md
+++ b/Games/DevilsPlayground/Docs/AgentBriefing.md
@@ -13,7 +13,7 @@ You are working on **Devil's Playground**, a stealth-puzzle roguelite. The user 
 
 ### What to do first (every session)
 
-1. `cd C:\dev\Zenith` and `git checkout master && git pull` (work on master; the worktree at `.claude/worktrees/...` is unrelated).
+1. `cd C:\dev\Zenith` and `git checkout master && git pull` (work on master; per OrchestratorPlaybook Invariant 2 no worktrees — if the harness drops you into `.claude/worktrees/<name>/`, treat it as a transient sandbox and remember Sharpmake bakes the cwd absolute path into generated vcxprojs).
 2. Read `Games/DevilsPlayground/Docs/Status.md` — tells you the current build state and the in-flight task.
 3. Read `Games/DevilsPlayground/Docs/Questions.md` — surface any blockers; address them or skip them if the user hasn't responded.
 4. Read `Games/DevilsPlayground/Docs/MvpRoadmap.md` — pick the **first un-checked task**.
@@ -34,7 +34,7 @@ You are working on **Devil's Playground**, a stealth-puzzle roguelite. The user 
 
 - **Game:** Devil's Playground. Top-down stealth-puzzle roguelite. You play a bodiless demon possessing villagers in a 1670s English village to collect 5 reagents and complete a ritual at a pentagram while a witch-finder hunts you. Each possessed body has a 30-second life timer.
 - **Engine:** Zenith (custom C++20, Vulkan-based). Located at `C:\dev\Zenith\`. The DP project lives at `C:\dev\Zenith\Games\DevilsPlayground\`.
-- **Status:** Skeleton-grade UE5 port. ~25% of shipping scope present. 34 automated tests registered (verified 2026-05-12). Real loss states, real navmesh, real pause, real archetype/reagent variety, audio system — all absent. MVP target ~4-9 months depending on navmesh and Mixamo spike outcomes.
+- **Status (2026-05-15):** Phase 1 + Phase 2 substantively complete; Phase 4 loss-state UI shipped (PR #75). ~110 automated tests registered, full headless suite 0 failures. Loss states, navmesh, pause, archetype/reagent variety, HUD upgrades, and most engine instrumentation all landed. The live frontier is Phase 3 assets (Mixamo spike — HUMAN_GATE) and Phase 4.3.x bot-driven playthrough. See [Status.md](Status.md) for the live wave-by-wave breakdown.
 
 ### Document map (read in this order)
 
@@ -223,10 +223,12 @@ PR titles use Conventional Commits: `feat(dp): MVP-X.Y.Z — short summary`. Typ
 
 ### 3.5 CI & auto-merge specifics
 
-**Assumed CI provider:** GitHub Actions. Workflows live in `.github/workflows/`. **Phase 0.0 of the MvpRoadmap authors them** (MVP-0.0.2 + MVP-0.0.3). Required checks for auto-merge:
+**CI provider:** GitHub Actions. Workflows live in `.github/workflows/`. **Phase 0.0 of the MvpRoadmap authored them** (MVP-0.0.2 + MVP-0.0.3). Required checks for auto-merge (verified live via `gh api repos/.../branches/master/protection`):
 
-- `dp-build` — clean MSBuild of `vs2022_Debug_Win64_True` (authored in MVP-0.0.2).
-- `dp-tests` — `Tools/run_dp_tests.ps1 -Headless` exit code 0 (authored in MVP-0.0.3).
+- `dp-build` — clean MSBuild of `vs2022_Debug_Win64_True` (MVP-0.0.2).
+- `dp-tests` — `Tools/run_dp_tests.ps1 -Headless` exit code 0 (MVP-0.0.3; re-added in PR #15 after PR #14 unblocked SET_MODEL_MATERIAL).
+- `complexity-gate` — Cyclomatic-complexity threshold.
+- `doc-lint` — runs `Tools/doc_lint.ps1` (MVP-0.3.2, PR #24); not blocking auto-merge but always required to pass.
 - `dp-asset-lint` — once MVP-3.5.1 lands, the asset linter pass.
 
 **Auto-merge command:**
@@ -301,7 +303,7 @@ pwsh.exe -File Tools/run_dp_tests.ps1 -Filter "Apprehend_PriestCatches" -PerProc
 - Conventional Commits subject format: `feat(dp): MVP-X.Y.Z — short summary` / `test(dp): ...` / `fix(dp): ...` / `chore(dp): ...` / `docs(dp): ...`.
 - Squash-merge via `gh pr merge --auto --squash`.
 - Never force-push to master. Never bypass hooks. If hooks fail, fix the root cause.
-- The worktree at `.claude/worktrees/flamboyant-mirzakhani-9186f1/` is unrelated to DP. Ignore it.
+- The Claude Code harness may place sessions in a `.claude/worktrees/<name>/` checkout. Per OrchestratorPlaybook Invariant 2 (no worktrees), this is treated as transient — work happens on `master` with feature branches, regardless of which directory the shell starts in. Be aware that Sharpmake-regenerated vcxprojs bake the cwd's absolute path into `ENGINE_ASSETS_DIR`/`GAME_ASSETS_DIR`/`SHADER_SOURCE_ROOT`/`ZENITH_ROOT` and post-build event xcopy commands, so committing vcxprojs from a worktree would break checkouts elsewhere.
 
 ### 4.6 Parallel agents
 
@@ -356,7 +358,11 @@ Read these before you touch code; they're permanent footguns:
 - **`SimulateClickOnUIElement` asserts on missing element.** Only call after the element is known to exist in the active scene's canvas.
 - **Tests must be wrapped in `#ifdef ZENITH_INPUT_SIMULATOR`** or they won't compile in non-tools builds.
 - **Scene authoring lives in `Project_RegisterEditorAutomationSteps`** (Claude user-memory `feedback_scene_setup_via_editor_automation`). Don't write imperative scene construction; use `AddStep_*` calls. Marble.cpp is the canonical reference.
-- **DevilsPlayground is in `C:\dev\Zenith\Games\DevilsPlayground\` (main repo)**, NOT in any worktree under `.claude/worktrees/`. Always work on `master` branch.
+- **DevilsPlayground lives at `C:\dev\Zenith\Games\DevilsPlayground\` in the main repo.** Always work on `master` branch with per-task feature branches. If the harness places you in a `.claude/worktrees/<name>/` checkout, treat it as transient — the no-worktrees Invariant from OrchestratorPlaybook still holds; in particular don't commit Sharpmake-regenerated vcxprojs from inside a worktree (they bake the worktree's absolute path).
+- **`DP_Player::ResetForNewRun()` is the canonical per-run reset.** Used by `DPPauseMenuController::HandleRestart`/`HandleQuit` AND the harness between-tests hook. `ResetForTest` exists only as a backward-compat alias under `#ifdef ZENITH_INPUT_SIMULATOR`; prefer the new name.
+- **Perception system clamps hearing range at `min(emit_radius, agent_max_range)`.** A 200m emit doesn't reach a priest 100m away if the priest's `hearing_range_m` is 30m. For "map-wide" stimuli (BellSoul-class) use `DP_AI::NotifyAllPriestsOfInvestigatePos` to bypass the clamp via direct BB write.
+- **Run tests through `Tools/run_dp_tests.ps1`, not direct `devilsplayground.exe --automated-test`.** The runner adds `--skip-tool-exports --skip-unit-tests` which the engine's automated-test driver requires for reliable batched behaviour; the direct exe path skips them and tests can fail spuriously.
+- **`Sharpmake_Build.bat` has a `pause` directive** that hangs non-interactively. Invoke `Sharpmake/Sharpmake.Application.exe` directly with the same `/sources(...)` args.
 - **Engine work is in-scope for autonomous agents** (per user direction 2026-05-12). Subagents may edit anywhere under `Zenith/` for tasks like MVP-0.4 (instrumentation hooks) and MVP-1.2 (navmesh generator). Engine PRs trigger mandatory Reviewer-subagent dispatch (OrchestratorPlaybook §5.4) and a Combat smoke build (catches cross-game regressions). Design rationale logged in `DecisionLog.md` before opening the PR for any net-new engine namespace.
 
 ### 4.10 When the user appears mid-session

--- a/Games/DevilsPlayground/Docs/BuildEnvironment.md
+++ b/Games/DevilsPlayground/Docs/BuildEnvironment.md
@@ -83,7 +83,7 @@ cd C:\dev\Zenith
 .\Tools\run_dp_tests.ps1 -Headless
 ```
 
-Expected: 34 tests run (verified 2026-05-12 via grep of `ZENITH_AUTOMATED_TEST_REGISTER` macros across 24 .cpp files); some pass, some fail (depending on current prototype state). The runner exits 0 if all pass, 1 if any fail.
+Expected: ~110 tests run (verified 2026-05-15 via `grep -c ZENITH_AUTOMATED_TEST_REGISTER Games/DevilsPlayground/Tests/*.cpp`); current master suite is fully green in headless mode. The runner exits 0 if all pass, 1 if any fail.
 
 Filter to a specific test during dev:
 

--- a/Games/DevilsPlayground/Docs/ManualSetupChecklist.md
+++ b/Games/DevilsPlayground/Docs/ManualSetupChecklist.md
@@ -39,7 +39,7 @@
   cd ..
   .\Tools\run_dp_tests.ps1 -Headless
   ```
-  Result: the existing 34 tests run; some pass, some may fail. The orchestrator can work with that. What matters is **the build itself succeeds**.
+  Result: the ~110 registered tests run; current master suite is fully green in headless mode. What matters is **the build itself succeeds** so the orchestrator can run + extend it.
 
 ## C. GitHub repository configuration (web UI work)
 

--- a/Games/DevilsPlayground/Docs/MvpRoadmap.md
+++ b/Games/DevilsPlayground/Docs/MvpRoadmap.md
@@ -44,17 +44,17 @@ These tasks land the **infrastructure** needed by every subsequent task. They ar
 **Test-first ordering — corrected 2026-05-12 (round-3 peer review):** an earlier wording made MVP-0.1.1 a "test that fails to compile because `DP_Tuning` doesn't exist." That's incompatible with auto-merge on green CI — a compile-failing PR is rejected at the build gate, not the test gate. The corrected pattern: **MVP-0.1.1 lands the API + the test + the implementation in a single PR.** Test-first discipline is preserved *inside the PR* (write the test first locally, watch it fail locally, then implement, watch it pass, commit both). CI sees a single green PR with the new test passing.
 
 - [x] **MVP-0.1.1** — In one PR: (a) Add `Source/DP_Tuning.h/.cpp` declaring `namespace DP_Tuning` with `Initialize()`, `Shutdown()`, `Get<T>(key)`. (b) Implement: load `Config/Tuning.json` at startup, walk the tree, flatten to dot-keyed values, cache in `Zenith_Vector<KVPair>`. (c) Hook `DP_Tuning::Initialize()` into `DevilsPlayground::InitializeResources()`. (d) Add `Test_P1Tuning_LoadsAndValuesInBand` (Tier 1) that calls `Get<float>("possession.life_timer_default_s")` and asserts equals 30.0, plus 10 other key sanity checks. The test passes; CI green; auto-merge. **Test-first discipline lives in the agent's local session, not in the PR boundary.** This is faster (one PR, not two) and matches the auto-merge contract. *Shipped 2026-05-12 in [PR #3](https://github.com/tomosh22/Zenith/pull/3) (commit e2b10e3a) out-of-sequence — orchestrator was reading the pre-reconciliation roadmap. Phase 0.0 still owed.*
-- [ ] **MVP-0.1.2** — Migrate `DPVillager_Behaviour` to read `m_fMaxLife`, `m_fMoveSpeed` from `DP_Tuning`. Add migration test that proves prototype's behaviour unchanged.
-- [ ] **MVP-0.1.3** — Migrate `Priest_Behaviour` configuration block to `DP_Tuning`. **This task fixes the existing drift:** the prototype hardcodes sight=20, hearing=25, FOV=120 while Tuning.json (and GDD §4.5) specify sight=25, hearing=30, FOV=110 with 130° peripheral. After this task, the priest reads from config. Add `Test_P1Tuning_PriestValuesMatchConfig` as a regression guard against future hardcode drift.
-- [ ] **MVP-0.1.4** — Migrate `DPInteractable_Behaviour` and all its subclasses' timing constants to `DP_Tuning`.
+- [x] **MVP-0.1.2** — Migrate `DPVillager_Behaviour` to read `m_fMaxLife`, `m_fMoveSpeed` from `DP_Tuning`. Add migration test that proves prototype's behaviour unchanged.
+- [x] **MVP-0.1.3** — Migrate `Priest_Behaviour` configuration block to `DP_Tuning`. **This task fixes the existing drift:** the prototype hardcodes sight=20, hearing=25, FOV=120 while Tuning.json (and GDD §4.5) specify sight=25, hearing=30, FOV=110 with 130° peripheral. After this task, the priest reads from config. Add `Test_P1Tuning_PriestValuesMatchConfig` as a regression guard against future hardcode drift.
+- [x] **MVP-0.1.4** — Migrate `DPInteractable_Behaviour` and all its subclasses' timing constants to `DP_Tuning`.
 
 **General rule on TDD + auto-merge:** test-first means *within a session* (red, then green, then commit), not *across PRs*. A PR opens with green CI; the failing-test phase is local-only. The Reviewer subagent verifies that each new API has a corresponding test in the same PR.
 
 ### 0.2 Archetype system
 
-- [ ] **MVP-0.2.1** — Add `Test_P2Archetype_TimersMatchSpec` for the 4 MVP archetypes. Per the updated TestPlan §3.1, the expectation table contains only **Farmhand, Beggar, Devout, Child** (Sexton was swapped out for Beggar on 2026-05-12 — see DecisionLog).
-- [ ] **MVP-0.2.2** — Add `Source/DP_Archetypes.h/.cpp`. Load `Config/Archetypes.json` (filter `"mvp": true` entries). Expose `DP_Archetypes::Get(id)` returning const ref to archetype data. Make the failing test pass.
-- [ ] **MVP-0.2.3** — Add `m_eArchetype` enum field to `DPVillager_Behaviour`; on `OnAwake`, look up timer + abilities from the registry. Authoring step (`AddStep_AttachScript`) takes archetype id as parameter.
+- [x] **MVP-0.2.1** — Add `Test_P2Archetype_TimersMatchSpec` for the 4 MVP archetypes. Per the updated TestPlan §3.1, the expectation table contains only **Farmhand, Beggar, Devout, Child** (Sexton was swapped out for Beggar on 2026-05-12 — see DecisionLog).
+- [x] **MVP-0.2.2** — Add `Source/DP_Archetypes.h/.cpp`. Load `Config/Archetypes.json` (filter `"mvp": true` entries). Expose `DP_Archetypes::Get(id)` returning const ref to archetype data. Make the failing test pass.
+- [x] **MVP-0.2.3** — Add `m_eArchetype` enum field to `DPVillager_Behaviour`; on `OnAwake`, look up timer + abilities from the registry. Authoring step (`AddStep_AttachScript`) takes archetype id as parameter.
 - [ ] **MVP-0.2.4** — Add `Test_P3Inventory_ArchetypeCount` parameterised over the full 24 (currently fails for 20 of them; those tests are `#ifdef DP_POST_MVP_ARCHETYPES`-guarded).
 
 ### 0.3 Workflow scaffolding
@@ -62,7 +62,7 @@ These tasks land the **infrastructure** needed by every subsequent task. They ar
 *Note: `Docs/Status.md`, `Docs/Questions.md`, `Docs/DecisionLog.md` were authored in the planning session and already exist. MVP-0.3 only adds the session-end helper + the long-deferred doc linter.*
 
 - [ ] **MVP-0.3.1** — Add `Tools/agent_session_close.ps1` — script that updates `Status.md`, appends to `DecisionLog.md`, prints the next task name from this roadmap. Agents call it at session end.
-- [ ] **MVP-0.3.2** — **Doc linter** (added 2026-05-12 round-5 — five rounds of peer review consensus). Author `Tools/doc_lint.py` that cross-checks numeric/textual claims across docs:
+- [x] **MVP-0.3.2** — **Doc linter** (added 2026-05-12 round-5 — five rounds of peer review consensus). Author `Tools/doc_lint.py` that cross-checks numeric/textual claims across docs:
    1. Test count in Status.md / TestPlan.md / BuildEnvironment.md / AgentBriefing.md / Shortfalls.md must all match (currently 34, verified via grep).
    2. MVP archetype names in MVPScope.md / TestPlan.md `kExpectMVP[]` / MvpRoadmap §0.2.1 / `Archetypes.json` `"mvp": true` entries must agree (currently: Farmhand, Beggar, Devout, Child).
    3. Roadmap task IDs are unique (catches future duplicate-section bugs like the round-5 navmesh dedup).
@@ -70,7 +70,7 @@ These tasks land the **infrastructure** needed by every subsequent task. They ar
    5. No claims like "X does not exist" for files that DO exist (e.g. the recurring `DP_Fog.slang` stale claim).
    6. Cross-references via markdown links resolve (no dead `(./Path.md)` pointers).
    Add CI step running the linter on every PR; fail the PR on any violation. ~100 lines of Python. Five reconciliation rounds have shown this is the recurring failure mode — landing it in Phase 0 saves weeks across the rest of the project.
-- [ ] **MVP-0.3.3** — **Git LFS configuration** (added 2026-05-12 round-5). Author `.gitattributes` with LFS patterns for binary asset types (`*.zmodel`, `*.zskel`, `*.zanim`, `*.ztxtr`, `*.zaudio`, `*.spv`, `*.fbx`, `*.png`, `*.wav`, `*.ogg`). Confirm `git lfs install` ran (ManualSetupChecklist §F). LFS must be configured BEFORE Phase 3 binary imports — retrofitting LFS to existing binary commits is painful and CI-disruptive.
+- [x] **MVP-0.3.3** — **Git LFS configuration** (added 2026-05-12 round-5). Author `.gitattributes` with LFS patterns for binary asset types (`*.zmodel`, `*.zskel`, `*.zanim`, `*.ztxtr`, `*.zaudio`, `*.spv`, `*.fbx`, `*.png`, `*.wav`, `*.ogg`). Confirm `git lfs install` ran (ManualSetupChecklist §F). LFS must be configured BEFORE Phase 3 binary imports — retrofitting LFS to existing binary commits is painful and CI-disruptive.
 
 ### 0.4 Test instrumentation hooks — orchestrator-driven engine work
 
@@ -84,10 +84,10 @@ Per [TestPlan §0.4](TestPlan.md). These hooks unlock the test plan for shipping
 
 The orchestrator may surface design decisions to Questions.md when in doubt — that's still the escape hatch — but the default is "act, log, ship."
 
-- [ ] **MVP-0.4.1** — `Zenith_AudioBus`. Engine-wide bus class. `EmitSound(const char* name, Vec3 position, float loudness, float radius)` records to a per-frame ring buffer in test builds. **Note (round-4 reconciliation):** the `radius` field is required by `Test_P2Forge_AudibleAt30m` (TestPlan §3.5) which asserts `radius >= 30.0`. Earlier signature missed this. Shipping builds delegate to the audio system (not yet existing — that's post-MVP). `GetEmittedSoundsForTest()` returns `Zenith_Vector<EmittedSound>` where `EmittedSound = { name, position, loudness, radius, frame }`. `ClearEmittedSoundsForTest()` resets. Files: `Zenith/Core/Zenith_AudioBus.h/.cpp`.
-- [ ] **MVP-0.4.2** — `Zenith_RenderBus::GetSubmittedDrawCallsForTest()`. Per-frame draw-call recording. Pattern after existing engine instrumentation in `Flux/`. Files: `Zenith/Flux/Zenith_RenderBus.h/.cpp` or appropriate Flux sub-location.
-- [ ] **MVP-0.4.3** — `Zenith_SaveSystem` skeleton. `GetWrittenBlobsForTest()` + `SetReadbackBlob()`. Doesn't touch disk yet. Files: `Zenith/FileAccess/Zenith_SaveSystem.h/.cpp`.
-- [ ] **MVP-0.4.4** — `Zenith_NavMesh::GetQueryCountForTest()`. Per-frame counter on `FindPath` calls. Files: `Zenith/AI/Navigation/Zenith_NavMesh.h/.cpp`.
+- [x] **MVP-0.4.1** — `Zenith_AudioBus`. Engine-wide bus class. `EmitSound(const char* name, Vec3 position, float loudness, float radius)` records to a per-frame ring buffer in test builds. **Note (round-4 reconciliation):** the `radius` field is required by `Test_P2Forge_AudibleAt30m` (TestPlan §3.5) which asserts `radius >= 30.0`. Earlier signature missed this. Shipping builds delegate to the audio system (not yet existing — that's post-MVP). `GetEmittedSoundsForTest()` returns `Zenith_Vector<EmittedSound>` where `EmittedSound = { name, position, loudness, radius, frame }`. `ClearEmittedSoundsForTest()` resets. Files: `Zenith/Core/Zenith_AudioBus.h/.cpp`.
+- [x] **MVP-0.4.2** — `Zenith_RenderBus::GetSubmittedDrawCallsForTest()`. Per-frame draw-call recording. Pattern after existing engine instrumentation in `Flux/`. Files: `Zenith/Flux/Zenith_RenderBus.h/.cpp` or appropriate Flux sub-location.
+- [x] **MVP-0.4.3** — `Zenith_SaveSystem` skeleton. `GetWrittenBlobsForTest()` + `SetReadbackBlob()`. Doesn't touch disk yet. Files: `Zenith/FileAccess/Zenith_SaveSystem.h/.cpp`.
+- [x] **MVP-0.4.4** — `Zenith_NavMesh::GetQueryCountForTest()`. Per-frame counter on `FindPath` calls. Files: `Zenith/AI/Navigation/Zenith_NavMesh.h/.cpp`.
 
 **Until MVP-0.4 completes, every test that references these surfaces is BLOCKED.** ~40 tests across Tier 1-4. Phase 0.0 → 0.1 → 0.2 → 0.3 → 1.x sequencing can proceed using only tests that don't depend on these surfaces. If MVP-0.4 slips, MVP-1.1 (pause), MVP-1.2 (navmesh — independent of audio/render/save), and MVP-1.4 (drop) can still proceed.
 
@@ -121,12 +121,12 @@ Plus a default `NavMeshGenerationConfig` with agent radius 0.4m, height 1.8m, st
 
 #### Plan
 
-- [ ] **MVP-1.2.0** — **Spike (2-day timebox, was 5).** Author a single static test scene with 4 cube walls forming a room with a doorway. Call `Zenith_NavMeshGenerator::GenerateFromScene` on it. Assert the returned `Zenith_NavMesh*` is non-null and `FindPath(start, end)` routes around the wall (not through). Read `Zenith_NavMeshGenerator.Tests.inl` first to copy the test pattern. If the spike fails at day 2, switch to fallback (MVP-1.2.alt) — see "Why much shorter timebox" below.
-- [ ] **MVP-1.2.1** — `Test_P1NavMesh_PathRespectsWalls`. Same shape as the spike test, just promoted to the real test suite.
-- [ ] **MVP-1.2.2** — Replace `DP_AI::GetOrBuildLevelNavMesh` (currently returns a synthetic flat quad — see `Source/PublicInterfaces.cpp:210` for the existing stub) with a call to `Zenith_NavMeshGenerator::GenerateFromScene(activeScene, kDpDefaultNavMeshConfig)`. Cache the result; invalidate on scene unload.
-- [ ] **MVP-1.2.3** — `Test_P1NavMesh_ClosedDoorBlocksPath`. Wire `DPDoor::SyncNavMeshBlock` (currently a no-op in the prototype because the flat-quad navmesh has nothing to block) to the generator's portal system. Closed doors disable the matching portal.
-- [ ] **MVP-1.2.4** — `Test_P1NavMesh_RegenerationOnSceneSwap`. Switch from GameLevel to a gym scene; assert the generator runs again and produces the correct polygon count for the new scene.
-- [ ] **MVP-1.2.5** — Add `Zenith_NavMeshAgent::GetPathWaypoints() -> Zenith_Vector<Vec3>` if it's not already present. Used by Tier 4 tests.
+- [x] **MVP-1.2.0** — **Spike (2-day timebox, was 5).** Author a single static test scene with 4 cube walls forming a room with a doorway. Call `Zenith_NavMeshGenerator::GenerateFromScene` on it. Assert the returned `Zenith_NavMesh*` is non-null and `FindPath(start, end)` routes around the wall (not through). Read `Zenith_NavMeshGenerator.Tests.inl` first to copy the test pattern. If the spike fails at day 2, switch to fallback (MVP-1.2.alt) — see "Why much shorter timebox" below.
+- [x] **MVP-1.2.1** — `Test_P1NavMesh_PathRespectsWalls`. Same shape as the spike test, just promoted to the real test suite.
+- [x] **MVP-1.2.2** — Replace `DP_AI::GetOrBuildLevelNavMesh` (currently returns a synthetic flat quad — see `Source/PublicInterfaces.cpp:210` for the existing stub) with a call to `Zenith_NavMeshGenerator::GenerateFromScene(activeScene, kDpDefaultNavMeshConfig)`. Cache the result; invalidate on scene unload.
+- [x] **MVP-1.2.3** — `Test_P1NavMesh_ClosedDoorBlocksPath`. Wire `DPDoor::SyncNavMeshBlock` (currently a no-op in the prototype because the flat-quad navmesh has nothing to block) to the generator's portal system. Closed doors disable the matching portal.
+- [x] **MVP-1.2.4** — `Test_P1NavMesh_RegenerationOnSceneSwap`. Switch from GameLevel to a gym scene; assert the generator runs again and produces the correct polygon count for the new scene.
+- [x] **MVP-1.2.5** — Add `Zenith_NavMeshAgent::GetPathWaypoints() -> Zenith_Vector<Vec3>` if it's not already present. Used by Tier 4 tests.
 
 **Why much shorter timebox:** the original 5-day spike was scoped to write the pipeline from scratch. Now it's "call an existing function and verify it works on our colliders." Two days is plenty; if it fails in two days, the generator has a fundamental bug or DP's collider setup is incompatible, both of which need different responses than "write a new generator."
 
@@ -145,7 +145,7 @@ Plus a default `NavMeshGenerationConfig` with agent radius 0.4m, height 1.8m, st
 
 **Added 2026-05-12 round-3 peer review.** The existing `Test_HumanPlaythrough.cpp:432` `ComputePathAStar` uses a grid + per-cell walkability check. The grid is **decoupled from the navmesh** — once MVP-1.2 lands real navmesh with door portals, the test pathfinder still navigates its own grid which may not align with navmesh wall geometry. Test bots could pass MVP acceptance by routing through walls.
 
-- [ ] **MVP-1.2.9** — Wrap `Zenith_NavMesh::FindPath` in a test-harness-friendly API. Surface: `Zenith_NavMeshTestPathfinder::ComputePath(start, end, outWaypoints) -> bool`. Implementation: thin wrapper around the real navmesh agent's pathfinding so test bots use **the same path** the priest would use. Add `Zenith_NavMeshAgent::GetPathWaypoints() -> Zenith_Vector<Vec3>` if not already present (TestPlan §2.2 references this; verify and add to the agent API). Retire `ComputePathAStar` from `Test_HumanPlaythrough.cpp` (mark deprecated; route callers through the new test-pathfinder). Tier 4 playthrough tests use this new API exclusively.
+- [x] **MVP-1.2.9** — Wrap `Zenith_NavMesh::FindPath` in a test-harness-friendly API. Surface: `Zenith_NavMeshTestPathfinder::ComputePath(start, end, outWaypoints) -> bool`. Implementation: thin wrapper around the real navmesh agent's pathfinding so test bots use **the same path** the priest would use. Add `Zenith_NavMeshAgent::GetPathWaypoints() -> Zenith_Vector<Vec3>` if not already present (TestPlan §2.2 references this; verify and add to the agent API). Retire `ComputePathAStar` from `Test_HumanPlaythrough.cpp` (mark deprecated; route callers through the new test-pathfinder). Tier 4 playthrough tests use this new API exclusively.
 
 **Why this matters:** without it, the Tier 4 acceptance gate is meaningless — the bot wins by cheating. Reviewer 4 (round 3) flagged this as a Critical Issue.
 
@@ -153,60 +153,60 @@ Plus a default `NavMeshGenerationConfig` with agent radius 0.4m, height 1.8m, st
 
 **Restructured 2026-05-12** to merge API declarations with their first test (round-2 peer review: a test that references undeclared types is a build break, not a "red" test).
 
-- [ ] **MVP-1.3.1** — In one PR: add `DP_OnRunLost` event struct + cause enum (`Apprehended`, `Dawn`, `NoVessels`) to `PublicInterfaces.h/.cpp`, AND author the failing `Test_P1Apprehend_PriestCatchesPlayer` that subscribes to it. The test compiles but fails because no `Apprehend` BT branch dispatches the event yet.
-- [ ] **MVP-1.3.2** — Add `Apprehend` BT branch to `Priest_Behaviour`: distance < `priest.apprehend_range_m` → channel for `priest.apprehend_channel_s` seconds → dispatch `DP_OnRunLost{Apprehended}`. Make MVP-1.3.1's test pass.
-- [ ] **MVP-1.3.3** — `Test_P1Apprehend_SwitchBreaksChannel`. Implement channel-interrupt-on-switch in the BT branch.
-- [ ] **MVP-1.3.4** — `Test_P1Apprehend_OutOfRangeIgnored`. Regression guard.
-- [ ] **MVP-1.3.5** — Wire `Dawn` and `NoVessels` causes through the same event (dispatched from the Night timer and from `DPVillager_Behaviour` respectively). These have their own tests at MVP-4.2.2 / MVP-4.2.3.
+- [x] **MVP-1.3.1** — In one PR: add `DP_OnRunLost` event struct + cause enum (`Apprehended`, `Dawn`, `NoVessels`) to `PublicInterfaces.h/.cpp`, AND author the failing `Test_P1Apprehend_PriestCatchesPlayer` that subscribes to it. The test compiles but fails because no `Apprehend` BT branch dispatches the event yet.
+- [x] **MVP-1.3.2** — Add `Apprehend` BT branch to `Priest_Behaviour`: distance < `priest.apprehend_range_m` → channel for `priest.apprehend_channel_s` seconds → dispatch `DP_OnRunLost{Apprehended}`. Make MVP-1.3.1's test pass.
+- [x] **MVP-1.3.3** — `Test_P1Apprehend_SwitchBreaksChannel`. Implement channel-interrupt-on-switch in the BT branch.
+- [x] **MVP-1.3.4** — `Test_P1Apprehend_OutOfRangeIgnored`. Regression guard.
+- [x] **MVP-1.3.5** — Wire `Dawn` and `NoVessels` causes through the same event (dispatched from the Night timer and from `DPVillager_Behaviour` respectively). These have their own tests at MVP-4.2.2 / MVP-4.2.3.
 
 ### 1.4 Voluntary switch + drop verb
 
-- [ ] **MVP-1.4.1** — Test_P1Switch_FaintNotDie (failing).
-- [ ] **MVP-1.4.2** — Add villager `m_eState` field + transitions (Idle, Possessed, Fainted, Dead). Voluntary switch sets Fainted with 10 s recovery.
-- [ ] **MVP-1.4.3** — Test_P1Switch_BurnOutDoesDie (negative control).
-- [ ] **MVP-1.4.4** — Test_P1Drop_GoesToGroundAtBodyPosition (failing).
-- [ ] **MVP-1.4.5** — Add G-key drop verb to `DPPlayerController_Behaviour`. Held item's transform parented from villager-bone-socket to scene root at villager's foot position.
-- [ ] **MVP-1.4.6** — Test_P1Drop_PickupChainHandoff.
+- [x] **MVP-1.4.1** — Test_P1Switch_FaintNotDie (failing).
+- [x] **MVP-1.4.2** — Add villager `m_eState` field + transitions (Idle, Possessed, Fainted, Dead). Voluntary switch sets Fainted with 10 s recovery.
+- [x] **MVP-1.4.3** — Test_P1Switch_BurnOutDoesDie (negative control).
+- [x] **MVP-1.4.4** — Test_P1Drop_GoesToGroundAtBodyPosition (failing).
+- [x] **MVP-1.4.5** — Add G-key drop verb to `DPPlayerController_Behaviour`. Held item's transform parented from villager-bone-socket to scene root at villager's foot position.
+- [x] **MVP-1.4.6** — Test_P1Drop_PickupChainHandoff.
 
 ### 1.5 Possession cooldown
 
-- [ ] **MVP-1.5.1** — Test_P1Cooldown_CannotPossessFor1pt5s (failing).
-- [ ] **MVP-1.5.2** — Add `s_fCooldownRemaining` to `DP_Player`. `SetPossessedVillager` checks it.
-- [ ] **MVP-1.5.3** — Test_P1Cooldown_NotAffectedByDeath.
+- [x] **MVP-1.5.1** — Test_P1Cooldown_CannotPossessFor1pt5s (failing).
+- [x] **MVP-1.5.2** — Add `s_fCooldownRemaining` to `DP_Player`. `SetPossessedVillager` checks it.
+- [x] **MVP-1.5.3** — Test_P1Cooldown_NotAffectedByDeath.
 
 ### 1.6 Demon-scent
 
-- [ ] **MVP-1.6.1** — Test_P1Scent_AccumulatesOnPossession (failing).
-- [ ] **MVP-1.6.2** — Add per-entity scent table to `DP_Player`. Update on possession-switch event; tick decay each frame.
-- [ ] **MVP-1.6.3** — Test_P1Scent_NotificationToBlackboard. **Note:** the test is authored against the priest blackboard, but in MVP no behaviour consumes the `BB.HighScentTarget` key (hounds and variants are post-MVP). The test asserts only the data-path (scent accumulates → blackboard updates), not consumption. Removed post-MVP scope ambiguity from previous version.
+- [x] **MVP-1.6.1** — Test_P1Scent_AccumulatesOnPossession (failing).
+- [x] **MVP-1.6.2** — Add per-entity scent table to `DP_Player`. Update on possession-switch event; tick decay each frame.
+- [x] **MVP-1.6.3** — Test_P1Scent_NotificationToBlackboard. **Note:** the test is authored against the priest blackboard, but in MVP no behaviour consumes the `BB.HighScentTarget` key (hounds and variants are post-MVP). The test asserts only the data-path (scent accumulates → blackboard updates), not consumption. Removed post-MVP scope ambiguity from previous version.
 
 ### 1.7 Sprint + walk-quiet
 
-- [ ] **MVP-1.7.1** — Test_P1Sprint_DrainsLifeFaster (with Sprint impl in the same PR per the corrected test-first pattern).
-- [ ] **MVP-1.7.2** — Add Shift handling in `DP_Input::ReadMoveVillager` for sprint. Apply speed multiplier and life-cost.
-- [ ] **MVP-1.7.3** — Test_P1Sprint_NoDrainWhenNotMoving.
-- [ ] **MVP-1.7.4** — Test_P1WalkQuiet_FootstepLoudnessHalved (with walk-quiet impl in the same PR). Added 2026-05-12 round-3/4 reconciliation — walk-quiet is MVPScope §1.1 but was missing from earlier roadmap.
-- [ ] **MVP-1.7.5** — Add Ctrl handling in `DP_Input::ReadMoveVillager` for walk-quiet. Footstep emissions through `Zenith_AudioBus::EmitSound` apply the `walk_footstep_loudness_multiplier` from Tuning.json.
-- [ ] **MVP-1.7.6** — Test_P1WalkQuiet_AelfricEffectiveHearingHalved.
+- [x] **MVP-1.7.1** — Test_P1Sprint_DrainsLifeFaster (with Sprint impl in the same PR per the corrected test-first pattern).
+- [x] **MVP-1.7.2** — Add Shift handling in `DP_Input::ReadMoveVillager` for sprint. Apply speed multiplier and life-cost.
+- [x] **MVP-1.7.3** — Test_P1Sprint_NoDrainWhenNotMoving.
+- [x] **MVP-1.7.4** — Test_P1WalkQuiet_FootstepLoudnessHalved (with walk-quiet impl in the same PR). Added 2026-05-12 round-3/4 reconciliation — walk-quiet is MVPScope §1.1 but was missing from earlier roadmap.
+- [x] **MVP-1.7.5** — Add Ctrl handling in `DP_Input::ReadMoveVillager` for walk-quiet. Footstep emissions through `Zenith_AudioBus::EmitSound` apply the `walk_footstep_loudness_multiplier` from Tuning.json.
+- [x] **MVP-1.7.6** — Test_P1WalkQuiet_AelfricEffectiveHearingHalved.
 
 ### 1.8 Possession range
 
-- [ ] **MVP-1.8.1** — Test_P1Range_RefusedOutOfRange.
-- [ ] **MVP-1.8.2** — Add anchor-position tracking to `DP_Player`. `SetPossessedVillager` checks distance.
-- [ ] **MVP-1.8.3** — Test_P1Range_AcceptedInRange.
+- [x] **MVP-1.8.1** — Test_P1Range_RefusedOutOfRange.
+- [x] **MVP-1.8.2** — Add anchor-position tracking to `DP_Player`. `SetPossessedVillager` checks distance.
+- [x] **MVP-1.8.3** — Test_P1Range_AcceptedInRange.
 
 ### 1.9 Priest omniscience removed
 
-- [ ] **MVP-1.9.1** — Test_P1Priest_DoesNotChasePossessedOutOfSight.
-- [ ] **MVP-1.9.2** — Remove the `DP_Player::GetPossessedVillager` fallback in `Priest_Behaviour::BridgePerceptionToBlackboard`. Update harness pursuit-test fixture to seed perception properly.
-- [ ] **MVP-1.9.3** — Test_P1Priest_PursuesAfterLineOfSight (regression guard).
+- [x] **MVP-1.9.1** — Test_P1Priest_DoesNotChasePossessedOutOfSight.
+- [x] **MVP-1.9.2** — Remove the `DP_Player::GetPossessedVillager` fallback in `Priest_Behaviour::BridgePerceptionToBlackboard`. Update harness pursuit-test fixture to seed perception properly.
+- [x] **MVP-1.9.3** — Test_P1Priest_PursuesAfterLineOfSight (regression guard).
 
 ### 1.10 Save/load run state
 
-- [ ] **MVP-1.10.1** — Add `DP_RunState` struct + Test_P1Save_RoundTripMeta in one PR (per the corrected test-first pattern). Fields: schema version (`uint32_t uSchemaVersion = 1`), possessed villager, life timer, held items per villager, scent table, win mask, dawn timer. **Schema version is mandatory** — every serialised blob starts with the version u32 so future format changes have a migration anchor. Serialise via `Zenith_SaveSystem` skeleton from MVP-0.4.3.
-- [ ] **MVP-1.10.2** — Test_P1Save_RobustToCorruption. Truncated, malformed, and wrong-version blobs all fail-soft (return default state, do not crash).
-- [ ] **MVP-1.10.3** — Test_P1Save_VersionMismatchFallsBackToDefault. Inject a blob with `uSchemaVersion = 999` (future); assert the load returns a default `DP_RunState` rather than the truncated/corrupted data.
-- [ ] **MVP-1.10.4** — Add `Docs/SaveFormat.md` documenting: the schema-version contract (every save starts with u32 version), the migration policy (each future version implements a migration function from N-1 to N; failed migration falls back to default), the rejection policy (versions lower than oldest-supported are rejected with a one-line log).
+- [x] **MVP-1.10.1** — Add `DP_RunState` struct + Test_P1Save_RoundTripMeta in one PR (per the corrected test-first pattern). Fields: schema version (`uint32_t uSchemaVersion = 1`), possessed villager, life timer, held items per villager, scent table, win mask, dawn timer. **Schema version is mandatory** — every serialised blob starts with the version u32 so future format changes have a migration anchor. Serialise via `Zenith_SaveSystem` skeleton from MVP-0.4.3.
+- [x] **MVP-1.10.2** — Test_P1Save_RobustToCorruption. Truncated, malformed, and wrong-version blobs all fail-soft (return default state, do not crash).
+- [x] **MVP-1.10.3** — Test_P1Save_VersionMismatchFallsBackToDefault. Inject a blob with `uSchemaVersion = 999` (future); assert the load returns a default `DP_RunState` rather than the truncated/corrupted data.
+- [x] **MVP-1.10.4** — Add `Docs/SaveFormat.md` documenting: the schema-version contract (every save starts with u32 version), the migration policy (each future version implements a migration function from N-1 to N; failed migration falls back to default), the rejection policy (versions lower than oldest-supported are rejected with a one-line log).
 
 ---
 
@@ -216,29 +216,29 @@ The four MVP archetypes, the five MVP reagents, fog-of-war shader, HUD upgrades.
 
 ### 2.1 Archetype gameplay
 
-- [ ] **MVP-2.1.1** — Test_P2Archetype_DevoutChannel (failing). Implement possession-channel state in `DP_Player` and `DPVillager_Behaviour`.
-- [ ] **MVP-2.1.2** — Test_P2Archetype_DevoutChannelInterrupt. Implement interrupt-on-priest-LOS.
+- [x] **MVP-2.1.1** — Test_P2Archetype_DevoutChannel (failing). Implement possession-channel state in `DP_Player` and `DPVillager_Behaviour`.
+- [x] **MVP-2.1.2** — Test_P2Archetype_DevoutChannelInterrupt. Implement interrupt-on-priest-LOS.
 - [ ] **MVP-2.1.3** — Test_P2Archetype_ChildHalfTimer.
-- [ ] **MVP-2.1.4** — Test_P2Archetype_ChildCannotCarryTools. Add restriction check in `DPItemBase_Behaviour::OnUpdate` pickup path.
+- [x] **MVP-2.1.4** — Test_P2Archetype_ChildCannotCarryTools. Add restriction check in `DPItemBase_Behaviour::OnUpdate` pickup path.
 - [x] ~~**MVP-2.1.5** — Test_P2Archetype_SextonChapelStealth~~ — **Sexton moved post-MVP entirely 2026-05-12.** The archetype is replaced in MVP by Beggar (Aelfric ignores). New task added below.
-- [ ] **MVP-2.1.6** — `Test_P2Archetype_BeggarIgnoredByAelfric`. Possess a Beggar; place Aelfric with line-of-sight; assert `BB.TargetWithDevil != beggar_id` across 60 frames. Implementation in `Priest_Behaviour::BridgePerceptionToBlackboard` filters the perceived-targets list by archetype-id, skipping Beggars.
+- [x] **MVP-2.1.6** — `Test_P2Archetype_BeggarIgnoredByAelfric`. Possess a Beggar; place Aelfric with line-of-sight; assert `BB.TargetWithDevil != beggar_id` across 60 frames. Implementation in `Priest_Behaviour::BridgePerceptionToBlackboard` filters the perceived-targets list by archetype-id, skipping Beggars.
 
 ### 2.2 Reagent uniqueness
 
-- [ ] **MVP-2.2.1** — Add reagent registry from `Config/Reagents.json`.
-- [ ] **MVP-2.2.2** — Refactor `DPItemBase_Behaviour` pickup to use reagent's `pickup_channel_s` for reagents (1.0 s) vs. 0 s for tools.
-- [ ] **MVP-2.2.3** — Test_P2Reagent_UniquePickupChannel.
-- [ ] **MVP-2.2.4** — Implement `BogWater::EvaporateAfterDrop` (8 s timer + entity destroy).
-- [ ] **MVP-2.2.5** — Test_P2Reagent_BogWaterEvaporates.
-- [ ] **MVP-2.2.6** — Implement `BellSoul::RingsBellOnPickup` (dispatch `DP_OnBellRing` + emit perception stimulus via the entire map).
-- [ ] **MVP-2.2.7** — Test_P2Reagent_BellSoulRingsBell.
+- [x] **MVP-2.2.1** — Add reagent registry from `Config/Reagents.json`.
+- [x] **MVP-2.2.2** — Refactor `DPItemBase_Behaviour` pickup to use reagent's `pickup_channel_s` for reagents (1.0 s) vs. 0 s for tools.
+- [x] **MVP-2.2.3** — Test_P2Reagent_UniquePickupChannel.
+- [x] **MVP-2.2.4** — Implement `BogWater::EvaporateAfterDrop` (8 s timer + entity destroy).
+- [x] **MVP-2.2.5** — Test_P2Reagent_BogWaterEvaporates.
+- [x] **MVP-2.2.6** — Implement `BellSoul::RingsBellOnPickup` (dispatch `DP_OnBellRing` + emit perception stimulus via the entire map).
+- [x] **MVP-2.2.7** — Test_P2Reagent_BellSoulRingsBell.
 
 ### 2.3 Forge crafting expansion
 
-- [ ] **MVP-2.3.1** — Add forge recipe table (in `DPForge_Behaviour` initially; later move to `Config/Recipes.json` post-MVP).
-- [ ] **MVP-2.3.2** — Test_P2Forge_IronWoodSpike.
-- [ ] **MVP-2.3.3** — Test_P2Forge_IronBrassKeySkeleton.
-- [ ] **MVP-2.3.4** — Test_P2Forge_AudibleAt30m (uses Audio bus instrumentation hook).
+- [x] **MVP-2.3.1** — Add forge recipe table (in `DPForge_Behaviour` initially; later move to `Config/Recipes.json` post-MVP).
+- [x] **MVP-2.3.2** — Test_P2Forge_IronWoodSpike.
+- [x] **MVP-2.3.3** — Test_P2Forge_IronBrassKeySkeleton.
+- [x] **MVP-2.3.4** — Test_P2Forge_AudibleAt30m (uses Audio bus instrumentation hook).
 
 ### 2.4 Fog memory & visibility tests
 
@@ -253,18 +253,18 @@ The remaining MVP fog work is **test coverage and memory-fog implementation**, n
 - [x] ~~MVP-2.4.0 (add GatherFogHolePositions API)~~ — done. Already exists.
 - [x] ~~MVP-2.4.1 (author DP_Fog.slang)~~ — done. Already exists in engine.
 - [x] ~~MVP-2.4.2 (wire DPFogPass to upload CBV)~~ — done. Already implemented.
-- [ ] **MVP-2.4.3** — Audit `DPFogPass.cpp` (312 lines) against the GDD §4.6 contract: per-frame rebuild, possessed-villager 8m hole, un-possessed 1.5m, lights sized by range, Aelfric **does not** carve a hole. Author `Test_P2Fog_AelfricNotRevealed` as the regression guard.
-- [ ] **MVP-2.4.4** — `Test_P2Fog_LightAddsHole`. Capture fog-hole array against a scene with N known lights; assert N matches.
-- [ ] **MVP-2.4.5** — **Memory fog (NEW work).** Add per-tile last-seen-frame buffer to `DPFogPass`. Update the shader to read it and apply the four-state model from `Config/Tuning.json` `_comment_memory_states`. `Test_P2Fog_MemoryDimsAfter10s`.
+- [x] **MVP-2.4.3** — Audit `DPFogPass.cpp` (312 lines) against the GDD §4.6 contract: per-frame rebuild, possessed-villager 8m hole, un-possessed 1.5m, lights sized by range, Aelfric **does not** carve a hole. Author `Test_P2Fog_AelfricNotRevealed` as the regression guard.
+- [x] **MVP-2.4.4** — `Test_P2Fog_LightAddsHole`. Capture fog-hole array against a scene with N known lights; assert N matches.
+- [x] **MVP-2.4.5** — **Memory fog (NEW work).** Add per-tile last-seen-frame buffer to `DPFogPass`. Update the shader to read it and apply the four-state model from `Config/Tuning.json` `_comment_memory_states`. `Test_P2Fog_MemoryDimsAfter10s`.
 
 ### 2.5 HUD upgrades
 
-- [ ] **MVP-2.5.1** — Add whisper-line to HUD (single-line UI text bottom-centre). Subscribes to Aelfric-state-change events.
-- [ ] **MVP-2.5.2** — Add demon-scent indicator (numeric for now: "Scent: 0.4"). Polishes later.
-- [ ] **MVP-2.5.3** — Add Aelfric awareness icon (placeholder: state-name as text).
-- [ ] **MVP-2.5.4** — Add dawn sun-gauge (placeholder: text countdown).
-- [ ] **MVP-2.5.5** — Add pause menu (Resume / Restart / Quit).
-- [ ] **MVP-2.5.6** — Add main-menu Quit button.
+- [x] **MVP-2.5.1** — Add whisper-line to HUD (single-line UI text bottom-centre). Subscribes to Aelfric-state-change events.
+- [x] **MVP-2.5.2** — Add demon-scent indicator (numeric for now: "Scent: 0.4"). Polishes later.
+- [x] **MVP-2.5.3** — Add Aelfric awareness icon (placeholder: state-name as text).
+- [x] **MVP-2.5.4** — Add dawn sun-gauge (placeholder: text countdown).
+- [x] **MVP-2.5.5** — Add pause menu (Resume / Restart / Quit).
+- [x] **MVP-2.5.6** — Add main-menu Quit button.
 
 ---
 
@@ -324,9 +324,9 @@ The three playthrough tests that define MVP done.
 
 ### 4.2 Loss states
 
-- [ ] **MVP-4.2.1** — Author `Test_P4Playthrough_Night1LossByApprehend`. Possessed villager stands still in priest's pursuit path.
-- [ ] **MVP-4.2.2** — Author `Test_P4Playthrough_Night1LossByDawn`. Possess villager, idle, wait for dawn-timer expiry.
-- [ ] **MVP-4.2.3** — Author `Test_P4Playthrough_Night1LossByNoVillagers`. Burn out every villager in sequence.
+- [x] **MVP-4.2.1** — Author `Test_P4Playthrough_Night1LossByApprehend`. Possessed villager stands still in priest's pursuit path.
+- [x] **MVP-4.2.2** — Author `Test_P4Playthrough_Night1LossByDawn`. Possess villager, idle, wait for dawn-timer expiry.
+- [x] **MVP-4.2.3** — Author `Test_P4Playthrough_Night1LossByNoVillagers`. Burn out every villager in sequence.
 
 ### 4.3 Polish & demo build
 

--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -10,7 +10,7 @@
 
 ## Open
 
-### ⚠️ Q-2026-05-13-NM03 — MVP-1.2.2 (real navmesh in DP_AI) reveals disconnected regions; `PriestPursuit_Test` breaks because priest + closest villager land in different regions.
+### ✅ Q-2026-05-13-NM03 — MVP-1.2.2 (real navmesh in DP_AI) reveals disconnected regions; `PriestPursuit_Test` breaks because priest + closest villager land in different regions.
 
 **Context:** With PR #32 (walls block paths) + PR #33 (O(N) adjacency, 850ms generate) both landed, the production path of wiring `DP_AI::GetOrBuildLevelNavMesh` to call `Zenith_NavMeshGenerator::GenerateFromScene` is technically feasible. I wired it with a build-index-keyed cache and ran the DP suite -- 49/50 pass, but `PriestPursuit_Test` fails:
 
@@ -34,11 +34,11 @@
 
 **Cost of getting it wrong:** moderate. Sticking with the synthetic flat quad means doors don't gate AI navigation -- the priest patrols through walls. The roadmap acknowledges this; MVP-1.2 was always going to be a multi-PR effort.
 
-**Status:** asked 2026-05-13.
+**Status:** RESOLVED 2026-05-14 via PRs #36 (ColliderComponent::SetIncludeInNavMesh — runtime-blockable obstacle opt-out), #37 (within-room vertex dedup keyed by region not Y), #39 (Priest_Behaviour refreshes navmesh + live DP_AI wiring), #40 (closed-door + regen-on-swap tests). PriestPursuit_Test green on master; full headless suite 107+ PASSED.
 
 ---
 
-### ⚠️ Q-2026-05-13-NM01 — NavMesh generator's geometry collector only voxelises box-collider TOP faces; walls never block the floor below.
+### ✅ Q-2026-05-13-NM01 — NavMesh generator's geometry collector only voxelises box-collider TOP faces; walls never block the floor below.
 
 **Context:** During MVP-1.2.0 spike (real navmesh integration) I built a tiny test scene with a 12x12m floor + a 5m wide / 1m tall box-collider wall, called `Zenith_NavMeshGenerator::GenerateFromScene`, and tried to verify that `Zenith_Pathfinding::FindPath((0, 0.1, -3), (0, 0.1, +3))` routed around the wall. It didn't -- the returned path is a 2-waypoint straight line right through where the wall should be (length 6.0, `|x|max` 0.0).
 
@@ -54,11 +54,11 @@ I tried emitting all six box faces. Polygon count was unchanged (1681 polygons, 
 
 **Cost of getting it wrong:** Phase 1.2 slips by a couple of days either way. Going with option (a) and discovering it's harder than expected costs the same as going straight to (b). Going with (b) when (a) would have worked means we ship a hand-authored navmesh that needs re-baking every time level geometry changes.
 
-**Status:** asked 2026-05-13. The spike findings are documented but I did NOT commit the failing test -- a test named `Test_P1NavMesh_PathRespectsWalls` that doesn't actually assert wall-respecting paths would be misleading. The test will be re-introduced once the generator fix lands.
+**Status:** RESOLVED 2026-05-13 via PR #32 (option a — `CollectGeometryFromScene` now emits all six box faces; non-walkable side/bottom faces rasterize as obstruction spans that trip `HasInsufficientClearance` on the floor span beneath). `Test_P1NavMesh_PathRespectsWalls` + `Test_T1NavMesh_BTUnitsCanFollowRealPath` (PR #39) pin the contract.
 
 ---
 
-### ⚠️ Q-2026-05-12-001 — No CI gate for DP. Auto-merge merges immediately without running DP tests.
+### ✅ Q-2026-05-12-001 — No CI gate for DP. Auto-merge merges immediately without running DP tests.
 
 **Context:** [.github/workflows/complexity.yml](../../../.github/workflows/complexity.yml) (renamed from msbuild.yml in MVP-0.0.2) runs a complexity gate but did not originally build DP or run `Tools/run_dp_tests.ps1` -- those checks landed in MVP-0.0.2 (`dp-build`) and MVP-0.0.3 (`dp-tests`) workflows. [AgentBriefing.md §3.5](AgentBriefing.md) describes required checks (`build-debug-tools`, `tests-headless`) but they're aspirational, not implemented yet — they're MVP-0.3 territory.
 
@@ -68,11 +68,11 @@ I tried emitting all six box faces. Polygon count was unchanged (1681 polygons, 
 
 **Cost of getting it wrong:** moderate. Without CI, regressions only surface when the next session boots. Most autonomous-session PRs are small enough that local validation suffices.
 
-**Status:** asked 2026-05-12. Acting on best guess.
+**Status:** RESOLVED 2026-05-13 via PRs #5 (`dp-build`), #7 (`dp-tests` skeleton), #10 (branch protection — `dp-build` + `complexity-gate` required), #15 (`dp-tests` re-added to required-checks list after PR #14 unblocked it). Auto-merge now blocks on green CI for all three required checks (`dp-build`, `dp-tests`, `complexity-gate`).
 
 ---
 
-### ⚠️ Q-2026-05-12-002 — `HumanPlaythrough_Test` is pre-existing-broken under `--exit-after-frames 600`.
+### ✅ Q-2026-05-12-002 — `HumanPlaythrough_Test` is pre-existing-broken under `--exit-after-frames 600`.
 
 **Context:** [Test_HumanPlaythrough.cpp](../Tests/Test_HumanPlaythrough.cpp) declares `m_iMaxFrames = 6000` (~3-min wall-clock test). The runner script default is `--exit-after-frames 600`. The CLI flag is a hard cap, so the test is cut off at frame 600 and `Verify` returns false (objectives not yet delivered). Result: `passed=false` on every batch run with default flags.
 
@@ -88,7 +88,7 @@ I tried emitting all six box faces. Polygon count was unchanged (1681 polygons, 
 
 **Cost of getting it wrong:** low. The single pre-existing fail doesn't block forward progress.
 
-**Status:** asked 2026-05-12. Acting on best guess.
+**Status:** RESOLVED 2026-05-13 via PR #13 (`m_bRequiresGraphics = true` tag in the test's registration). The test is now skipped in headless CI batches (counts as PASSED-skipped) and remains runnable locally with graphics. The test's own registration comment cites this question ID.
 
 ---
 
@@ -116,7 +116,7 @@ Additionally, **Sharpmake regenerates vcxproj files with the cwd's absolute path
 
 ---
 
-### ⚠️ Q-2026-05-12-004 — `Build/dp_test_results/*.json` is committed to git but updated on every test run.
+### ✅ Q-2026-05-12-004 — `Build/dp_test_results/*.json` is committed to git but updated on every test run.
 
 **Context:** The previous commit (`22776b42 Devils Playground`) committed the contents of `Build/dp_test_results/` — 28 per-test JSON files. My test runs overwrite them (with potentially-different `frames` counts each time). Working in this dir, my session wiped them once and then regenerated 35 of them (the 28 original + 6 renamed + 1 new test from this PR), creating a large noisy diff.
 
@@ -126,7 +126,7 @@ Additionally, **Sharpmake regenerates vcxproj files with the cwd's absolute path
 
 **Cost of getting it wrong:** low.
 
-**Status:** asked 2026-05-12. Acting on best guess.
+**Status:** RESOLVED 2026-05-13 via PR #18 (`chore(dp): gitignore Build/dp_test_results/` — directly cites this question ID in the commit message). Files were removed via `git rm --cached` and the directory added to `.gitignore`. CI artefact upload still captures the JSONs in `dp-tests.yml`.
 
 ---
 

--- a/Games/DevilsPlayground/Docs/Shortfalls.md
+++ b/Games/DevilsPlayground/Docs/Shortfalls.md
@@ -2,10 +2,10 @@
 
 **Document purpose:** A frank, gap-by-gap audit of where the current `DevilsPlayground` prototype falls short of the shipping vision described in [GameDesignDocument.md](GameDesignDocument.md). Written for producers, leads, and external partners assessing the runway from "skeleton-grade port" to "ship-ready PC/console title."
 
-**Scope:** Everything in the current `Games/DevilsPlayground/` tree as of 2026-05-11 (commit-ish: skeleton-grade UE port, M0/M0.5/M1 milestones complete).
+**Scope:** Everything in the current `Games/DevilsPlayground/` tree. **Note (2026-05-15):** this doc was written against the 2026-05-11 skeleton-grade port. Phase 1 + Phase 2 + Phase 4 loss-state UI have shipped since (see [Status.md](Status.md) for the current state) — many "missing" items listed below are now landed. Treat the headline gaps in §1 as historical snapshots and cross-check against Status.md before acting on any one.
 
 **Updated 2026-05-11** (post peer-review reconciliation):
-- Prototype contains 24 test `.cpp` files registering exactly 34 tests (verified via grep on 2026-05-12; the earlier "~28" was hand-wavy).
+- Prototype originally contained 24 test `.cpp` files registering 34 tests; as of 2026-05-15 the suite is ~110 tests across 100 .cpp files.
 - GameLevel scene spawns 17 villagers (CLAUDE.md's "14" in one comment is a stale value from earlier port milestones; "17" in `DevilsPlayground.cpp` line 565 is the current truth).
 - `DPFogPass.cpp` is substantially implemented (~312 lines with `SetupDPFog`/`ExecuteDPFog`/`BuildPipelines`). The shader file `Zenith/Flux/Shaders/Fog/DP_Fog.slang` **also exists** (with compiled `.spv` reflection files) — corrected 2026-05-12 round-4 peer review; earlier rounds claimed this file needed authoring (MVP-2.4.1) but it's already in the repo. The remaining MVP-2.4 work is *test coverage + memory-fog implementation*, not shader authoring.
 - Non-tools builds (`*_False` configurations) were **fixed as of 2026-05-10** per project memory; previous "broken" claims in this doc are obsolete (see §3.8 below).
@@ -25,35 +25,25 @@ These are the issues that, if left as-is, prevent the prototype from being demon
 
 ### 1.1 The witch-finder cannot end the run
 
-**Status:** Critical. **GDD ref:** §4.5.
+**Status:** ✅ RESOLVED 2026-05-14. **GDD ref:** §4.5.
 
-The prototype's `Priest_Behaviour` perceives, pursues, and navigates — but **there is no collision check between the priest and the possessed villager** and no apprehend logic. The player literally cannot lose to the antagonist. The only loss states currently available are (a) running out of life-timer with no other villager nearby (which simply soft-locks rather than ending the run) and (b) wall-clock timeout outside the game.
+PR #41 (`MVP-1.3.1+1.3.2`) shipped the `Apprehend` BT branch + `DP_OnRunLost{Apprehended}` event. PRs #42, #54 (NoVessels), #57 (Dawn) added the other two loss causes. PR #75 wired the HUD banner per cause. Coverage tests `Test_P1Apprehend_PriestCatchesPlayer`, `Test_P1Apprehend_SwitchBreaksChannel`, `Test_P1Apprehend_OutOfRangeIgnored`, `Test_P1Apprehend_PriestStandsStillDuringChannel` pin the contract.
 
-For a stealth game whose entire dramatic premise is "an inquisitor hunts you," this is the gap. Until it lands, every other priest improvement is decoration.
-
-**Bridge cost:** ~3 engineering weeks. Add an `Apprehend` BT branch that triggers on overlap with the possessed body's collider, with a 3 s channel that can be interrupted by switching bodies. Hook into a new `DP_OnRunLost` event.
+_Historical text (kept for record):_ The prototype's `Priest_Behaviour` perceives, pursues, and navigates — but **there is no collision check between the priest and the possessed villager** and no apprehend logic. The player literally cannot lose to the antagonist.
 
 ### 1.2 No real navmesh — only a single 200×200 m polygon
 
-**Status:** Critical. **GDD ref:** §6.1, §4.5.
+**Status:** ✅ RESOLVED 2026-05-14. **GDD ref:** §6.1, §4.5.
 
-`DP_AI::GetOrBuildLevelNavMesh` returns a synthetic flat quad. The priest can walk through any wall. `DPDoor::SyncNavMeshBlock` is wired up correctly but operates on a navmesh that doesn't have doorways to begin with, so it's a no-op. The path-finding tests pass because they only assert "distance to target decreases" — not "the path respects geometry."
+Generated-from-colliders path (option a) shipped via PRs #32 (walls block via six-face emit + obstruction-span clearance check), #33 (O(N) adjacency, ~850 ms generate), #36 (portal stitch + ColliderComponent opt-out for runtime-blockable obstacles), #37 (region-keyed vertex dedup), #39 (`Priest_Behaviour` refreshes live navmesh + reactive-selector hack), #40 (closed-door + regen-on-swap tests). `Test_P1NavMesh_PathRespectsWalls`, `Test_P1NavMesh_ClosedDoorBlocksPath`, `Test_P1NavMesh_RegenerationOnSceneSwap`, `Test_T1NavMesh_BTUnitsCanFollowRealPath`, `PriestPursuit_Test` all pin the contract.
 
-This is the single largest blocker to any meaningful level design.
-
-**Bridge cost:** ~6 engineering weeks. Two paths:
-- **Generate from colliders.** Walk the scene's static collider set, voxelise, build a polygon soup, triangulate. Standard navmesh generator. Reuse-able for other Zenith games (Combat, AIShowcase).
-- **Pre-bake assets.** Author `.znavmesh` files in the editor, ship as data. Less elegant but ships faster.
-
-Recommend (a) — it pays back across the engine.
+_Historical text:_ The prototype's `DP_AI::GetOrBuildLevelNavMesh` returned a synthetic flat quad; the priest could walk through any wall. Bridge cost was estimated at ~6 engineering weeks; actual delivery was ~2 days across 6 PRs.
 
 ### 1.3 Pause is a lie
 
-**Status:** Critical. **GDD ref:** §7.2.
+**Status:** ✅ RESOLVED. **GDD ref:** §7.2.
 
-`DPPauseMenuController_Behaviour` toggles a UI overlay text element when Esc is pressed. The game's simulation keeps running underneath. For a stealth game where every decision is time-priced, this is unshippable — players need to pause to think.
-
-**Bridge cost:** ~1 engineering week. The engine has `Zenith_SceneManager::SetScenePaused` (or equivalent — verify). Wire the pause overlay to call it. Add an audio ducking pass.
+PR #30 (`MVP-1.1` Real pause) wired Esc to `Zenith_SceneManager::SetScenePaused` on the gameplay scene; controller migrates to the persistent scene so it keeps ticking. PR #71 added R/Q shortcuts (restart/quit-to-menu) while paused. PR #74 caught a state-leak where `HandleRestart` flipped the flag without actually reloading the scene; extracted `ResetAllRunStateBeforeReload()` helper. Tests `Test_P1Pause_TimerStopsOnEscape`, `Test_P1Pause_PriestStopsOnEscape`, `Test_P1Pause_InputSimDuringPause`, `Test_P2Menu_PauseAndMainMenuShortcuts`, `Test_P2Pause_RestartActuallyReloadsScene` pin the chain. Audio ducking pass still pending.
 
 ### 1.4 No villager animations at all
 
@@ -81,17 +71,17 @@ These are systems described in the GDD that don't exist in code at all yet. None
 
 ### 2.1 Possession depth
 
-| GDD feature | Prototype state |
-|---|---|
-| 24 villager archetypes with distinct timers/abilities | 1 archetype. All villagers identical. |
-| Possession range tied to last death anchor | No range limit; any villager anywhere on the map can be clicked. |
-| Possession channel (0.8 s for Devout) | Instant for all. |
-| Possession cooldown (1.5 s after voluntary switch) | None. Players can chain-click. |
-| Demon-scent (per-body, decays) | No tracking of possession history per body. |
-| Voluntary switch (faint vs. die) | Cannot voluntarily switch — switching during life-timer just transfers state immediately, body stays put. |
-| Sprint as life-cost mechanic | Single speed. No sprint, no walk. |
+| GDD feature | Prototype state | 2026-05-15 status |
+|---|---|---|
+| 24 villager archetypes with distinct timers/abilities | 1 archetype. All villagers identical. | ✅ 4 MVP archetypes shipped (Farmhand/Beggar/Devout/Child) via PRs #19, #20, #58, #59, #62. Remaining 20 are post-MVP per `Config/Archetypes.json` `"mvp": false` filter. |
+| Possession range tied to last death anchor | No range limit; any villager anywhere on the map can be clicked. | ✅ Shipped in PR #44 (`MVP-1.8` 15 m anchor; anchor moves on each successful hop). |
+| Possession channel (0.8 s for Devout) | Instant for all. | ✅ Shipped in PR #62 (`MVP-2.1.1+2` Devout channel + priest interrupt). |
+| Possession cooldown (1.5 s after voluntary switch) | None. Players can chain-click. | ✅ Shipped in PR #43 (`MVP-1.5` 1.5 s cooldown after voluntary switch; death/apprehend bypass). |
+| Demon-scent (per-body, decays) | No tracking of possession history per body. | ✅ Shipped in PR #45 (`MVP-1.6` table + decay + write to priest BB). |
+| Voluntary switch (faint vs. die) | Cannot voluntarily switch — switching during life-timer just transfers state immediately, body stays put. | ✅ Shipped in PR #55 (`MVP-1.4.1–3` Idle/Possessed/Fainted/Dead state machine with 10 s recovery); coverage gap closed in PR #60. |
+| Sprint as life-cost mechanic | Single speed. No sprint, no walk. | ✅ Shipped in PRs #46 (sprint), #47 (walk-quiet), #53 (Aelfric effective hearing halved by walk-quiet). |
 
-**Bridge cost:** ~6 engineering weeks for the new state-machine + ~4 design weeks for archetype tuning.
+**Bridge cost (original estimate ~6+4 weeks):** actual delivery was ~2 days of autonomous-loop work across 11 PRs.
 
 ### 2.2 The witch-finder is half a character
 
@@ -383,7 +373,7 @@ Not all of the prototype is a list of things to fix. The following are genuine *
 
 1. **The `Project_*` lifecycle hooks** (9 entry points, mirroring Combat). Clean architecture. Don't deviate.
 2. **The `DP_*` namespace public-interface contract** (Source/PublicInterfaces.h/cpp). The discipline of behaviours-talk-only-via-namespace is preserved-worthy.
-3. **The automated test harness** (34 tests, batch mode, gym scenes). One of the strongest QA stories of any in-development game I've seen at this stage. Build on it; don't replace it.
+3. **The automated test harness** (110+ tests as of 2026-05-15, batch mode, gym scenes). One of the strongest QA stories of any in-development game I've seen at this stage. Build on it; don't replace it.
 4. **The editor-automation scene authoring pattern.** Declarative `AddStep_*` calls reading like a recipe. Bake into `.zscen` for ship, but keep the authoring DSL for live iteration.
 5. **The perception-system bridge pattern** in `Priest_Behaviour::BridgePerceptionToBlackboard`. The right shape for the GDD's Aelfric variants — just needs the omniscience-fallback removed.
 6. **The fog-hole clear-and-rebuild strategy.** Simple, deterministic, no subscription overhead. Keep.

--- a/Games/DevilsPlayground/Docs/Status.md
+++ b/Games/DevilsPlayground/Docs/Status.md
@@ -1,6 +1,6 @@
 # DP Status
 
-**Last updated:** 2026-05-15 — Phase 1 + Phase 2 substantively complete; Phase 4 loss-state UI shipped. Auto-loop sweep landed PRs #50 through #76 in <24 h. Master HEAD `b64af334` (PR #75) + PR #76 merged at `01:09Z`. Full suite **107 PASSED, 0 FAILED** locally via `Tools/run_dp_tests.ps1 -Headless`.
+**Last updated:** 2026-05-15 — Phase 1 + Phase 2 substantively complete; Phase 4 loss-state UI shipped. Auto-loop sweep landed PRs #50 through #79 in <24 h. Master HEAD `0e67f13e`. Full suite **~110 PASSED, 0 FAILED** locally via `Tools/run_dp_tests.ps1 -Headless`.
 **Build:** ✅ DP target builds clean (`vs2022_Debug_Win64_True`, 0 warnings, 0 errors).
 **Tests:** Full local suite green. Headless skips graphics-only tests by m_bRequiresGraphics; all compute-only tests pass.
 
@@ -56,12 +56,13 @@
 | **MVP-4.3.1–3** Bot-driven playthrough | ⏸ deferred | — | Different shape than the loss-state pin; needs the test-pathfinder + a real human-bot. Less urgent now that the loss UI exists |
 | **MVP-4.3.4** Human-driven playthrough | 🚧 HUMAN_GATE | — | Tomos plays the demo end-to-end |
 
-### In flight (auto-merge enabled, awaiting CI)
+### Recent quality-of-life landings
 
 | Wave | Status | PRs | Notes |
 |------|--------|-----|-------|
-| **MVP-2.5.5** Rename ResetForTest → ResetForNewRun | 🔄 in CI | #77 | Misleading name (production HandleRestart uses it); backward-compat alias retained |
-| **MVP-1.3.2 coverage** Priest stillness during apprehend channel | 🔄 in CI | #78 | Pins "the priest plants and channels in place" GDD framing; samples post-Pursue-settle and asserts <0.1m drift to dispatch |
+| **MVP-2.5.5** Rename ResetForTest → ResetForNewRun | ✅ landed | #77 | Misleading name (production HandleRestart uses it); backward-compat alias retained under ZENITH_INPUT_SIMULATOR |
+| **MVP-1.3.2 coverage** Priest stillness during apprehend channel | ✅ landed | #78 | Pins "the priest plants and channels in place" GDD framing; samples post-Pursue-settle and asserts <0.1m drift to dispatch |
+| **Status.md refresh** Phase 1+2 wave-by-wave + integration-test pattern | ✅ landed | #79 | Promoted every Phase-1 wave from deferred to landed; added Phase-2 + Phase-4 tables |
 
 ## Suite growth
 
@@ -161,7 +162,7 @@ Tomos's role: tick `ManualSetupChecklist.md` once before the first session; revi
 
 1. **Operating mode for fresh sessions:** orchestrator + subagents (Mode B). Read [OrchestratorPlaybook.md](OrchestratorPlaybook.md) before doing anything else.
 2. **Hard invariants:** (a) only the orchestrator invokes MSBuild / Tools/run_dp_tests.ps1 / the game executable; (b) no worktrees, all work on `master` with per-task feature branches; (c) only the orchestrator writes Status.md / Questions.md / DecisionLog.md / MvpRoadmap.md / Config/*.json.
-3. **First action:** verify the baseline. Build the prototype, run the full suite via `Tools/run_dp_tests.ps1 -Headless`. Expect **~107-110 PASSED / 0 FAILED** on `master @ b64af334`+ (count depends on whether #77/#78 have merged).
+3. **First action:** verify the baseline. Build the prototype, run the full suite via `Tools/run_dp_tests.ps1 -Headless`. Expect **~110 PASSED / 0 FAILED** on `master @ 0e67f13e` (the post-#79 head).
 4. **Next-up work** (now that Phase 1 + 2 are substantively done):
    - **Phase 3 (assets)** — Mixamo Y-Bot spike (`MVP-3.0.1` 🚧 HUMAN_GATE), villager / priest skeletons. Most of Phase 3 needs human-provided FBX.
    - **Phase 4 acceptance playthrough** — bot-driven (`MVP-4.3.1-3`) is the biggest deferred chunk. Needs the test-pathfinder + a real human-bot that drives the WASD/click inputs along a full run.
@@ -172,7 +173,7 @@ Tomos's role: tick `ManualSetupChecklist.md` once before the first session; revi
 5. **Local-run pitfalls** (caught 2026-05-15):
    - Direct `devilsplayground.exe --automated-test <name>` invocation differs from `Tools/run_dp_tests.ps1 -Filter <name>` results. The runner adds `--skip-tool-exports --skip-unit-tests` which the engine's automated-test driver requires for reliable batched test behaviour. Always run tests through the runner script, not direct exe invocation.
    - The `Sharpmake_Build.bat` script has a `pause` directive; running it non-interactively hangs. Invoke `Sharpmake.Application.exe` directly with the same args.
-6. **Branching:** all work on `master`. Branch as `dp/mvp-<task-id>` or `dp/<scope>`. The worktree at `.claude/worktrees/wizardly-payne-c210e5/` is the canonical session worktree.
+6. **Branching:** all work on `master`. Branch as `dp/mvp-<task-id>` or `dp/<scope>`. Per OrchestratorPlaybook Invariant 2 (no git worktrees), prefer `C:\dev\Zenith\` directly; if the harness places you in a `.claude/worktrees/<name>/` checkout, treat it as a transient sandbox and remember Sharpmake bakes the cwd path into generated vcxprojs.
 7. **No external spend** unless you find a paid blocker (and even then, log it in Questions.md and pick a different task to unblock yourself).
 8. **Engine surface to be aware of** for new tests/features:
    - `Zenith_BTNode::m_eLastStatus` must be assigned by leaf nodes before returning.

--- a/Games/DevilsPlayground/Docs/TestPlan.md
+++ b/Games/DevilsPlayground/Docs/TestPlan.md
@@ -4,7 +4,7 @@
 
 **Author:** Test Design (Claude)
 **Companion docs:** [GameDesignDocument.md](GameDesignDocument.md), [Shortfalls.md](Shortfalls.md)
-**Last updated:** 2026-05-11
+**Last updated:** 2026-05-15 — Phase 1 + Phase 2 substantively complete; ~110 tests now registered (was 34 at original authoring). See [Status.md](Status.md) for the live wave-by-wave breakdown. Individual test entries below describe the intended verify-contract; for any test name listed as "to author" or "planned," cross-check against `Games/DevilsPlayground/Tests/Test_*.cpp` first (many have shipped since 2026-05-11 and just haven't been promoted out of the planned sections here).
 
 ---
 
@@ -1207,7 +1207,7 @@ This loop is fully autonomous. No human inspects screenshots; no human listens t
 
 ## 8. Authoring Conventions for New Tests
 
-To keep the suite navigable as it grows from the current 34 tests to the ~250 tests this plan describes:
+To keep the suite navigable as it grows from the current ~110 tests to the ~250 tests this plan describes:
 
 ### 8.1 File template
 


### PR DESCRIPTION
## Summary

Phase 1 + Phase 2 substantively complete after the auto-loop sweep (PRs #38-#79), but most docs hadn't been updated. This audit fixes drift across **9 files** with **138 deletions / 135 insertions**.

## What this fixes

**MvpRoadmap.md** — 79 \`- [ ]\` → \`- [x]\` flips for shipped items across Phases 0.1, 0.2, 0.3, 0.4, 1.2-1.10, 2.1-2.5, 4.2. Each flip backed by a specific PR ref.

**Questions.md** — 5 \"Open\" → \"Resolved\" updates with PR refs:
- Q-2026-05-13-NM03 (navmesh disconnected regions) — PRs #36, #37, #39, #40
- Q-2026-05-13-NM01 (generator top-face only) — PR #32
- Q-2026-05-12-001 (no CI gate) — PRs #5, #7, #10, #15
- Q-2026-05-12-002 (HumanPlaythrough broken) — PR #13
- Q-2026-05-12-004 (test-results JSONs committed) — PR #18

**Status.md** — fixed worktree-as-canonical-workspace statement (was contradicting OrchestratorPlaybook Invariant 2); bumped HEAD ref; \"In flight\" section now \"Recent landings\" with PRs #77-#79 all merged.

**AgentBriefing.md** — fixed test count, CI required-checks list (live-verified via \`gh api branches/master/protection\`), worktree gotcha note. Added 4 new pitfall entries to section 4.9: ResetForNewRun canonical reset, perception clamp + bypass, runner-only test invocation, Sharpmake pause hang.

**Shortfalls.md** — sections 1.1 (witch-finder), 1.2 (navmesh), 1.3 (pause), 2.1 (possession depth) marked RESOLVED with PR refs. Added top-of-file note warning that headline gaps in §1 are now historical.

**Test count fixes** (34 → ~110 as of 2026-05-15) across CLAUDE.md, BuildEnvironment.md, ManualSetupChecklist.md, Shortfalls.md, TestPlan.md.

**SaveFormat.md** — verified against \`DP_Save.h\` schema; accurate; no edits needed.

## Verification

- [x] \`Tools/doc_lint.ps1\` → ALL CHECKS PASS.
- [x] \`Tools/run_dp_tests.ps1 -Headless\` → **110 passed, 0 failed**.

## Follow-up flagged in commit body

- TestPlan.md: ~30 shipped tests not yet promoted from \"planned\" entries; 2 name mismatches in §3.5 forge. Larger rewrite deferred.
- GameDesignDocument.md, MVPScope.md, Glossary.md, OrchestratorPlaybook.md, StartPrompts.md, AssetManifest.md, AssetTestPlan.md, CIPolicy.md, DecisionLog.md not audited (those were last touched 2026-05-12 and may have similar staleness; DecisionLog is append-only by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)