### PR TITLE
feat+test(dp): MVP-4.3.2 -- post-victory/post-loss restart prompt + R-key shortcut

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -289,6 +289,8 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByApprehend.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByDawn.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp" />
+    <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -287,6 +287,12 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -583,6 +583,8 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByApprehend.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByDawn.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
+    <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp" />
+    <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_Possession.cpp" />
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -287,6 +287,12 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
@@ -51,6 +51,7 @@ public:
 		m_xVictoryHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnVictory>(
 			[this](const DP_OnVictory&)
 			{
+				m_bRunOver = true;
 				SetStatusText("VICTORY",
 					Zenith_Maths::Vector4(0.3f, 1.0f, 0.3f, 1.0f),
 					/*fHoldSeconds=*/0.0f /* permanent */);
@@ -69,6 +70,7 @@ public:
 			[this](const DP_OnRunLost& xEvt)
 			{
 				m_bRunLostReceived = true;
+				m_bRunOver = true;
 				m_eLastRunLostCause = xEvt.m_eCause;
 				char buf[64];
 				BuildRunLostText(buf, sizeof(buf), xEvt.m_eCause);
@@ -204,6 +206,24 @@ public:
 			pxAwareness->SetText(buf);
 			pxAwareness->SetVisible(true);
 		}
+
+		// MVP-4.3.2: post-victory / post-run-lost "press any key to
+		// restart" overlay. Set m_bRunOver true when either Victory or
+		// RunLost dispatches; show the RestartPrompt UI element with the
+		// canonical R/Q hint. Element is authored hidden by default; only
+		// becomes visible once the run is actually over.
+		if (auto* pxPrompt = xUI.FindElement<Zenith_UI::Zenith_UIText>("RestartPrompt"))
+		{
+			if (m_bRunOver)
+			{
+				pxPrompt->SetText("Press R to restart, Q to quit");
+				pxPrompt->SetVisible(true);
+			}
+			else
+			{
+				pxPrompt->SetVisible(false);
+			}
+		}
 	}
 
 public:
@@ -279,9 +299,13 @@ public:
 	// by Phase-4 loss playthrough tests to verify the HUD reacted.
 	bool DidRunLostHandlerFireForTest() const { return m_bRunLostReceived; }
 	DP_RunLostCause LastRunLostCauseForTest() const { return m_eLastRunLostCause; }
+	// MVP-4.3.2 test accessor: did either Victory or RunLost handler set
+	// the run-over flag? Used by Phase-4 restart-prompt tests.
+	bool IsRunOverForTest() const { return m_bRunOver; }
 	void ResetRunLostForTest()
 	{
 		m_bRunLostReceived = false;
+		m_bRunOver = false;
 		m_eLastRunLostCause = DP_RunLostCause::Apprehended;
 	}
 #endif
@@ -426,5 +450,10 @@ private:
 	Zenith_EventHandle m_xRunLostHandle       = INVALID_EVENT_HANDLE;
 	float              m_fStatusHoldRemaining = -1.0f;  // <0 = permanent / not set
 	bool               m_bRunLostReceived     = false;
+	// MVP-4.3.2: set by EITHER the Victory or RunLost subscriber. Drives
+	// the RestartPrompt UI element + gates the pause-menu R/Q shortcuts
+	// when the player isn't paused but the run is over (e.g., they
+	// watched "VICTORY" appear and just want to start a new run).
+	bool               m_bRunOver             = false;
 	DP_RunLostCause    m_eLastRunLostCause    = DP_RunLostCause::Apprehended;
 };

--- a/Games/DevilsPlayground/Components/DPPauseMenuController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPPauseMenuController_Behaviour.h
@@ -29,6 +29,7 @@
 #include "EntityComponent/Components/Zenith_UIComponent.h"
 #include "EntityComponent/Zenith_SceneManager.h"
 #include "EntityComponent/Zenith_Scene.h"
+#include "EntityComponent/Zenith_EventSystem.h"
 #include "Input/Zenith_Input.h"
 #include "Input/Zenith_KeyCodes.h"
 #include "UI/Zenith_UIText.h"
@@ -54,6 +55,7 @@ public:
 		{
 			s_pxPersistentInstance->m_xGameplayScene = m_xParentEntity.GetScene();
 			s_pxPersistentInstance->ResetVisibleAndUnpause();
+			s_pxPersistentInstance->m_bRunOver = false;
 			return;
 		}
 
@@ -62,10 +64,36 @@ public:
 		m_xGameplayScene = m_xParentEntity.GetScene();
 		Zenith_SceneManager::MarkEntityPersistent(m_xParentEntity);
 		s_pxPersistentInstance = this;
+
+		// MVP-4.3.2: mirror DPHUDController's run-over flag so the R/Q
+		// shortcuts work even when the player hasn't opened the pause
+		// menu first. The HUD owns the user-facing prompt ("Press R to
+		// restart"); this controller owns the input handler. Both
+		// subscribe to the same two events.
+		m_xVictoryHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnVictory>(
+			[this](const DP_OnVictory&)
+			{
+				m_bRunOver = true;
+			});
+		m_xRunLostHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnRunLost>(
+			[this](const DP_OnRunLost&)
+			{
+				m_bRunOver = true;
+			});
 	}
 
 	void OnDestroy()
 	{
+		if (m_xVictoryHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(m_xVictoryHandle);
+			m_xVictoryHandle = INVALID_EVENT_HANDLE;
+		}
+		if (m_xRunLostHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(m_xRunLostHandle);
+			m_xRunLostHandle = INVALID_EVENT_HANDLE;
+		}
 		if (s_pxPersistentInstance == this)
 		{
 			s_pxPersistentInstance = nullptr;
@@ -77,10 +105,13 @@ public:
 		const bool bEsc = Zenith_Input::WasKeyPressedThisFrame(ZENITH_KEY_ESCAPE);
 
 		// MVP-2.5.5: while paused, R restarts the run (reload
-		// gameplay scene) and Q quits to the main menu. Both are
-		// only honoured while shown=true so they don't fire during
-		// normal play.
-		if (m_bShown)
+		// gameplay scene) and Q quits to the main menu.
+		// MVP-4.3.2: same shortcuts also honoured when the run is
+		// over (m_bRunOver set by Victory / RunLost subscribers).
+		// The player sees the permanent banner + "Press R to restart"
+		// HUD prompt and can press the key without first opening the
+		// pause menu.
+		if (m_bShown || m_bRunOver)
 		{
 			if (Zenith_Input::WasKeyPressedThisFrame(ZENITH_KEY_R))
 			{
@@ -146,9 +177,17 @@ public:
 		{
 			s_pxPersistentInstance->ResetVisibleAndUnpause();
 			s_pxPersistentInstance->m_xGameplayScene = Zenith_Scene();
+			s_pxPersistentInstance->m_bRunOver = false;
 		}
 		s_bRestartRequestedForTest = false;
 		s_bQuitToMenuRequestedForTest = false;
+	}
+	// MVP-4.3.2 test accessor: did either Victory or RunLost handler
+	// set the run-over flag in the pause controller? Used by tests
+	// that verify R/Q work without first opening the pause menu.
+	static bool IsRunOverForTest()
+	{
+		return s_pxPersistentInstance != nullptr && s_pxPersistentInstance->m_bRunOver;
 	}
 	static DPPauseMenuController_Behaviour* GetPersistentInstanceForTest()
 	{
@@ -212,8 +251,14 @@ private:
 		m_bShown = false;
 	}
 
-	bool         m_bShown = false;
-	Zenith_Scene m_xGameplayScene;
+	bool               m_bShown = false;
+	// MVP-4.3.2: set by Victory / RunLost subscribers in OnStart. Lets the
+	// R/Q shortcuts fire when the run is over without first opening the
+	// pause menu (the HUD's RestartPrompt element prompts the player).
+	bool               m_bRunOver = false;
+	Zenith_Scene       m_xGameplayScene;
+	Zenith_EventHandle m_xVictoryHandle = INVALID_EVENT_HANDLE;
+	Zenith_EventHandle m_xRunLostHandle = INVALID_EVENT_HANDLE;
 
 	static inline DPPauseMenuController_Behaviour* s_pxPersistentInstance = nullptr;
 #ifdef ZENITH_INPUT_SIMULATOR

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -620,6 +620,17 @@ namespace
 		Zenith_EditorAutomation::AddStep_SetUIColor("AelfricAwareness", 0.95f, 0.6f, 0.3f, 1.0f);
 		Zenith_EditorAutomation::AddStep_SetUIVisible("AelfricAwareness", false);
 
+		// MVP-4.3.2: post-victory / post-run-lost restart prompt. Hidden
+		// by default; DPHUDController flips visibility when m_bRunOver
+		// is set by either the DP_OnVictory or DP_OnRunLost subscriber.
+		// Positioned below the centre Status banner.
+		Zenith_EditorAutomation::AddStep_CreateUIText("RestartPrompt", "Press R to restart, Q to quit");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("RestartPrompt", static_cast<int>(Zenith_UI::AnchorPreset::Center));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("RestartPrompt", 0.0f, 60.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("RestartPrompt", 28.0f);
+		Zenith_EditorAutomation::AddStep_SetUIColor("RestartPrompt", 1.0f, 1.0f, 1.0f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("RestartPrompt", false);
+
 		// Attach the global coordinators. Each is independent — order doesn't
 		// matter, but Combat-style is to attach the player first.
 		Zenith_EditorAutomation::AddStep_AttachScript("DPPlayerController_Behaviour");

--- a/Games/DevilsPlayground/Tests/Test_P4UI_RestartPromptAfterRunOver.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P4UI_RestartPromptAfterRunOver.cpp
@@ -1,0 +1,356 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "EntityComponent/Components/Zenith_UIComponent.h"
+#include "UI/Zenith_UIText.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/DPHUDController_Behaviour.h"
+#include "Components/DPPauseMenuController_Behaviour.h"
+
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P4UI_RestartPromptAfterRunOver (MVP-4.3.2)
+//
+// Pins the "press any key to restart" overlay contract. When the run
+// ends (either DP_OnVictory or DP_OnRunLost), the player should see
+// a "Press R to restart, Q to quit" hint AND those keys should work
+// without the player first having to open the pause menu.
+//
+// Verifies the full chain:
+//   1. DP_OnVictory dispatches.
+//   2. DPHUDController_Behaviour's subscriber sets m_bRunOver = true.
+//   3. DPHUDController_Behaviour::OnUpdate makes the RestartPrompt UI
+//      element visible with the canonical hint text.
+//   4. DPPauseMenuController_Behaviour's subscriber sets its OWN
+//      m_bRunOver = true (the two controllers track independently
+//      so neither needs the other's interface).
+//   5. PauseMenu::IsRunOverForTest() returns true -- so any R-key
+//      press from the input handler will fire HandleRestart even
+//      though m_bShown is false.
+//   6. Repeat with DP_OnRunLost{Dawn} as the trigger.
+//
+// Procedure (single test exercises both code paths because the
+// production wiring is identical):
+//   PHASE A: Victory path
+//     a. Load GameLevel; find HUD + PauseManager.
+//     b. Reset HUD's and PauseMenu's run-over flags.
+//     c. Verify RestartPrompt is NOT visible pre-event.
+//     d. Dispatch DP_OnVictory.
+//     e. Tick one frame so OnUpdate observes the flag flip.
+//     f. Snapshot: HUD::IsRunOverForTest, PauseMenu::IsRunOverForTest,
+//        RestartPrompt visibility, RestartPrompt text.
+//   PHASE B: Dawn (loss) path
+//     a. Reset both flags via the test accessors.
+//     b. Dispatch DP_OnRunLost{Dawn}.
+//     c. Tick one frame.
+//     d. Snapshot again.
+//
+// What this catches:
+//   * The HUD's OnUpdate forgets to flip RestartPrompt visible
+//     when m_bRunOver is true.
+//   * The DPHUDController's DP_OnVictory subscriber forgets to
+//     also set m_bRunOver (it always set m_bRunLostReceived before
+//     MVP-4.3.2; the new flag is the addition).
+//   * DPPauseMenuController forgets to subscribe to DP_OnVictory
+//     (or DP_OnRunLost) and the R/Q shortcuts only work after the
+//     player manually opens the pause menu with Esc.
+//   * The RestartPrompt UI element was never authored in the
+//     scene (a future refactor of DevilsPlayground.cpp's HUD
+//     authoring sequence could drop the line by accident).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int {
+		kRP_Start, kRP_WaitScene, kRP_ResetA, kRP_SnapshotPre_A,
+		kRP_DispatchVictory, kRP_TickA, kRP_SnapshotPost_A,
+		kRP_ResetB, kRP_DispatchRunLost, kRP_TickB,
+		kRP_SnapshotPost_B, kRP_Verify, kRP_Done
+	};
+
+	int g_iPhase = kRP_Start;
+	Zenith_EntityID g_xVillager;
+	DPHUDController_Behaviour* g_pxHud = nullptr;
+
+	// Pre-event snapshot (sanity: prompt is hidden before run ends).
+	bool g_bPromptVisiblePreA = false;
+	bool g_bHudRunOverPreA = false;
+	bool g_bPauseRunOverPreA = false;
+
+	// Phase A (Victory) snapshot.
+	bool g_bPromptVisiblePostA = false;
+	bool g_bHudRunOverPostA = false;
+	bool g_bPauseRunOverPostA = false;
+	char g_szPromptTextPostA[128] = "<unset>";
+
+	// Phase B (RunLost Dawn) snapshot.
+	bool g_bPromptVisiblePostB = false;
+	bool g_bHudRunOverPostB = false;
+	bool g_bPauseRunOverPostB = false;
+	char g_szPromptTextPostB[128] = "<unset>";
+
+	DPHUDController_Behaviour* FindHud()
+	{
+		DPHUDController_Behaviour* pxHud = nullptr;
+		DP_Query::ForEachScriptInActiveScene<DPHUDController_Behaviour>(
+			[&pxHud](Zenith_EntityID, DPHUDController_Behaviour& xH)
+			{
+				if (pxHud == nullptr) pxHud = &xH;
+			});
+		return pxHud;
+	}
+
+	// Walk all loaded scenes for RestartPrompt. The element lives on the
+	// GameManager's UICanvas in the active scene today, but use the
+	// PR #81 robust pattern in case future work migrates it.
+	Zenith_UI::Zenith_UIText* FindRestartPromptText()
+	{
+		Zenith_UI::Zenith_UIText* pxResult = nullptr;
+		const uint32_t uSlotCount = Zenith_SceneManager::GetSceneSlotCount();
+		for (uint32_t uSlot = 0; uSlot < uSlotCount; ++uSlot)
+		{
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetLoadedSceneDataAtSlot(uSlot);
+			if (pxScene == nullptr) continue;
+			pxScene->Query<Zenith_UIComponent>().ForEach(
+				[&pxResult](Zenith_EntityID, Zenith_UIComponent& xUI)
+				{
+					if (pxResult != nullptr) return;
+					pxResult = xUI.FindElement<Zenith_UI::Zenith_UIText>("RestartPrompt");
+				});
+			if (pxResult) break;
+		}
+		return pxResult;
+	}
+
+	void SnapshotPromptText(char* szOut, size_t uOutSize, bool& bOutVisible)
+	{
+		Zenith_UI::Zenith_UIText* pxPrompt = FindRestartPromptText();
+		if (pxPrompt == nullptr)
+		{
+			std::snprintf(szOut, uOutSize, "<missing>");
+			bOutVisible = false;
+			return;
+		}
+		std::snprintf(szOut, uOutSize, "%s", pxPrompt->GetText().c_str());
+		bOutVisible = pxPrompt->IsVisible();
+	}
+}
+
+static void Setup_P4RestartPrompt()
+{
+	g_iPhase = kRP_Start;
+	g_xVillager = INVALID_ENTITY_ID;
+	g_pxHud = nullptr;
+	g_bPromptVisiblePreA = false;
+	g_bHudRunOverPreA = false;
+	g_bPauseRunOverPreA = false;
+	g_bPromptVisiblePostA = false;
+	g_bHudRunOverPostA = false;
+	g_bPauseRunOverPostA = false;
+	std::snprintf(g_szPromptTextPostA, sizeof(g_szPromptTextPostA), "<unset>");
+	g_bPromptVisiblePostB = false;
+	g_bHudRunOverPostB = false;
+	g_bPauseRunOverPostB = false;
+	std::snprintf(g_szPromptTextPostB, sizeof(g_szPromptTextPostB), "<unset>");
+}
+
+static bool Step_P4RestartPrompt(int iFrame)
+{
+	switch (g_iPhase)
+	{
+	case kRP_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kRP_WaitScene;
+		return true;
+
+	case kRP_WaitScene:
+	{
+		Zenith_EntityID xFoundV;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xFoundV](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xFoundV.IsValid()) xFoundV = xId;
+			});
+		DPHUDController_Behaviour* pxHud = FindHud();
+		const bool bHasPause =
+			DPPauseMenuController_Behaviour::GetPersistentInstanceForTest() != nullptr;
+		if (xFoundV.IsValid() && pxHud != nullptr && bHasPause)
+		{
+			g_xVillager = xFoundV;
+			g_pxHud = pxHud;
+			g_iPhase = kRP_ResetA;
+		}
+		else if (iFrame > 120)
+		{
+			g_iPhase = kRP_Done;
+		}
+		return true;
+	}
+
+	case kRP_ResetA:
+		// Reset both controllers' run-over flags so we observe a clean
+		// rising edge on dispatch.
+		g_pxHud->ResetRunLostForTest();
+		DPPauseMenuController_Behaviour::ResetForTest();
+		// Re-pull the persistent instance after ResetForTest (it doesn't
+		// drop the singleton, just clears state).
+		g_iPhase = kRP_SnapshotPre_A;
+		return true;
+
+	case kRP_SnapshotPre_A:
+	{
+		g_bHudRunOverPreA = g_pxHud->IsRunOverForTest();
+		g_bPauseRunOverPreA = DPPauseMenuController_Behaviour::IsRunOverForTest();
+		Zenith_UI::Zenith_UIText* pxPrompt = FindRestartPromptText();
+		g_bPromptVisiblePreA = pxPrompt != nullptr ? pxPrompt->IsVisible() : false;
+		g_iPhase = kRP_DispatchVictory;
+		return true;
+	}
+
+	case kRP_DispatchVictory:
+		Zenith_EventDispatcher::Get().Dispatch(DP_OnVictory{});
+		g_iPhase = kRP_TickA;
+		return true;
+
+	case kRP_TickA:
+		// One frame for the HUD's OnUpdate to see m_bRunOver=true and
+		// flip the RestartPrompt's visibility.
+		g_iPhase = kRP_SnapshotPost_A;
+		return true;
+
+	case kRP_SnapshotPost_A:
+		g_bHudRunOverPostA = g_pxHud->IsRunOverForTest();
+		g_bPauseRunOverPostA = DPPauseMenuController_Behaviour::IsRunOverForTest();
+		SnapshotPromptText(g_szPromptTextPostA, sizeof(g_szPromptTextPostA), g_bPromptVisiblePostA);
+		g_iPhase = kRP_ResetB;
+		return true;
+
+	case kRP_ResetB:
+		// Reset for the RunLost path.
+		g_pxHud->ResetRunLostForTest();
+		DPPauseMenuController_Behaviour::ResetForTest();
+		g_iPhase = kRP_DispatchRunLost;
+		return true;
+
+	case kRP_DispatchRunLost:
+		Zenith_EventDispatcher::Get().Dispatch(DP_OnRunLost{ DP_RunLostCause::Dawn });
+		g_iPhase = kRP_TickB;
+		return true;
+
+	case kRP_TickB:
+		g_iPhase = kRP_SnapshotPost_B;
+		return true;
+
+	case kRP_SnapshotPost_B:
+		g_bHudRunOverPostB = g_pxHud->IsRunOverForTest();
+		g_bPauseRunOverPostB = DPPauseMenuController_Behaviour::IsRunOverForTest();
+		SnapshotPromptText(g_szPromptTextPostB, sizeof(g_szPromptTextPostB), g_bPromptVisiblePostB);
+		g_iPhase = kRP_Verify;
+		return true;
+
+	case kRP_Verify:
+		std::printf("[P4RestartPrompt] Pre-A: hudRO=%d pauseRO=%d promptVis=%d\n",
+			(int)g_bHudRunOverPreA, (int)g_bPauseRunOverPreA, (int)g_bPromptVisiblePreA);
+		std::printf("[P4RestartPrompt] Victory: hudRO=%d pauseRO=%d promptVis=%d promptText='%s'\n",
+			(int)g_bHudRunOverPostA, (int)g_bPauseRunOverPostA,
+			(int)g_bPromptVisiblePostA, g_szPromptTextPostA);
+		std::printf("[P4RestartPrompt] RunLost(Dawn): hudRO=%d pauseRO=%d promptVis=%d promptText='%s'\n",
+			(int)g_bHudRunOverPostB, (int)g_bPauseRunOverPostB,
+			(int)g_bPromptVisiblePostB, g_szPromptTextPostB);
+		std::fflush(stdout);
+		// Cleanup: leave both controllers reset for the next batched test.
+		g_pxHud->ResetRunLostForTest();
+		DPPauseMenuController_Behaviour::ResetForTest();
+		g_iPhase = kRP_Done;
+		return false;
+
+	case kRP_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P4RestartPrompt()
+{
+	if (g_pxHud == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: HUD controller not found in GameLevel after 120 frames -- scene authoring may have dropped the AttachScript step");
+		return false;
+	}
+	// Pre-event sanity: flags clear, prompt hidden. Establishes that the
+	// resets and authoring defaults are sane.
+	if (g_bHudRunOverPreA || g_bPauseRunOverPreA)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: HUD or PauseMenu reported run-over BEFORE any event dispatched. ResetForTest didn't clear m_bRunOver");
+		return false;
+	}
+	if (g_bPromptVisiblePreA)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: RestartPrompt was visible BEFORE any event dispatched. Element should be authored hidden by default");
+		return false;
+	}
+	// Phase A: Victory triggers the prompt + both controllers' flags.
+	if (!g_bHudRunOverPostA)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: after DP_OnVictory, HUD m_bRunOver is false -- DPHUDController's victory subscriber regressed (was only setting status text; should also set m_bRunOver)");
+		return false;
+	}
+	if (!g_bPauseRunOverPostA)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: after DP_OnVictory, PauseMenu m_bRunOver is false -- DPPauseMenuController forgot to subscribe to DP_OnVictory in OnStart. R/Q shortcuts won't work after victory without first opening the pause menu");
+		return false;
+	}
+	if (!g_bPromptVisiblePostA)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: after DP_OnVictory, RestartPrompt is not visible. HUD's OnUpdate didn't flip the element when m_bRunOver=true");
+		return false;
+	}
+	if (std::strcmp(g_szPromptTextPostA, "Press R to restart, Q to quit") != 0)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: after Victory, RestartPrompt text is '%s', expected 'Press R to restart, Q to quit'. HUD's prompt-text writer regressed",
+			g_szPromptTextPostA);
+		return false;
+	}
+	// Phase B: RunLost triggers the same flags + prompt visibility.
+	if (!g_bHudRunOverPostB || !g_bPauseRunOverPostB)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: after DP_OnRunLost{Dawn}, hudRunOver=%d pauseRunOver=%d. One or both subscribers regressed",
+			(int)g_bHudRunOverPostB, (int)g_bPauseRunOverPostB);
+		return false;
+	}
+	if (!g_bPromptVisiblePostB)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P4RestartPrompt: after DP_OnRunLost, RestartPrompt is not visible. Either the HUD's OnUpdate condition was specific to Victory, OR the RunLost reset between phases stuck m_bRunOver to false");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP4RestartPromptTest = {
+	"Test_P4UI_RestartPromptAfterRunOver",
+	&Setup_P4RestartPrompt,
+	&Step_P4RestartPrompt,
+	&Verify_P4RestartPrompt,
+	240
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP4RestartPromptTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

MVP-4.3.2 (MvpRoadmap.md line 334): *\"Add post-victory and post-loss 'press any key to restart' overlay.\"*

Previously, when the run ended (Victory or RunLost) the HUD showed a permanent banner but no instruction. R/Q shortcuts to restart/quit existed (PR #71) but **only worked while the pause menu was open** — a player who hadn't pressed Esc first was stuck staring at \"VICTORY\" or \"CAUGHT BY AELFRIC\" with no way to start a new run.

## Changes

**\`DPHUDController_Behaviour\`**
- Both Victory and RunLost subscribers now set \`m_bRunOver = true\` (in addition to their existing per-event work).
- \`OnUpdate\` flips the new \`RestartPrompt\` UI element visible whenever \`m_bRunOver\`, with text \"Press R to restart, Q to quit\".
- Test accessor \`IsRunOverForTest()\`.

**\`DPPauseMenuController_Behaviour\`**
- Subscribes to \`DP_OnVictory\` + \`DP_OnRunLost\` in \`OnStart\` (mirrors HUD).
- \`OnUpdate\`'s R/Q shortcut gate becomes \`(m_bShown || m_bRunOver)\` instead of just \`m_bShown\`. R/Q now work immediately after run-over without first opening the pause menu.
- \`OnDestroy\` unsubscribes both handles; \`ResetForTest\` clears \`m_bRunOver\`.

**\`DevilsPlayground.cpp\`**
- GameLevel HUD authoring adds a \`RestartPrompt\` UIText element (Centre anchor, +60y offset under Status; hidden by default). Gym scenes don't get it — they don't fire Victory/RunLost.

## Test

\`Test_P4UI_RestartPromptAfterRunOver.cpp\` (headless) exercises BOTH code paths in one test:
1. Pre-event: flags clear, prompt hidden ✓
2. Dispatch \`DP_OnVictory\` → tick → verify both controllers' flags set + RestartPrompt visible + correct text
3. Reset both, dispatch \`DP_OnRunLost{Dawn}\` → tick → verify same end state

Catches: HUD subscriber missing \`m_bRunOver\` assignment, Pause controller missing subscription, HUD OnUpdate not flipping element visibility, RestartPrompt authoring drift.

## Verification

- [x] Local solo: \`pwsh ./Tools/run_dp_tests.ps1 -Headless -Filter RestartPrompt\` → PASS
- [x] Full headless suite: **113 passed, 0 failed**

## MVP-DoD progress

This is Sprint A PR #2 of 3. After PR #84 (MVP-4.3.1 deterministic acceptance criteria), Sprint A is done and MVP-DoD only needs PR #85 (packaging script) + MVP-4.3.4 human-gate playthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)