### PR TITLE
fix(dp,tools): personality playthrough CI fixes (doc-lint + runner cap)

### DIFF
--- a/Games/DevilsPlayground/Docs/Questions.md
+++ b/Games/DevilsPlayground/Docs/Questions.md
@@ -74,7 +74,7 @@ I tried emitting all six box faces. Polygon count was unchanged (1681 polygons, 
 
 ### ✅ Q-2026-05-12-002 — `HumanPlaythrough_Test` is pre-existing-broken under `--exit-after-frames 600`.
 
-**Context:** [Test_HumanPlaythrough.cpp](../Tests/Test_HumanPlaythrough.cpp) declares `m_iMaxFrames = 6000` (~3-min wall-clock test). The runner script default is `--exit-after-frames 600`. The CLI flag is a hard cap, so the test is cut off at frame 600 and `Verify` returns false (objectives not yet delivered). Result: `passed=false` on every batch run with default flags.
+**Context:** [Test_HumanPlaythrough.cpp](../Tests/Test_PersonalityPlaythrough.cpp) (renamed to Test_PersonalityPlaythrough.cpp 2026-05-17) declares `m_iMaxFrames = 6000` (~3-min wall-clock test). The runner script default is `--exit-after-frames 600`. The CLI flag is a hard cap, so the test is cut off at frame 600 and `Verify` returns false (objectives not yet delivered). Result: `passed=false` on every batch run with default flags.
 
 **Implication:** Baseline batch reports 33/34 (now 34/35 after this PR). The HumanPlaythrough failure isn't a regression — it's persistent. But Status.md / future PR descriptions will repeatedly need to caveat "1 pre-existing fail."
 

--- a/Tools/run_dp_tests.ps1
+++ b/Tools/run_dp_tests.ps1
@@ -48,7 +48,13 @@ param(
     [string]$Exe         = "Games/DevilsPlayground/Build/output/win64/vs2022_debug_win64_true/devilsplayground.exe",
     [string]$ResultsDir  = "build/dp_test_results",
     [string]$Filter      = "",
-    [int]$ExitAfterFrames = 600,
+    # Bumped 2026-05-17 from 600 to 8500 to give the
+    # PersonalityPlaythrough_* tests (max-frames 6000-8000 each) room to
+    # run end-to-end. Each per-test budget is still governed by the
+    # test's own `m_iMaxFrames`, so short tests stay short -- this only
+    # raises the per-batch ceiling. Stealth is the slowest in practice
+    # at ~3600 frames; 8500 leaves comfortable headroom.
+    [int]$ExitAfterFrames = 8500,
     [double]$FixedDt     = 0.01666,
     [switch]$Headless,
     [switch]$PerProcess,


### PR DESCRIPTION
## Summary
Follow-up to #88. Two small fixes that should have been in the original PR but landed after the auto-merge fired.

- **doc-lint:** `Games/DevilsPlayground/Docs/Questions.md:77` had a broken link to the renamed `Test_HumanPlaythrough.cpp`. Repointed to the successor `Test_PersonalityPlaythrough.cpp`.
- **dp-tests:** the runner script's `-ExitAfterFrames` default was 600. CI invokes the runner without overriding, so all four `PersonalityPlaythrough_*` tests were clipped at frame 600 (they need 1800-3600 to complete). Bumped the default to 8500. Each test's own `m_iMaxFrames` still bounds its individual run, so short tests stay short.

Both checks pass locally.

## Test plan
- [x] `doc_lint.ps1` passes locally (`ALL CHECKS PASS`)
- [x] All 4 `PersonalityPlaythrough_*` tests PASS locally with the bumped cap
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)