### PR TITLE
test(dp): FullPlaythrough_Test pause-overlay phase now passes (FindHudText walks all loaded scenes)

### DIFF
--- a/Games/DevilsPlayground/Tests/Test_FullPlaythrough.cpp
+++ b/Games/DevilsPlayground/Tests/Test_FullPlaythrough.cpp
@@ -235,19 +235,34 @@ namespace
 		DP_Player::SetHeldItem(xVillager, xFake);
 	}
 
-	// Look up a UI element by name on the GameManager's UICanvas.
+	// Look up a UI element by name in ANY loaded scene's UICanvas. The
+	// HUD elements (LifeBar / Objectives / HeldItem / Status / ...) are
+	// authored on the GameManager entity in the active gameplay scene,
+	// but DPPauseMenuController_Behaviour::OnStart migrates its parent
+	// entity (and the PauseOverlay text element on it) to the persistent
+	// scene via `Zenith_SceneManager::MarkEntityPersistent` so the
+	// controller keeps ticking while the gameplay scene is paused.
+	//
+	// Originally this helper only walked the active scene -- the
+	// FullPlaythrough_Test's pause-overlay phase saw `pauseOpen=0`
+	// because PauseOverlay had migrated and the search missed it. Walk
+	// every loaded scene; first match wins.
 	Zenith_UI::Zenith_UIText* FindHudText(const char* szName)
 	{
-		Zenith_Scene xActive = Zenith_SceneManager::GetActiveScene();
-		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xActive);
-		if (!pxScene) return nullptr;
 		Zenith_UI::Zenith_UIText* pxResult = nullptr;
-		pxScene->Query<Zenith_UIComponent>().ForEach(
-			[szName, &pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
-			{
-				if (pxResult) return;
-				pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>(szName);
-			});
+		const uint32_t uSlotCount = Zenith_SceneManager::GetSceneSlotCount();
+		for (uint32_t uSlot = 0; uSlot < uSlotCount; ++uSlot)
+		{
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetLoadedSceneDataAtSlot(uSlot);
+			if (pxScene == nullptr) continue;
+			pxScene->Query<Zenith_UIComponent>().ForEach(
+				[szName, &pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
+				{
+					if (pxResult) return;
+					pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>(szName);
+				});
+			if (pxResult) break;
+		}
 		return pxResult;
 	}
 

--- a/Games/DevilsPlayground/Tests/Test_HumanPlaythrough.cpp
+++ b/Games/DevilsPlayground/Tests/Test_HumanPlaythrough.cpp
@@ -238,18 +238,28 @@ namespace
 		return true;
 	}
 
+	// Look up a UI element by name in ANY loaded scene's UICanvas.
+	// DPPauseMenuController_Behaviour::OnStart migrates its parent
+	// entity to the persistent scene, so a search restricted to the
+	// active scene would miss PauseOverlay. Walk every loaded scene;
+	// first match wins. See FullPlaythrough_Test::FindHudText for the
+	// fuller rationale.
 	Zenith_UI::Zenith_UIText* FindHudText(const char* szName)
 	{
-		Zenith_Scene xActive = Zenith_SceneManager::GetActiveScene();
-		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xActive);
-		if (!pxScene) return nullptr;
 		Zenith_UI::Zenith_UIText* pxResult = nullptr;
-		pxScene->Query<Zenith_UIComponent>().ForEach(
-			[szName, &pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
-			{
-				if (pxResult) return;
-				pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>(szName);
-			});
+		const uint32_t uSlotCount = Zenith_SceneManager::GetSceneSlotCount();
+		for (uint32_t uSlot = 0; uSlot < uSlotCount; ++uSlot)
+		{
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetLoadedSceneDataAtSlot(uSlot);
+			if (pxScene == nullptr) continue;
+			pxScene->Query<Zenith_UIComponent>().ForEach(
+				[szName, &pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
+				{
+					if (pxResult) return;
+					pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>(szName);
+				});
+			if (pxResult) break;
+		}
 		return pxResult;
 	}
 


### PR DESCRIPTION
## Summary

\`FullPlaythrough_Test\` was reporting \`pauseOpen=0 pauseClose=0\` when run with graphics, even though every \`Test_P1Pause_*\` test passes in isolation and the pause overlay toggles correctly during a real human session.

**Root cause: test-side bug, not gameplay.** \`DPPauseMenuController_Behaviour::OnStart\` migrates its parent entity (and the \`PauseOverlay\` UIText element on it) to the **persistent** scene via \`MarkEntityPersistent\` so the controller keeps ticking while the gameplay scene is paused. The test's \`FindHudText\` helper was only walking the **active** scene -- so after migration it couldn't find the overlay element, and \`IsVisible()\` on the nullptr-guarded default-false scored zero for both phases.

Fix: walk every loaded scene slot (active + persistent + any additive scenes), return the first match. Mirrors the cross-scene iteration pattern \`DP_Query::ForEachScriptInLoadedScenes\` already uses.

Applied to both \`Test_FullPlaythrough.cpp\` and \`Test_HumanPlaythrough.cpp\` (identical helpers; both query \`PauseOverlay\`; the latter is \`m_bRequiresGraphics=true\` and would have bitten anyone running it locally).

## Why the headless suite missed this

The 9 graphics-required tests (including FullPlaythrough + HumanPlaythrough) are tagged \`m_bRequiresGraphics=true\` and skipped in headless CI. So this bug only manifested when running locally with Vulkan + a window. The fix has been verified by running FullPlaythrough_Test with graphics enabled.

## Verification

- [x] \`FullPlaythrough_Test\` with graphics: **PASSED (94 frames)**. All 13 gameplay phases now verify end-to-end: scene load, possession, WASD movement, orbit camera, item pickup, door unlock, chest open, forge crafting, noise-machine perception, pentagram win, pause overlay, villager death.
- [x] Headless full suite: **111 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)