### PR TITLE
feat(engine,dp,tools): scene obstacles in telemetry + walls in visualiser

### DIFF
--- a/Games/DevilsPlayground/Tests/Test_PersonalityPlaythrough.cpp
+++ b/Games/DevilsPlayground/Tests/Test_PersonalityPlaythrough.cpp
@@ -9,7 +9,9 @@
 #include "EntityComponent/Zenith_EventSystem.h"
 #include "EntityComponent/Components/Zenith_TransformComponent.h"
 #include "EntityComponent/Components/Zenith_CameraComponent.h"
+#include "EntityComponent/Components/Zenith_ColliderComponent.h"
 #include "EntityComponent/Components/Zenith_UIComponent.h"
+#include "Physics/Zenith_Physics_Fwd.h"
 #include "Input/Zenith_InputSimulator.h"
 #include "Input/Zenith_KeyCodes.h"
 #include "Input/Zenith_Input.h"
@@ -503,6 +505,93 @@ namespace
 			});
 
 		Zenith_Telemetry::GetRecorder().RecordFrame(xSample);
+	}
+
+	// Scan every Zenith_ColliderComponent in the active scene and emit a
+	// SceneObstacle (top-down OBB) for any whose world-space centre sits
+	// above the floor (y > 1.5 m). The same y threshold the path grid
+	// uses (kPathFloorY in BuildPathGrid + DPHeuristicBot's kPathFloorYTop)
+	// classifies anything taller than the floor's mesh-aware OBB top as
+	// "not walkable" -- here we report exactly that set of obstacles so the
+	// visualiser shows the bot's pathing constraint, not just the authored
+	// geometry.
+	//
+	// Convention reminder:
+	//   * Floor: mesh-local bounds 0..1, body at y=0, mesh-aware OBB top
+	//     at y=1.0. Centre at y=0.5 -> below the 1.5 threshold, excluded.
+	//   * Wall: mesh-local bounds 0..4, body at y=1, mesh-aware OBB top
+	//     at y=5.0. Centre at y=3.0 -> above the 1.5 threshold, included.
+	//
+	// World-space OBB derivation: the unit-cube mesh has its origin at
+	// the corner (0,0,0), so its local centre is (0.5, 0.5, 0.5). After
+	// transform (scale -> rotate -> translate) the world centre is
+	//   P + Q * (0.5*S)
+	// where S is the entity's scale, Q its rotation, P its position. The
+	// top-down half-extents are 0.5*Sx and 0.5*Sz; the yaw is extracted
+	// from Q via glm::yaw().
+	void ScanSceneObstacles(Zenith_Vector<Zenith_Telemetry::SceneObstacle>& xOutObs)
+	{
+		xOutObs.Clear();
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene == nullptr) return;
+
+		uint32_t uIncluded = 0;
+		uint32_t uExcludedFloor = 0;
+		uint32_t uExcludedNonBox = 0;
+
+		pxScene->Query<Zenith_ColliderComponent, Zenith_TransformComponent>().ForEach(
+			[&](Zenith_EntityID /*xId*/, Zenith_ColliderComponent& xCol, Zenith_TransformComponent& xT)
+			{
+				// Skip non-box obstacles. Spheres / capsules don't have a
+				// clean OBB; the visualiser is rectangle-only for now.
+				const CollisionVolumeType eVol = xCol.GetCollisionVolumeType();
+				if (eVol != COLLISION_VOLUME_TYPE_OBB && eVol != COLLISION_VOLUME_TYPE_AABB)
+				{
+					++uExcludedNonBox;
+					return;
+				}
+
+				Zenith_Maths::Vector3 xPos;
+				Zenith_Maths::Quat    xRot;
+				Zenith_Maths::Vector3 xScale;
+				xT.GetPosition(xPos);
+				xT.GetRotation(xRot);
+				xT.GetScale(xScale);
+
+				// World centre = P + Q * (0.5 * S). Use glm to rotate the
+				// half-scale vector by the quaternion.
+				const Zenith_Maths::Vector3 xLocalHalfS(0.5f * xScale.x,
+				                                        0.5f * xScale.y,
+				                                        0.5f * xScale.z);
+				const Zenith_Maths::Vector3 xRotatedHalfS = xRot * xLocalHalfS;
+				const Zenith_Maths::Vector3 xCentre = xPos + xRotatedHalfS;
+
+				// Tall-obstacle filter: anything whose mesh-aware OBB centre
+				// sits above the floor's top (y=1.0). 1.5 m is the same
+				// threshold the path grid uses.
+				if (xCentre.y < 1.5f)
+				{
+					++uExcludedFloor;
+					return;
+				}
+
+				// Top-down half-extents (XZ plane only). The y component
+				// is discarded.
+				Zenith_Telemetry::SceneObstacle xO;
+				xO.fCentreX     = xCentre.x;
+				xO.fCentreZ     = xCentre.z;
+				xO.fHalfExtentX = 0.5f * xScale.x;
+				xO.fHalfExtentZ = 0.5f * xScale.z;
+				xO.fYawRadians  = glm::yaw(xRot);
+				xOutObs.PushBack(xO);
+				++uIncluded;
+			});
+
+		std::printf("[PersonalityPlaythrough] scanned %u obstacles "
+			"(excluded %u floor, %u non-box)\n",
+			uIncluded, uExcludedFloor, uExcludedNonBox);
+		std::fflush(stdout);
 	}
 
 	// Look up a UI element by name in ANY loaded scene's UICanvas.
@@ -1399,6 +1488,12 @@ static bool Step_HumanPlaythrough(int /*iFrame*/)
 			xHeader.strSceneName       = "GameLevel";
 			xHeader.fFixedDt           = kHPFixedDt;
 			xHeader.uSamplePeriodFrames = kHPSamplePeriodFrames;
+			// Static-scene obstacles. Scanned once now (scene fully
+			// populated, scripts have OnAwake/OnStart'd) and stamped into
+			// the recording's header. The visualiser renders these as
+			// semi-transparent rectangles under the entity trails so
+			// movement makes sense against actual geometry.
+			ScanSceneObstacles(xHeader.axObstacles);
 			Zenith_Telemetry::GetRecorder().Begin(xHeader);
 			// Hooks AFTER Begin so the very first events land in this run.
 			g_pxTelemetryHooks = std::make_unique<DPTelemetry::Hooks>();

--- a/Tools/dp_telemetry_visualise.ps1
+++ b/Tools/dp_telemetry_visualise.ps1
@@ -267,6 +267,47 @@ $borderPen = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(60, 
 $g.DrawRectangle($borderPen, $offsetX, $offsetY, $drawW, $drawH)
 $borderPen.Dispose()
 
+# ----------------------------------------------------------------------
+# Scene-obstacle layer (walls, props). Drawn BEFORE entity trails so they
+# sit visually behind the paths. Each obstacle is a top-down OBB stamped
+# into the telemetry header by the recording session; we project its 4
+# corners through the same world->image map the entity trails use, then
+# fill as a semi-transparent grey polygon. v1 telemetry files have no
+# obstacles field, so the loop is a no-op there.
+# ----------------------------------------------------------------------
+$obstacles = if ($telemetry.header.obstacles) { @($telemetry.header.obstacles) } else { @() }
+if ($obstacles.Count -gt 0) {
+    if (-not $Quiet) { Write-Host "  + $($obstacles.Count) scene obstacles" -ForegroundColor DarkGray }
+    # 40% alpha matte grey -- low enough that overlapping trails stay
+    # clearly readable, opaque enough that the wall layout is obvious.
+    $wallFill   = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(102, 130, 135, 145))
+    $wallStroke = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(150, 160, 165, 175), 1.0)
+    foreach ($obs in $obstacles) {
+        $cx  = [double]$obs.cx
+        $cz  = [double]$obs.cz
+        $hx  = [double]$obs.hx
+        $hz  = [double]$obs.hz
+        $yaw = [double]$obs.yaw
+        $cosY = [math]::Cos($yaw)
+        $sinY = [math]::Sin($yaw)
+        # 4 local corners of the OBB (CCW in local XZ), rotated into world.
+        $corners = @(
+            @(-$hx, -$hz), @( $hx, -$hz), @( $hx,  $hz), @(-$hx,  $hz)
+        )
+        $worldPts = @()
+        foreach ($lc in $corners) {
+            $wx = $cx + $lc[0] * $cosY - $lc[1] * $sinY
+            $wz = $cz + $lc[0] * $sinY + $lc[1] * $cosY
+            $pt = Project $wx $wz
+            $worldPts += New-Object System.Drawing.Point($pt[0], $pt[1])
+        }
+        $g.FillPolygon($wallFill, [System.Drawing.Point[]]$worldPts)
+        $g.DrawPolygon($wallStroke, [System.Drawing.Point[]]$worldPts)
+    }
+    $wallFill.Dispose()
+    $wallStroke.Dispose()
+}
+
 # Per-entity colour palette. Hash entity-id into a fixed palette of 17
 # distinguishable hues + cycle for overflow. Priest gets a fixed bright
 # red because there's typically only one and it's visually load-bearing.

--- a/Zenith/Telemetry/Zenith_Telemetry.cpp
+++ b/Zenith/Telemetry/Zenith_Telemetry.cpp
@@ -126,6 +126,26 @@ namespace Zenith_Telemetry
 	}
 
 	// =========================================================
+	// SceneObstacle
+	// =========================================================
+	void SceneObstacle::WriteToDataStream(Zenith_DataStream& xS) const
+	{
+		xS << fCentreX;
+		xS << fCentreZ;
+		xS << fHalfExtentX;
+		xS << fHalfExtentZ;
+		xS << fYawRadians;
+	}
+	void SceneObstacle::ReadFromDataStream(Zenith_DataStream& xS)
+	{
+		xS >> fCentreX;
+		xS >> fCentreZ;
+		xS >> fHalfExtentX;
+		xS >> fHalfExtentZ;
+		xS >> fYawRadians;
+	}
+
+	// =========================================================
 	// Header
 	// =========================================================
 	void Header::WriteToDataStream(Zenith_DataStream& xS) const
@@ -137,6 +157,15 @@ namespace Zenith_Telemetry
 		WriteString(xS, strSceneName);
 		xS << fFixedDt;
 		xS << uSamplePeriodFrames;
+		// v2+ only: obstacle count + list. Writers always emit v2 so a
+		// recording produced by current code always carries this section
+		// (empty if the caller didn't populate it).
+		const uint32_t uNumObs = axObstacles.GetSize();
+		xS << uNumObs;
+		for (uint32_t i = 0; i < uNumObs; ++i)
+		{
+			axObstacles.Get(i).WriteToDataStream(xS);
+		}
 	}
 	void Header::ReadFromDataStream(Zenith_DataStream& xS)
 	{
@@ -147,6 +176,26 @@ namespace Zenith_Telemetry
 		ReadString(xS, strSceneName);
 		xS >> fFixedDt;
 		xS >> uSamplePeriodFrames;
+		// v2+ adds the obstacles list. v1 files leave axObstacles empty
+		// (default state). Magic + version are validated by Reader, so
+		// hitting this read with uVersion==1 just means we skip the
+		// obstacle payload and treat the file as obstacle-free.
+		axObstacles.Clear();
+		if (uVersion >= 2u)
+		{
+			uint32_t uNumObs = 0;
+			xS >> uNumObs;
+			// Safety cap: a level with > 64k walls is almost certainly
+			// a corrupt count; bail to zero so the reader doesn't try
+			// to allocate gigabytes.
+			if (uNumObs > 65536u) uNumObs = 0;
+			for (uint32_t i = 0; i < uNumObs; ++i)
+			{
+				SceneObstacle xO;
+				xO.ReadFromDataStream(xS);
+				axObstacles.PushBack(xO);
+			}
+		}
 	}
 
 	// =========================================================
@@ -284,7 +333,10 @@ namespace Zenith_Telemetry
 				"Zenith_Telemetry::Reader: bad magic 0x%08X in %s", m_xHeader.uMagic, szBinaryPath);
 			return false;
 		}
-		if (m_xHeader.uVersion != 1u)
+		// Accept v1 (legacy, no obstacles) and v2 (current, header carries
+		// SceneObstacle list). Anything else is a forward-incompat file
+		// produced by a newer writer than this reader knows how to parse.
+		if (m_xHeader.uVersion != 1u && m_xHeader.uVersion != 2u)
 		{
 			Zenith_Error(LOG_CATEGORY_CORE,
 				"Zenith_Telemetry::Reader: unknown version %u in %s", m_xHeader.uVersion, szBinaryPath);
@@ -349,7 +401,23 @@ namespace Zenith_Telemetry
 		xOut << "    \"startUTCMs\": " << m_xHeader.uStartUTCMs << ",\n";
 		xOut << "    \"sceneName\": \"" << m_xHeader.strSceneName << "\",\n";
 		xOut << "    \"fixedDt\": " << m_xHeader.fFixedDt << ",\n";
-		xOut << "    \"samplePeriodFrames\": " << m_xHeader.uSamplePeriodFrames << "\n";
+		xOut << "    \"samplePeriodFrames\": " << m_xHeader.uSamplePeriodFrames << ",\n";
+		// Static-scene obstacles. Always emitted (empty array if none) so
+		// downstream readers (visualiser, etc.) don't need a fallback path
+		// when the writer was older or didn't populate them.
+		xOut << "    \"obstacles\": [";
+		const uint32_t uNumObs = m_xHeader.axObstacles.GetSize();
+		for (uint32_t i = 0; i < uNumObs; ++i)
+		{
+			const SceneObstacle& xO = m_xHeader.axObstacles.Get(i);
+			char buf[256];
+			std::snprintf(buf, sizeof(buf),
+				"{\"cx\":%.3f,\"cz\":%.3f,\"hx\":%.3f,\"hz\":%.3f,\"yaw\":%.5f}",
+				xO.fCentreX, xO.fCentreZ, xO.fHalfExtentX, xO.fHalfExtentZ, xO.fYawRadians);
+			xOut << buf;
+			if (i + 1 < uNumObs) xOut << ",";
+		}
+		xOut << "]\n";
 		xOut << "  },\n";
 
 		// Frames

--- a/Zenith/Telemetry/Zenith_Telemetry.h
+++ b/Zenith/Telemetry/Zenith_Telemetry.h
@@ -94,15 +94,46 @@ namespace Zenith_Telemetry
 		void ReadFromDataStream(Zenith_DataStream& xStream);
 	};
 
+	// Top-down oriented-bounding-box of a static scene obstacle (wall,
+	// building, prop). Recorded once in the Header so the visualiser can
+	// draw scene geometry under the entity trails -- a trail that
+	// squeezes through a doorway or hugs a wall makes far more sense
+	// against a backdrop of the actual obstacles.
+	//
+	// Convention: XZ-plane projection only (Y is discarded because the
+	// visualiser is top-down). Half-extents are in the wall's LOCAL
+	// space; fYawRadians rotates that local frame into world space.
+	// Floors / non-blocking volumes are filtered by the caller before
+	// they reach here -- this struct just stores whatever rectangles
+	// the recording wants to overlay.
+	struct SceneObstacle
+	{
+		float fCentreX     = 0.0f;
+		float fCentreZ     = 0.0f;
+		float fHalfExtentX = 0.0f;
+		float fHalfExtentZ = 0.0f;
+		float fYawRadians  = 0.0f;
+
+		void WriteToDataStream(Zenith_DataStream& xStream) const;
+		void ReadFromDataStream(Zenith_DataStream& xStream);
+	};
+
 	struct Header
 	{
 		uint32_t    uMagic        = 0x4D4C545A; // 'ZTLM' little-endian
-		uint32_t    uVersion      = 1;
+		// Version 2 (2026-05-18): added axObstacles. Readers accept both
+		// versions -- a v1 file just yields an empty obstacle list.
+		uint32_t    uVersion      = 2;
 		uint64_t    uSeed         = 0;
 		uint64_t    uStartUTCMs   = 0;
 		std::string strSceneName;
 		float       fFixedDt      = 1.0f / 60.0f;
 		uint32_t    uSamplePeriodFrames = 6; // 10 Hz at fixed-dt 1/60
+		// Static scene obstacles, top-down OBBs. Populated by the caller
+		// before Recorder::Begin(); the recorder stores them as part of
+		// the header and the JSON exporter mirrors them in the header
+		// object so the visualiser can render walls under the trails.
+		Zenith_Vector<SceneObstacle> axObstacles;
 
 		void WriteToDataStream(Zenith_DataStream& xStream) const;
 		void ReadFromDataStream(Zenith_DataStream& xStream);


### PR DESCRIPTION
## Summary
Adds top-down OBB geometry to telemetry recordings so the visualiser draws scene walls under entity trails. Reading a movement trace against actual building outlines is dramatically clearer than imagining the geometry behind the dots.

## What changed
**Zenith_Telemetry** (engine)
- New `SceneObstacle` struct: `(cx, cz, hx, hz, yawRadians)` — top-down XZ OBB with explicit rotation
- `Header.axObstacles` — populated by caller before `Recorder::Begin()`
- Binary format bumped to **version 2** (header now serialises an obstacle list at the end); `Reader` accepts both v1 and v2
- JSON exporter emits an `obstacles` array inside the header

**PersonalityPlaythrough** (DP test)
- New `ScanSceneObstacles()` helper walks `Zenith_ColliderComponent` + filters to box shapes with mesh-aware OBB centre above y=1.5 (same threshold the pathfinder uses)
- Called once in `kHP_CaptureRefs` before `GetRecorder().Begin()`
- All 5 personalities pick walls up automatically (~159 obstacles per run)

**dp_telemetry_visualise.ps1** (tools)
- Reads `$telemetry.header.obstacles`, rotates each OBB's 4 corners by yaw, projects through the existing world→image map
- Renders as semi-transparent grey polygons (alpha 102) under the entity trails so paths stay clearly readable
- v1 telemetry files render unchanged (empty obstacle list)

## Verification
- All 5 personalities PASS headless (Casual 1846, Stealth 3586, Speedrunner 1317, Berserker 2063, Methodical 1861 frames)
- Speedrunner PNG shows red sprint trails on outdoor straights + yellow walks on close approaches inside the pentagram building's wall outline, threading through doorways

## Test plan
- [x] All 5 personality tests PASS
- [x] Visualiser renders walls under trails for fresh v2 recordings
- [x] Backwards-compat: v1 recordings still load + render with no obstacles
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)