### PR TITLE
fix(dp): DPTelemetryAnalyzer accept Zenith_Telemetry v2

### DIFF
--- a/Games/DevilsPlayground/Source/DPTelemetryAnalyzer.cpp
+++ b/Games/DevilsPlayground/Source/DPTelemetryAnalyzer.cpp
@@ -158,7 +158,11 @@ namespace DPTelemetryAnalyzer
 			{
 				const auto& xH = xReader.GetHeader();
 				if (xH.uMagic != 0x4D4C545Au) { xR.szReason = "magic != 'ZTLM'"; break; }
-				if (xH.uVersion != 1u)        { xR.szReason = "version != 1"; break; }
+				// Accept the two versions the current Reader handles
+				// (see Zenith_Telemetry::Reader::LoadFromFile). v1 was
+				// the original; v2 added Header.axObstacles.
+				if (xH.uVersion != 1u && xH.uVersion != 2u)
+				                              { xR.szReason = "version != 1 && != 2"; break; }
 				xR.bPassed = true; xR.szReason = "ok"; break;
 			}
 			case Criterion::HeaderHasSceneName:


### PR DESCRIPTION
Follow-up to #91. The analyzer's `HeaderMagicValid` criterion still asserted `uVersion == 1` so all v2 recordings failed at the first analyzer step. Relaxes to accept both v1 and v2, matching the engine Reader's policy.

Verified: `Test_DPTelemetryAnalyzer` PASSES locally after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)