### PR TITLE
chore(dp): Sprint C cleanup -- DP_Tuning leak + roadmap/testplan/questions tidy

### DIFF
--- a/Games/DevilsPlayground/Docs/MvpRoadmap.md
+++ b/Games/DevilsPlayground/Docs/MvpRoadmap.md
@@ -130,16 +130,14 @@ Plus a default `NavMeshGenerationConfig` with agent radius 0.4m, height 1.8m, st
 
 **Why much shorter timebox:** the original 5-day spike was scoped to write the pipeline from scratch. Now it's "call an existing function and verify it works on our colliders." Two days is plenty; if it fails in two days, the generator has a fundamental bug or DP's collider setup is incompatible, both of which need different responses than "write a new generator."
 
-#### Fallback path: hand-authored `.znavmesh` (ONLY if MVP-1.2.0 spike fails)
+#### ~~Fallback path: hand-authored `.znavmesh` (ONLY if MVP-1.2.0 spike fails)~~ DEPRECATED 2026-05-15
 
-(Unchanged from earlier rounds; preserved as recovery insurance.)
+The primary engine-navmesh-generator path won via PRs #32-#40. The fallback hand-authored pipeline is no longer needed and is preserved here only as historical record of the option that was considered.
 
-- [ ] **MVP-1.2.alt.1** — Define `.znavmesh` binary format (vertex list, triangle list, portal list, area types). Load via `Zenith_AssetRegistry`.
-- [ ] **MVP-1.2.alt.2** — Author `Tools/build_gamelevel_navmesh.ps1` to bake the GameLevel navmesh by hand from `DP_LevelData.h` collider tables. **Important caveat noted by round-4 reviewer:** `DP_LevelData.h` doesn't contain wall-polygon outlines — it has placement coordinates. The bake script would need to either (a) ingest Jolt collider geometry directly (same input the generator already uses), or (b) require Tomos to author a `Tools/GameLevelNavMesh.json` with explicit polygon definitions. Option (b) is more honest about the work but adds a manual asset.
-- [ ] **MVP-1.2.alt.3** — Bake the GameLevel `.znavmesh` and commit. Replace `DP_AI::GetOrBuildLevelNavMesh` to load the baked asset.
-- [ ] **MVP-1.2.alt.4** — Same tests as the primary path.
-
-**Note:** with the engine generator existing and tested, the fallback path is now genuinely a backup, not the safer-but-slower default.
+- ~~**MVP-1.2.alt.1** — Define `.znavmesh` binary format (vertex list, triangle list, portal list, area types). Load via `Zenith_AssetRegistry`.~~ Obsolete: primary path won.
+- ~~**MVP-1.2.alt.2** — Author `Tools/build_gamelevel_navmesh.ps1` to bake the GameLevel navmesh by hand from `DP_LevelData.h` collider tables.~~ Obsolete.
+- ~~**MVP-1.2.alt.3** — Bake the GameLevel `.znavmesh` and commit. Replace `DP_AI::GetOrBuildLevelNavMesh` to load the baked asset.~~ Obsolete.
+- ~~**MVP-1.2.alt.4** — Same tests as the primary path.~~ Obsolete; the primary path's tests (MVP-1.2.1, 1.2.3, 1.2.4 in PRs #39 + #40) cover the contract.
 
 ### 1.2.9 Navmesh-aware test pathfinder (REQUIRED before Tier 4)
 
@@ -218,7 +216,7 @@ The four MVP archetypes, the five MVP reagents, fog-of-war shader, HUD upgrades.
 
 - [x] **MVP-2.1.1** — Test_P2Archetype_DevoutChannel (failing). Implement possession-channel state in `DP_Player` and `DPVillager_Behaviour`.
 - [x] **MVP-2.1.2** — Test_P2Archetype_DevoutChannelInterrupt. Implement interrupt-on-priest-LOS.
-- [ ] **MVP-2.1.3** — Test_P2Archetype_ChildHalfTimer.
+- [x] **MVP-2.1.3** — ~~Test_P2Archetype_ChildHalfTimer.~~ Subsumed by `Test_P2Archetype_TimersMatchSpec.cpp` (PR #19/#20), which iterates the 4 MVP archetypes — Farmhand, Beggar, Devout, Child — and asserts each one's `life_timer_s` matches the value declared in `Config/Archetypes.json`. Verified 2026-05-15 doc audit.
 - [x] **MVP-2.1.4** — Test_P2Archetype_ChildCannotCarryTools. Add restriction check in `DPItemBase_Behaviour::OnUpdate` pickup path.
 - [x] ~~**MVP-2.1.5** — Test_P2Archetype_SextonChapelStealth~~ — **Sexton moved post-MVP entirely 2026-05-12.** The archetype is replaced in MVP by Beggar (Aelfric ignores). New task added below.
 - [x] **MVP-2.1.6** — `Test_P2Archetype_BeggarIgnoredByAelfric`. Possess a Beggar; place Aelfric with line-of-sight; assert `BB.TargetWithDevil != beggar_id` across 60 frames. Implementation in `Priest_Behaviour::BridgePerceptionToBlackboard` filters the perceived-targets list by archetype-id, skipping Beggars.

--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -148,15 +148,11 @@ Additionally, **Sharpmake regenerates vcxproj files with the cwd's absolute path
 
 ---
 
-### ⚠️ Q-2026-05-12-006 — Minor `DP_Tuning::Initialize` failure-path leak (non-blocking).
+### ✅ Q-2026-05-12-006 — Minor `DP_Tuning::Initialize` failure-path leak (non-blocking).
 
 **Context:** [DP_Tuning.cpp:319](../Source/DP_Tuning.cpp) — when `LoadJsonFile` fails, the code asserts and returns. The freshly-`new`'d `s_pxKvCache` (empty vector) is not freed; in release builds (asserts compiled out) this is a one-shot leak of an empty `Zenith_Vector<DottedKVPair>`. Reviewer subagent flagged this; the cost of fixing now is < 5 minutes (add `delete s_pxKvCache; s_pxKvCache = nullptr;` before the return).
 
-**My best guess if you don't reply:** Defer to a follow-up micro-PR or to the MVP-0.2.1 `DP_Json` extraction PR when the parser moves. The assert IS the intended fatal path; if Tuning.json fails to load, the game has bigger problems than a leak.
-
-**Cost of getting it wrong:** essentially zero.
-
-**Status:** noted 2026-05-12. Filing for follow-up; no action this PR.
+**Status:** RESOLVED 2026-05-15 via Sprint C cleanup PR. Added `delete s_pxKvCache; s_pxKvCache = nullptr;` before the assert-and-return in `Initialize`. The asset code path is unchanged; only the failure path is plugged.
 
 ---
 

--- a/Games/DevilsPlayground/Docs/TestPlan.md
+++ b/Games/DevilsPlayground/Docs/TestPlan.md
@@ -641,21 +641,29 @@ For each archetype, a corresponding `Test_P2Archetype_<Name><Ability>` test exis
 
 ### 3.5 Crafting Expansion
 
-#### Test_P2Forge_IronWoodSpike
+#### Test_P2Forge_WoodToSpike
 
-**Proves:** Iron + Wood at forge = Spike.
+**Proves:** Wood at forge = Spike (single-input recipe; the original spec said Iron + Wood but the shipped recipe in PR #63 is the simpler Wood -> Spike, matching `DPForge_Behaviour`'s per-instance recipe table).
 
-- **Setup:** villager at forge holding Iron. Wood item present at forge.
-- **Step:** interact (F). Wait 2 s.
-- **Verify:** held == Spike, both Iron and Wood entities destroyed, craft-count incremented.
+- **Setup:** villager at forge holding Wood.
+- **Step:** interact (F). Wait 1 s.
+- **Verify:** held == Spike, Wood entity destroyed, craft-count incremented. **Shipped** via [`Test_P2Forge_WoodToSpike.cpp`](../Tests/Test_P2Forge_WoodToSpike.cpp) (PR #63).
 
-#### Test_P2Forge_IronBrassKeySkeleton
+#### Test_P2Forge_IronToSkeletonKey
 
-**Proves:** Iron + Brass Key = Skeleton Key.
+**Proves:** Iron at forge = SkeletonKey (originally specced as Iron + Brass Key; the shipped MVP recipe per `DPForge_Behaviour` is Iron -> SkeletonKey).
 
-- **Setup:** villager at forge holding Iron. Brass Key present.
-- **Step:** interact. Wait 2 s.
-- **Verify:** held == SkeletonKey.
+- **Setup:** villager at forge holding Iron.
+- **Step:** interact. Wait 1 s.
+- **Verify:** held == SkeletonKey. **Shipped** via [`Test_P2Forge_IronToSkeletonKey.cpp`](../Tests/Test_P2Forge_IronToSkeletonKey.cpp) (PR #63).
+
+#### Test_P2Forge_PriestHearsTheHammer
+
+**Proves:** the forge's hammer sound emission reaches the priest's perception system (not just the AudioBus instrumentation). Caught a real wiring bug (PR #73): the forge originally only emitted via `Zenith_AudioBus::EmitSound`, missing the `Zenith_PerceptionSystem::EmitSoundStimulus` call the priest's hearing path needs.
+
+- **Setup:** load GameLevel, pick priest + a villager, possess the villager, teleport to forge.
+- **Step:** drive a forge interact, tick frames for the priest's BridgePerceptionToBlackboard to observe the heard sound.
+- **Verify:** priest's `BB.HasInvestigatePos` flips true. **Shipped** via [`Test_P2Forge_PriestHearsTheHammer.cpp`](../Tests/Test_P2Forge_PriestHearsTheHammer.cpp) (PR #73).
 
 #### Test_P2Forge_AudibleAt30m
 

--- a/Games/DevilsPlayground/Source/DP_Tuning.cpp
+++ b/Games/DevilsPlayground/Source/DP_Tuning.cpp
@@ -317,6 +317,11 @@ namespace DP_Tuning
 		if (!LoadJsonFile(xPath, xRoot))
 		{
 			Zenith_Assert(false, "DP_Tuning: failed to load %s", xPath.string().c_str());
+			// Q-2026-05-12-006 fix: release the heap allocation before bailing.
+			// Without this, the cache leaks until Shutdown -- which guards on
+			// s_bInitialized and won't run because we never set it true.
+			delete s_pxKvCache;
+			s_pxKvCache = nullptr;
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Batched cleanup PR following the Sprint A/B MVP-DoD work (PRs #82-#85). Four small items, no production-behaviour changes outside a 2-line defensive fix in DP_Tuning.

## Changes

1. **Q-2026-05-12-006** (DP_Tuning::Initialize failure-path leak) — added \`delete s_pxKvCache; s_pxKvCache = nullptr;\` before the assert-and-return path. Resolves the open question. Status flipped to ✅ in Questions.md.

2. **MVP-1.2.alt.{1,2,3,4}** retired in MvpRoadmap.md — primary engine-navmesh-generator path won via PRs #32-#40. The fallback hand-authored \`.znavmesh\` pipeline is no longer needed. Marked all four sub-items strikethrough + DEPRECATED 2026-05-15.

3. **MVP-2.1.3** status flipped to ✅ in MvpRoadmap.md — \`Test_P2Archetype_ChildHalfTimer\` was specced as a distinct test, but shipped \`Test_P2Archetype_TimersMatchSpec\` (PRs #19+#20) iterates ALL 4 MVP archetypes including Child. Subsumed.

4. **TestPlan.md §3.5 forge entries** promoted + renamed:
   - \`Test_P2Forge_IronWoodSpike\` → \`Test_P2Forge_WoodToSpike\` (matches shipped recipe in PR #63)
   - \`Test_P2Forge_IronBrassKeySkeleton\` → \`Test_P2Forge_IronToSkeletonKey\` (same)
   - Added entry for \`Test_P2Forge_PriestHearsTheHammer\` (the PR #73 integration test).

## Verification

- [x] \`doc_lint.ps1\`: ALL CHECKS PASS.
- [x] Full headless suite: **112 passed, 0 failed**.
- DP_Tuning change is defensive-only; happy-path behaviour unchanged.

## MVP status post-merge

Per Status.md, after this lands the remaining open work is:
- **MVP-4.3.4 (HUMAN_GATE)** — Tomos plays the packaged demo end-to-end.
- **Phase 3 assets** (HUMAN_GATE on Mixamo).
- **MVP-0.3.1** \`agent_session_close.ps1\` (low priority, not MVP-DoD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)