### PR TITLE
fix(dp): telemetry obstacle yaw -- atan2 Tait-Bryan, fixes rotation-collapse bug

### DIFF
--- a/Games/DevilsPlayground/Tests/Test_PersonalityPlaythrough.cpp
+++ b/Games/DevilsPlayground/Tests/Test_PersonalityPlaythrough.cpp
@@ -589,12 +589,25 @@ namespace
 				// Top-down OBB (XZ plane). Yaw extracted from the world
 				// rotation; the visualiser rotates the local-frame
 				// half-extents by yaw when computing the 4 corners.
+				//
+				// Why not glm::yaw(xRot)? GLM's implementation is
+				// `asin(-2*(qx*qz - qw*qy))`, which collapses to the
+				// [-pi/2, pi/2] range -- a 135-degree rotation comes
+				// back as 45 because asin(sin(135)) = asin(sin(45)).
+				// Half the BuildingAssetKit walls are authored at
+				// angles outside that range, so glm::yaw was rendering
+				// them at the wrong orientation. The atan2-based
+				// Tait-Bryan extraction below covers the full
+				// [-pi, pi] range and is exact for yaw-only rotations
+				// (which is all our walls have).
 				Zenith_Telemetry::SceneObstacle xO;
 				xO.fCentreX     = xCentre.x;
 				xO.fCentreZ     = xCentre.z;
 				xO.fHalfExtentX = xHalfExtents.x;
 				xO.fHalfExtentZ = xHalfExtents.z;
-				xO.fYawRadians  = glm::yaw(xRot);
+				xO.fYawRadians  = std::atan2(
+					2.0f * (xRot.w * xRot.y + xRot.x * xRot.z),
+					1.0f - 2.0f * (xRot.y * xRot.y + xRot.z * xRot.z));
 				xOutObs.PushBack(xO);
 				++uIncluded;
 			});


### PR DESCRIPTION
## Summary
Follow-up to #93. The scene-obstacle scanner used `glm::yaw`, which is implemented as `asin(-2*(qx*qz - qw*qy))`. `asin`'s codomain is `[-pi/2, pi/2]`, so any rotation outside that range collapses — a 135° yaw came back as 45°, a -120° as -60°, etc.

Diagnostic on the BuildingAssetKit walls confirmed a wall authored with quat `(w=0.383, y=0.924)` (a 135° yaw) was being recorded as 45°. Roughly half the walls in GameLevel are authored outside the `[-90°, 90°]` range so they all rendered at the wrong orientation.

## Fix
Replaces `glm::yaw` with the standard Tait-Bryan ZYX yaw extraction:
```
yaw = atan2(2*(w*y + x*z), 1 - 2*(y*y + z*z))
```
which covers the full `[-pi, pi]` range and is exact for yaw-only rotations (which is all our walls have).

## Test plan
- [x] All 5 personality tests PASS
- [x] Diagnostic confirmed quat `(w=0.383, y=0.924)` now extracts to 135° (was 45°)
- [x] Visualiser PNG shows perpendicular walls at correct angles
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)