### PR TITLE
feat(dp,tools): procgen P0 -- BSP layout generator + visualiser

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -185,6 +185,9 @@
     <ClInclude Include="..\Source\DPFogPass.h" />
     <ClInclude Include="..\Source\DPInputActions.h" />
     <ClInclude Include="..\Source\DPMaterials.h" />
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_Generator.h" />
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.h" />
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_LevelLayout.h" />
     <ClInclude Include="..\Source\DPTelemetry.h" />
     <ClInclude Include="..\Source\DPTelemetryAnalyzer.h" />
     <ClInclude Include="..\Source\DPUI.h" />
@@ -199,6 +202,8 @@
     <ClCompile Include="..\DevilsPlayground.cpp" />
     <ClCompile Include="..\Source\DPFogPass.cpp" />
     <ClCompile Include="..\Source\DPMaterials.cpp" />
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_Generator.cpp" />
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.cpp" />
     <ClCompile Include="..\Source\DPTelemetry.cpp" />
     <ClCompile Include="..\Source\DPTelemetryAnalyzer.cpp" />
     <ClCompile Include="..\Source\DP_Archetypes.cpp" />
@@ -305,6 +310,7 @@
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
+    <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp" />
     <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -8,6 +8,12 @@
     <ClCompile Include="..\Source\DPMaterials.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_Generator.cpp">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.cpp">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source\DPTelemetry.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -326,6 +332,9 @@
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
@@ -427,6 +436,15 @@
     <ClInclude Include="..\Source\DPMaterials.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_Generator.h">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.h">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_LevelLayout.h">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClInclude>
     <ClInclude Include="..\Source\DPTelemetry.h">
       <Filter>Source</Filter>
     </ClInclude>
@@ -461,6 +479,9 @@
     </Filter>
     <Filter Include="Source">
       <UniqueIdentifier>{d1bd1bf3-e8b3-cc5b-d652-680e16935819}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\DPProcLevel">
+      <UniqueIdentifier>{7e214264-baa7-437e-5700-c33e33a7bb41}</UniqueIdentifier>
     </Filter>
     <Filter Include="Tests">
       <UniqueIdentifier>{e52d7990-6129-41c3-18f9-76ebe4af3a75}</UniqueIdentifier>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -479,6 +479,9 @@
     <ClInclude Include="..\Source\DPFogPass.h" />
     <ClInclude Include="..\Source\DPInputActions.h" />
     <ClInclude Include="..\Source\DPMaterials.h" />
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_Generator.h" />
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.h" />
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_LevelLayout.h" />
     <ClInclude Include="..\Source\DPTelemetry.h" />
     <ClInclude Include="..\Source\DPTelemetryAnalyzer.h" />
     <ClInclude Include="..\Source\DPUI.h" />
@@ -493,6 +496,8 @@
     <ClCompile Include="..\DevilsPlayground.cpp" />
     <ClCompile Include="..\Source\DPFogPass.cpp" />
     <ClCompile Include="..\Source\DPMaterials.cpp" />
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_Generator.cpp" />
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.cpp" />
     <ClCompile Include="..\Source\DPTelemetry.cpp" />
     <ClCompile Include="..\Source\DPTelemetryAnalyzer.cpp" />
     <ClCompile Include="..\Source\DP_Archetypes.cpp" />
@@ -599,6 +604,7 @@
     <ClCompile Include="..\Tests\Test_PostFogHookFires.cpp" />
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
+    <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp" />
     <ClCompile Include="..\Tests\Test_T0NavMesh_QueryCountIncrements.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -8,6 +8,12 @@
     <ClCompile Include="..\Source\DPMaterials.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_Generator.cpp">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.cpp">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source\DPTelemetry.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -326,6 +332,9 @@
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
@@ -427,6 +436,15 @@
     <ClInclude Include="..\Source\DPMaterials.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_Generator.h">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_JsonExport.h">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\DPProcLevel\DPProcLevel_LevelLayout.h">
+      <Filter>Source\DPProcLevel</Filter>
+    </ClInclude>
     <ClInclude Include="..\Source\DPTelemetry.h">
       <Filter>Source</Filter>
     </ClInclude>
@@ -461,6 +479,9 @@
     </Filter>
     <Filter Include="Source">
       <UniqueIdentifier>{d1bd1bf3-e8b3-cc5b-d652-680e16935819}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\DPProcLevel">
+      <UniqueIdentifier>{7e214264-baa7-437e-5700-c33e33a7bb41}</UniqueIdentifier>
     </Filter>
     <Filter Include="Tests">
       <UniqueIdentifier>{e52d7990-6129-41c3-18f9-76ebe4af3a75}</UniqueIdentifier>

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_Generator.cpp
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_Generator.cpp
@@ -1,0 +1,368 @@
+#include "Zenith.h"
+#include "Source/DPProcLevel/DPProcLevel_Generator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+namespace DPProcLevel
+{
+	namespace
+	{
+		// Axis-aligned partition rectangle used during BSP recursion.
+		struct Partition
+		{
+			float fMinX, fMinZ, fMaxX, fMaxZ;
+			RoomId xLeafRoomId = kInvalidRoomId;  // assigned when this becomes a leaf
+		};
+
+		using Rng = std::mt19937_64;
+
+		// Uniform random float in [fLo, fHi].
+		float UniformF(Rng& xRng, float fLo, float fHi)
+		{
+			std::uniform_real_distribution<float> xDist(fLo, fHi);
+			return xDist(xRng);
+		}
+
+		// 2D OBB intersection via separating axis theorem. We test the
+		// 4 axes that the two OBBs' edges define; if any axis separates
+		// them, they don't intersect.
+		bool OBBsOverlap(const Room& xA, const Room& xB)
+		{
+			const float fCosA = std::cos(xA.fYawRadians);
+			const float fSinA = std::sin(xA.fYawRadians);
+			const float fCosB = std::cos(xB.fYawRadians);
+			const float fSinB = std::sin(xB.fYawRadians);
+
+			// Local-frame axis vectors for each OBB. Axis A0 = (cos, sin)
+			// (rotated +X local axis), A1 = (-sin, cos) (rotated +Z local
+			// axis). Use Right-handed R_y convention to match the
+			// telemetry visualiser fix from PR #95:
+			//   world.x = lx*cos + lz*sin
+			//   world.z = -lx*sin + lz*cos
+			// so axis A0 (lx=1, lz=0) is world (cos, -sin) and A1 (lx=0,
+			// lz=1) is world (sin, cos).
+			const float fA0x = fCosA;
+			const float fA0z = -fSinA;
+			const float fA1x = fSinA;
+			const float fA1z = fCosA;
+			const float fB0x = fCosB;
+			const float fB0z = -fSinB;
+			const float fB1x = fSinB;
+			const float fB1z = fCosB;
+
+			const float fDx = xB.fCentreX - xA.fCentreX;
+			const float fDz = xB.fCentreZ - xA.fCentreZ;
+
+			// Test against each of the 4 axes. For axis n (unit vector),
+			// the projected separation must exceed the sum of projected
+			// half-extents from each OBB.
+			auto IsSeparating = [&](float nx, float nz) -> bool
+			{
+				// Project A's half-extents onto axis n.
+				const float fAProj =
+					xA.fHalfExtentX * std::fabs(fA0x * nx + fA0z * nz) +
+					xA.fHalfExtentZ * std::fabs(fA1x * nx + fA1z * nz);
+				const float fBProj =
+					xB.fHalfExtentX * std::fabs(fB0x * nx + fB0z * nz) +
+					xB.fHalfExtentZ * std::fabs(fB1x * nx + fB1z * nz);
+				const float fCentreProj = std::fabs(fDx * nx + fDz * nz);
+				return fCentreProj > (fAProj + fBProj);
+			};
+
+			if (IsSeparating(fA0x, fA0z)) return false;
+			if (IsSeparating(fA1x, fA1z)) return false;
+			if (IsSeparating(fB0x, fB0z)) return false;
+			if (IsSeparating(fB1x, fB1z)) return false;
+			return true;
+		}
+
+		// Recursive BSP. Splits the partition until either axis is below
+		// 2 * fMinRoomSize or we hit uBspDepth depth. Leaves get an
+		// xLeafRoomId assigned in DFS order.
+		//
+		// Returns the SUBTREE'S list of leaf indices (into axLeaves).
+		Zenith_Vector<int32_t> BspRecurse(
+			Rng& xRng, const GenConfig& xCfg,
+			Partition xP, uint32_t uDepthRemaining,
+			Zenith_Vector<Partition>& axLeavesOut)
+		{
+			Zenith_Vector<int32_t> axLeafIndices;
+
+			const float fW = xP.fMaxX - xP.fMinX;
+			const float fH = xP.fMaxZ - xP.fMinZ;
+
+			// Stop splitting if either axis can't split into two valid
+			// children, or we hit the depth limit.
+			const bool bCanSplitX = (fW >= 2.0f * xCfg.fMinRoomSize);
+			const bool bCanSplitZ = (fH >= 2.0f * xCfg.fMinRoomSize);
+
+			if (uDepthRemaining == 0 || (!bCanSplitX && !bCanSplitZ))
+			{
+				xP.xLeafRoomId = static_cast<RoomId>(axLeavesOut.GetSize());
+				axLeavesOut.PushBack(xP);
+				axLeafIndices.PushBack(xP.xLeafRoomId);
+				return axLeafIndices;
+			}
+
+			// Pick split axis. Prefer the longer dimension to avoid
+			// degenerate sliver partitions.
+			const bool bSplitOnX = bCanSplitX && (!bCanSplitZ || (fW >= fH));
+
+			// Split position is in the middle 50%% of the dimension --
+			// 25%% to 75%% -- so we get visible variety without producing
+			// pathological strips.
+			Partition xLow = xP, xHigh = xP;
+			if (bSplitOnX)
+			{
+				const float fSplit = UniformF(xRng,
+					xP.fMinX + 0.25f * fW, xP.fMinX + 0.75f * fW);
+				xLow.fMaxX  = fSplit;
+				xHigh.fMinX = fSplit;
+			}
+			else
+			{
+				const float fSplit = UniformF(xRng,
+					xP.fMinZ + 0.25f * fH, xP.fMinZ + 0.75f * fH);
+				xLow.fMaxZ  = fSplit;
+				xHigh.fMinZ = fSplit;
+			}
+
+			Zenith_Vector<int32_t> axL = BspRecurse(xRng, xCfg, xLow, uDepthRemaining - 1, axLeavesOut);
+			Zenith_Vector<int32_t> axH = BspRecurse(xRng, xCfg, xHigh, uDepthRemaining - 1, axLeavesOut);
+			for (uint32_t i = 0; i < axL.GetSize(); ++i) axLeafIndices.PushBack(axL.Get(i));
+			for (uint32_t i = 0; i < axH.GetSize(); ++i) axLeafIndices.PushBack(axH.Get(i));
+			return axLeafIndices;
+		}
+
+		// Pick a room OBB inside a partition. Rotation-safe sizing: a
+		// room of half-extents (hx, hz) has bounding-circle radius
+		// sqrt(hx^2 + hz^2). For ANY rotation to keep the room inside
+		// its partition (with margin), that radius must be <= the
+		// partition's inscribed-circle radius. We pick the LARGEST
+		// square satisfying that constraint:
+		//   hx = hz = (min(pHX, pHZ) - margin) / sqrt(2)
+		// This gives ~70%% of the axis-aligned room you'd get from the
+		// naive "half-extent = partition half-extent - margin" formula,
+		// in exchange for guaranteeing the rotated OBB never leaks into
+		// an adjacent partition. Visual variety still comes from yaw
+		// rotation; if rectangular rooms are wanted later, swap this
+		// for an aspect-ratio-aware sizing that preserves bounding-circle
+		// <= inscribed-circle.
+		Room PartitionToRoom(const Partition& xP, RoomId xId, const GenConfig& xCfg)
+		{
+			const float fMargin = 0.5f;
+			const float fPartHX = 0.5f * (xP.fMaxX - xP.fMinX);
+			const float fPartHZ = 0.5f * (xP.fMaxZ - xP.fMinZ);
+			const float fSafeR  = std::min(fPartHX, fPartHZ) - fMargin;
+			constexpr float kInvSqrt2 = 0.70710678118f;
+			const float fH = std::min(fSafeR * kInvSqrt2, xCfg.fMaxRoomSize);
+			Room xRoom;
+			xRoom.id           = xId;
+			xRoom.fCentreX     = 0.5f * (xP.fMinX + xP.fMaxX);
+			xRoom.fCentreZ     = 0.5f * (xP.fMinZ + xP.fMaxZ);
+			xRoom.fHalfExtentX = fH;
+			xRoom.fHalfExtentZ = fH;
+			xRoom.fYawRadians  = 0.0f;
+			return xRoom;
+		}
+
+		// Two partitions are BSP-adjacent if they share a non-zero
+		// segment of edge. Used to seed the corridor graph.
+		bool PartitionsShareEdge(const Partition& xA, const Partition& xB)
+		{
+			constexpr float kEps = 0.001f;
+			// Vertical shared edge: A's right matches B's left or vice
+			// versa, and Z ranges overlap.
+			if (std::fabs(xA.fMaxX - xB.fMinX) < kEps ||
+			    std::fabs(xB.fMaxX - xA.fMinX) < kEps)
+			{
+				const float fZLo = std::max(xA.fMinZ, xB.fMinZ);
+				const float fZHi = std::min(xA.fMaxZ, xB.fMaxZ);
+				return (fZHi - fZLo) > kEps;
+			}
+			// Horizontal shared edge.
+			if (std::fabs(xA.fMaxZ - xB.fMinZ) < kEps ||
+			    std::fabs(xB.fMaxZ - xA.fMinZ) < kEps)
+			{
+				const float fXLo = std::max(xA.fMinX, xB.fMinX);
+				const float fXHi = std::min(xA.fMaxX, xB.fMaxX);
+				return (fXHi - fXLo) > kEps;
+			}
+			return false;
+		}
+
+		// Project the partition-edge midpoint onto a room's nearest edge
+		// to get a door point. The room may be rotated, so we work in the
+		// room's LOCAL frame: rotate the world midpoint into local, clamp
+		// to the room's local AABB, rotate back to world.
+		//
+		// This is "fuzzy" -- after room rotation the door point may not
+		// sit on a corridor partner's edge exactly. The corridor segment
+		// then has both endpoints anchored to physically-real room walls,
+		// which is what we want for the eventual wall+door entity
+		// authoring (Phase 1).
+		DoorPoint ProjectDoorPoint(const Room& xRoom, float fWorldX, float fWorldZ)
+		{
+			// Translate to room-centred frame.
+			const float fLocalX = fWorldX - xRoom.fCentreX;
+			const float fLocalZ = fWorldZ - xRoom.fCentreZ;
+			// Rotate into the room's local frame: inverse of R_y(yaw)
+			// applied to (fLocalX, fLocalZ). R_y inverse swaps the sign
+			// of the off-diagonal sin terms.
+			const float fCos = std::cos(xRoom.fYawRadians);
+			const float fSin = std::sin(xRoom.fYawRadians);
+			const float fRX  =  fLocalX * fCos - fLocalZ * fSin;
+			const float fRZ  =  fLocalX * fSin + fLocalZ * fCos;
+			// Clamp to the room's local half-extents (so the door sits
+			// on the nearest edge). The clamp picks the edge whose
+			// outward normal best matches the (fRX, fRZ) direction.
+			const float fAbsRX = std::fabs(fRX);
+			const float fAbsRZ = std::fabs(fRZ);
+			float fEdgeX, fEdgeZ;
+			if (fAbsRX * xRoom.fHalfExtentZ > fAbsRZ * xRoom.fHalfExtentX)
+			{
+				// X-edge is "closer" (in scaled coords).
+				fEdgeX = (fRX >= 0.0f) ? xRoom.fHalfExtentX : -xRoom.fHalfExtentX;
+				fEdgeZ = std::clamp(fRZ, -xRoom.fHalfExtentZ, xRoom.fHalfExtentZ);
+			}
+			else
+			{
+				fEdgeZ = (fRZ >= 0.0f) ? xRoom.fHalfExtentZ : -xRoom.fHalfExtentZ;
+				fEdgeX = std::clamp(fRX, -xRoom.fHalfExtentX, xRoom.fHalfExtentX);
+			}
+			// Rotate back to world.
+			DoorPoint xD;
+			xD.fX = xRoom.fCentreX + fEdgeX * fCos + fEdgeZ * fSin;
+			xD.fZ = xRoom.fCentreZ - fEdgeX * fSin + fEdgeZ * fCos;
+			xD.xRoomId = xRoom.id;
+			return xD;
+		}
+	}
+
+	bool Generate(uint64_t uSeed, const GenConfig& xConfig, LevelLayout& xOut)
+	{
+		// Reset output.
+		xOut = LevelLayout();
+		xOut.uSeed       = uSeed;
+		xOut.fBoundsMinX = xConfig.fBoundsMinX;
+		xOut.fBoundsMinZ = xConfig.fBoundsMinZ;
+		xOut.fBoundsMaxX = xConfig.fBoundsMaxX;
+		xOut.fBoundsMaxZ = xConfig.fBoundsMaxZ;
+
+		const float fW = xConfig.fBoundsMaxX - xConfig.fBoundsMinX;
+		const float fH = xConfig.fBoundsMaxZ - xConfig.fBoundsMinZ;
+		if (fW < 2.0f * xConfig.fMinRoomSize || fH < 2.0f * xConfig.fMinRoomSize)
+		{
+			Zenith_Warning(LOG_CATEGORY_CORE,
+				"DPProcLevel::Generate: bounds %gx%g too small for fMinRoomSize=%g",
+				fW, fH, xConfig.fMinRoomSize);
+			return false;
+		}
+
+		Rng xRng(uSeed);
+
+		// 1. BSP partition.
+		Partition xRoot;
+		xRoot.fMinX = xConfig.fBoundsMinX;
+		xRoot.fMinZ = xConfig.fBoundsMinZ;
+		xRoot.fMaxX = xConfig.fBoundsMaxX;
+		xRoot.fMaxZ = xConfig.fBoundsMaxZ;
+
+		Zenith_Vector<Partition> axLeaves;
+		BspRecurse(xRng, xConfig, xRoot, xConfig.uBspDepth, axLeaves);
+
+		// 2. Convert partitions to rooms, then assign yaws with
+		//    overlap-rejection. Rotation moves the OBB's corners outside
+		//    its axis-aligned footprint, so the retry loop checks both
+		//    world-bounds containment AND overlap against rooms already
+		//    placed. A yaw that fails either check is rejected; after
+		//    uMaxYawRetries failures the room falls back to yaw=0 (which
+		//    is always safe: the BSP partitions are non-overlapping and
+		//    contained in the bounds by construction).
+		auto IsRotatedRoomInBounds = [&xConfig](const Room& xR) -> bool
+		{
+			const float fCos = std::cos(xR.fYawRadians);
+			const float fSin = std::sin(xR.fYawRadians);
+			const float aLocal[4][2] = {
+				{ -xR.fHalfExtentX, -xR.fHalfExtentZ },
+				{  xR.fHalfExtentX, -xR.fHalfExtentZ },
+				{  xR.fHalfExtentX,  xR.fHalfExtentZ },
+				{ -xR.fHalfExtentX,  xR.fHalfExtentZ },
+			};
+			for (uint32_t i = 0; i < 4; ++i)
+			{
+				const float fLx = aLocal[i][0];
+				const float fLz = aLocal[i][1];
+				const float fWx = xR.fCentreX + fLx * fCos + fLz * fSin;
+				const float fWz = xR.fCentreZ - fLx * fSin + fLz * fCos;
+				if (fWx < xConfig.fBoundsMinX || fWx > xConfig.fBoundsMaxX) return false;
+				if (fWz < xConfig.fBoundsMinZ || fWz > xConfig.fBoundsMaxZ) return false;
+			}
+			return true;
+		};
+
+		for (uint32_t i = 0; i < axLeaves.GetSize(); ++i)
+		{
+			Room xRoom = PartitionToRoom(axLeaves.Get(i), static_cast<RoomId>(i), xConfig);
+
+			bool bAccepted = false;
+			for (uint32_t uAttempt = 0; uAttempt < xConfig.uMaxYawRetries; ++uAttempt)
+			{
+				xRoom.fYawRadians = UniformF(xRng, 0.0f, 6.28318530718f);  // [0, 2pi)
+				if (!IsRotatedRoomInBounds(xRoom)) continue;
+				bool bOverlap = false;
+				for (uint32_t j = 0; j < xOut.axRooms.GetSize(); ++j)
+				{
+					if (OBBsOverlap(xRoom, xOut.axRooms.Get(j))) { bOverlap = true; break; }
+				}
+				if (!bOverlap) { bAccepted = true; break; }
+			}
+			if (!bAccepted) xRoom.fYawRadians = 0.0f;
+
+			xOut.axRooms.PushBack(xRoom);
+		}
+
+		// 3. Corridors: for every BSP-adjacent leaf pair, emit a
+		//    Corridor between them. Door points are the midpoint of the
+		//    shared edge, projected onto each room's nearest edge.
+		for (uint32_t i = 0; i < axLeaves.GetSize(); ++i)
+		{
+			for (uint32_t j = i + 1; j < axLeaves.GetSize(); ++j)
+			{
+				const Partition& xA = axLeaves.Get(i);
+				const Partition& xB = axLeaves.Get(j);
+				if (!PartitionsShareEdge(xA, xB)) continue;
+
+				// Shared edge midpoint -- average the overlapping range.
+				float fMidX, fMidZ;
+				if (std::fabs(xA.fMaxX - xB.fMinX) < 0.001f ||
+				    std::fabs(xB.fMaxX - xA.fMinX) < 0.001f)
+				{
+					fMidX = std::fabs(xA.fMaxX - xB.fMinX) < 0.001f ? xA.fMaxX : xB.fMaxX;
+					fMidZ = 0.5f * (std::max(xA.fMinZ, xB.fMinZ) + std::min(xA.fMaxZ, xB.fMaxZ));
+				}
+				else
+				{
+					fMidZ = std::fabs(xA.fMaxZ - xB.fMinZ) < 0.001f ? xA.fMaxZ : xB.fMaxZ;
+					fMidX = 0.5f * (std::max(xA.fMinX, xB.fMinX) + std::min(xA.fMaxX, xB.fMaxX));
+				}
+
+				const DoorPoint xDA = ProjectDoorPoint(xOut.axRooms.Get(i), fMidX, fMidZ);
+				const DoorPoint xDB = ProjectDoorPoint(xOut.axRooms.Get(j), fMidX, fMidZ);
+				const int32_t iA = static_cast<int32_t>(xOut.axDoorPoints.GetSize());
+				xOut.axDoorPoints.PushBack(xDA);
+				const int32_t iB = static_cast<int32_t>(xOut.axDoorPoints.GetSize());
+				xOut.axDoorPoints.PushBack(xDB);
+
+				Corridor xC;
+				xC.iDoorA = iA;
+				xC.iDoorB = iB;
+				xOut.axCorridors.PushBack(xC);
+			}
+		}
+
+		return true;
+	}
+}

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_Generator.h
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_Generator.h
@@ -1,0 +1,50 @@
+#pragma once
+/**
+ * DPProcLevel::Generator - seed-deterministic BSP layout generator.
+ *
+ * P0 of the procgen feature. Given a seed + config, produces a LevelLayout
+ * with rooms + corridors + door points. Decoupled from the engine: pure
+ * data in, pure data out, no scene mutation. Phase 1 will translate
+ * LevelLayout into wall + door entity placements; Phase 2 will place
+ * game elements; Phase 3 villagers + priest.
+ *
+ * Algorithm (v1):
+ *   1. Recursively partition the world bounds via 2D BSP. Splits
+ *      alternate between X and Z axes; split position is randomised
+ *      within the middle 50%% of the current partition to give variety.
+ *      Stops when either axis is below 2 * GenConfig::fMinRoomSize.
+ *   2. Each leaf partition becomes a Room. The room shrinks to fit
+ *      inside the partition with margin, then receives a random yaw
+ *      rotation. If the rotated OBB overlaps a previously-placed room,
+ *      the yaw is retried up to GenConfig::uMaxYawRetries times before
+ *      falling back to 0.
+ *   3. Adjacent leaves in the BSP tree (siblings + ancestors) get a
+ *      corridor: pick the midpoint of their shared edge, project it
+ *      onto each room's nearest edge to get DoorPoints, emit a
+ *      Corridor referencing both DoorPoint indices.
+ *
+ * Determinism:
+ *   * Single uint64_t seed drives an std::mt19937_64 PRNG.
+ *   * Every random draw goes through that PRNG; no external clock or
+ *     std::random_device. Same seed -> identical LevelLayout across
+ *     runs, platforms, and processes.
+ *
+ * Failure:
+ *   * If the post-rotation overlap check fails for ALL retries, the
+ *     room falls back to yaw=0 (which is guaranteed not to overlap
+ *     since BSP partitions are non-overlapping by construction). The
+ *     test surface should pin a "no fall-back required" invariant
+ *     when uMaxYawRetries is generous.
+ */
+
+#include "DPProcLevel_LevelLayout.h"
+
+namespace DPProcLevel
+{
+	// Deterministic generation. Caller owns the LevelLayout; the
+	// function clears it before populating, so passing a recycled
+	// instance is fine. Returns true on success; only fails today
+	// for pathological GenConfigs (e.g. bounds smaller than
+	// fMinRoomSize). Failures are logged via Zenith_Warning.
+	bool Generate(uint64_t uSeed, const GenConfig& xConfig, LevelLayout& xOut);
+}

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_JsonExport.cpp
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_JsonExport.cpp
@@ -1,0 +1,74 @@
+#include "Zenith.h"
+#include "Source/DPProcLevel/DPProcLevel_JsonExport.h"
+
+#include <cstdio>
+#include <fstream>
+
+namespace DPProcLevel
+{
+	bool ExportLayoutJson(const LevelLayout& xLayout, const char* szPath)
+	{
+		std::ofstream xOut(szPath);
+		if (!xOut.is_open()) return false;
+
+		char buf[256];
+
+		xOut << "{\n";
+
+		// Header
+		xOut << "  \"header\": {\n";
+		xOut << "    \"version\": 1,\n";
+		xOut << "    \"seed\": " << xLayout.uSeed << ",\n";
+		std::snprintf(buf, sizeof(buf),
+			"    \"bounds\": { \"minX\": %.3f, \"minZ\": %.3f, \"maxX\": %.3f, \"maxZ\": %.3f }\n",
+			xLayout.fBoundsMinX, xLayout.fBoundsMinZ,
+			xLayout.fBoundsMaxX, xLayout.fBoundsMaxZ);
+		xOut << buf;
+		xOut << "  },\n";
+
+		// Rooms
+		xOut << "  \"rooms\": [";
+		const uint32_t uNR = xLayout.axRooms.GetSize();
+		for (uint32_t i = 0; i < uNR; ++i)
+		{
+			const Room& xR = xLayout.axRooms.Get(i);
+			std::snprintf(buf, sizeof(buf),
+				"{\"id\":%d,\"cx\":%.3f,\"cz\":%.3f,\"hx\":%.3f,\"hz\":%.3f,\"yaw\":%.5f}",
+				xR.id, xR.fCentreX, xR.fCentreZ, xR.fHalfExtentX, xR.fHalfExtentZ, xR.fYawRadians);
+			xOut << buf;
+			if (i + 1 < uNR) xOut << ",";
+		}
+		xOut << "],\n";
+
+		// Door points
+		xOut << "  \"doorPoints\": [";
+		const uint32_t uND = xLayout.axDoorPoints.GetSize();
+		for (uint32_t i = 0; i < uND; ++i)
+		{
+			const DoorPoint& xD = xLayout.axDoorPoints.Get(i);
+			std::snprintf(buf, sizeof(buf),
+				"{\"x\":%.3f,\"z\":%.3f,\"roomId\":%d}",
+				xD.fX, xD.fZ, xD.xRoomId);
+			xOut << buf;
+			if (i + 1 < uND) xOut << ",";
+		}
+		xOut << "],\n";
+
+		// Corridors
+		xOut << "  \"corridors\": [";
+		const uint32_t uNC = xLayout.axCorridors.GetSize();
+		for (uint32_t i = 0; i < uNC; ++i)
+		{
+			const Corridor& xC = xLayout.axCorridors.Get(i);
+			std::snprintf(buf, sizeof(buf),
+				"{\"doorA\":%d,\"doorB\":%d}",
+				xC.iDoorA, xC.iDoorB);
+			xOut << buf;
+			if (i + 1 < uNC) xOut << ",";
+		}
+		xOut << "]\n";
+
+		xOut << "}\n";
+		return true;
+	}
+}

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_JsonExport.h
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_JsonExport.h
@@ -1,0 +1,39 @@
+#pragma once
+/**
+ * DPProcLevel::JsonExport - writes a LevelLayout to a JSON file the
+ * PowerShell visualiser can consume. P0 inspection tool only -- not
+ * for runtime use. Format mirrors the telemetry JSON layout (header +
+ * arrays) so future readers can follow the same parsing pattern.
+ *
+ * Schema (v1):
+ *   {
+ *     "header": {
+ *       "version": 1,
+ *       "seed": <uint64>,
+ *       "bounds": { "minX": .., "minZ": .., "maxX": .., "maxZ": .. }
+ *     },
+ *     "rooms": [
+ *       { "id": N, "cx": .., "cz": .., "hx": .., "hz": .., "yaw": .. },
+ *       ...
+ *     ],
+ *     "doorPoints": [
+ *       { "x": .., "z": .., "roomId": N },
+ *       ...
+ *     ],
+ *     "corridors": [
+ *       { "doorA": N, "doorB": N },
+ *       ...
+ *     ]
+ *   }
+ */
+
+#include "DPProcLevel_LevelLayout.h"
+
+namespace DPProcLevel
+{
+	// Write the layout as JSON. Returns false on I/O error. The path is
+	// taken verbatim (no temp-dir munging) so the caller controls
+	// disposition -- unit tests typically write under
+	// %TEMP%/dp_proclevel_seed_<N>.json.
+	bool ExportLayoutJson(const LevelLayout& xLayout, const char* szPath);
+}

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_LevelLayout.h
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_LevelLayout.h
@@ -1,0 +1,108 @@
+#pragma once
+/**
+ * DPProcLevel::LevelLayout - data carrier for procedurally-generated levels.
+ *
+ * Pure-data output of DPProcLevel::Generator::Generate(). Decoupled from the
+ * scene-instantiation step (Phase 1 will translate this struct into wall +
+ * door entity placements) so the algorithm can be iterated on standalone:
+ * unit tests + a PowerShell visualiser both consume LevelLayout via the
+ * JSON export with no engine boot.
+ *
+ * Convention reminder (mirrors DPTelemetry::SceneObstacle):
+ *   * XZ plane only (Y is discarded for top-down)
+ *   * Room is an oriented bounding box: centre + half-extents (in local
+ *     room frame) + yawRadians (rotation around +Y, right-hand rule)
+ *   * Corridors connect ROOMS (by index) via a single straight line
+ *     between two DOOR POINTS (one anchored on each room's edge)
+ *
+ * Format-version 1. Bump if the struct layout changes incompatibly --
+ * the JSON exporter mirrors the same version field so old PNGs can be
+ * regenerated from old JSONs without lying about which generator built them.
+ */
+
+#include "Collections/Zenith_Vector.h"
+#include <cstdint>
+
+namespace DPProcLevel
+{
+	// Inclusive integer ID for a room. Used as the index into
+	// LevelLayout::axRooms; corridor + door references chain by ID.
+	using RoomId = int32_t;
+	constexpr RoomId kInvalidRoomId = -1;
+
+	struct Room
+	{
+		RoomId id          = kInvalidRoomId;
+		// World-space OBB. centre + half-extents + yaw. Half-extents are
+		// in the room's LOCAL frame so a yaw rotation just orients the
+		// rectangle without changing its size.
+		float   fCentreX    = 0.0f;
+		float   fCentreZ    = 0.0f;
+		float   fHalfExtentX = 0.0f;
+		float   fHalfExtentZ = 0.0f;
+		float   fYawRadians = 0.0f;
+	};
+
+	struct DoorPoint
+	{
+		// World-space XZ position of the door (on the shared edge of two
+		// rooms or on the corridor entrance to a room).
+		float fX = 0.0f;
+		float fZ = 0.0f;
+		// Which room this door anchors against. Each corridor has two
+		// door points, one per endpoint room.
+		RoomId xRoomId = kInvalidRoomId;
+	};
+
+	struct Corridor
+	{
+		// Indices into LevelLayout::axDoorPoints. A corridor connects
+		// exactly two door points; the corresponding rooms come from
+		// the door points' xRoomId fields.
+		int32_t iDoorA = -1;
+		int32_t iDoorB = -1;
+	};
+
+	struct LevelLayout
+	{
+		// Bounds the entire level occupies in world XZ. Set by the
+		// generator from its config; the visualiser uses it to size
+		// the rendering window so all rooms fit.
+		float fBoundsMinX = 0.0f;
+		float fBoundsMinZ = 0.0f;
+		float fBoundsMaxX = 0.0f;
+		float fBoundsMaxZ = 0.0f;
+
+		uint64_t uSeed = 0;     // generator seed -- echoed back so the
+		                        //   visualiser caption can show it
+
+		Zenith_Vector<Room>      axRooms;
+		Zenith_Vector<DoorPoint> axDoorPoints;
+		Zenith_Vector<Corridor>  axCorridors;
+	};
+
+	// Generator configuration. Defaults match the v1 design (100x100 m
+	// centred at (50,50), 4..15 m rooms, ~8 leaves, full-yaw rooms).
+	struct GenConfig
+	{
+		float    fBoundsMinX     = 0.0f;
+		float    fBoundsMinZ     = 0.0f;
+		float    fBoundsMaxX     = 100.0f;
+		float    fBoundsMaxZ     = 100.0f;
+		// Minimum room dimension after subdivision -- the BSP stops
+		// splitting a partition once any further split would produce a
+		// child smaller than this.
+		float    fMinRoomSize    = 4.0f;
+		// Hard cap on a single room's half-extent. The BSP partition
+		// may produce larger cells but the room placed inside is
+		// shrunk to fit so the visual variety stays consistent.
+		float    fMaxRoomSize    = 15.0f;
+		// BSP depth. Each leaf becomes one room, so the max room count
+		// is 2^depth.
+		uint32_t uBspDepth       = 3;
+		// Number of attempts the per-room yaw rotation gets to find an
+		// orientation that doesn't overlap previously-placed rooms.
+		// After this many failures the room falls back to yaw=0.
+		uint32_t uMaxYawRetries  = 16;
+	};
+}

--- a/Games/DevilsPlayground/Tests/Test_ProcLevel_BSP.cpp
+++ b/Games/DevilsPlayground/Tests/Test_ProcLevel_BSP.cpp
@@ -1,0 +1,296 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "Source/DPProcLevel/DPProcLevel_Generator.h"
+#include "Source/DPProcLevel/DPProcLevel_JsonExport.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+
+// ============================================================================
+// Test_ProcLevel_BSP -- P0 unit tests for the BSP layout generator.
+//
+// Pins the generator's contracts at the data level:
+//   1. Determinism: Generate(seed=N) twice produces byte-identical
+//      LevelLayouts (room count + every room's centre/extent/yaw + every
+//      door point + every corridor).
+//   2. Bounds: every room's OBB centre sits inside the config bounds and
+//      the room's far corners do not exceed the bounds by more than a
+//      tolerance margin.
+//   3. Connectivity: starting from room 0, BFS over the corridor graph
+//      reaches every other room (no orphaned partitions).
+//   4. No-overlap: applies the OBB SAT check (mirrored in the generator)
+//      to every pair of rooms and asserts no intersection.
+//
+// As a side effect, the test emits a layout JSON per seed under
+// %TEMP%/dp_proclevel_seed_<N>.json for the PowerShell visualiser to
+// pick up. That's the "look at the PNG" half of the dev loop -- the
+// test itself only verifies the contract, the visualiser shows what
+// the generator's actually producing.
+// ============================================================================
+
+namespace
+{
+	bool g_bPassed = false;
+	const char* g_szFailureReason = "";
+	int  g_iFailureSeed   = -1;
+
+	// Mirror of the generator's OBBsOverlap for the no-overlap test.
+	// Kept private to the test so the generator's helper can be tweaked
+	// without silently breaking the verification, and so any divergence
+	// surfaces here as a build break or a failing assertion.
+	bool OBBsOverlap(const DPProcLevel::Room& xA, const DPProcLevel::Room& xB)
+	{
+		const float fCosA = std::cos(xA.fYawRadians);
+		const float fSinA = std::sin(xA.fYawRadians);
+		const float fCosB = std::cos(xB.fYawRadians);
+		const float fSinB = std::sin(xB.fYawRadians);
+
+		const float fA0x = fCosA;  const float fA0z = -fSinA;
+		const float fA1x = fSinA;  const float fA1z = fCosA;
+		const float fB0x = fCosB;  const float fB0z = -fSinB;
+		const float fB1x = fSinB;  const float fB1z = fCosB;
+
+		const float fDx = xB.fCentreX - xA.fCentreX;
+		const float fDz = xB.fCentreZ - xA.fCentreZ;
+
+		auto IsSeparating = [&](float nx, float nz) -> bool
+		{
+			const float fAProj =
+				xA.fHalfExtentX * std::fabs(fA0x * nx + fA0z * nz) +
+				xA.fHalfExtentZ * std::fabs(fA1x * nx + fA1z * nz);
+			const float fBProj =
+				xB.fHalfExtentX * std::fabs(fB0x * nx + fB0z * nz) +
+				xB.fHalfExtentZ * std::fabs(fB1x * nx + fB1z * nz);
+			const float fCentreProj = std::fabs(fDx * nx + fDz * nz);
+			return fCentreProj > (fAProj + fBProj);
+		};
+
+		if (IsSeparating(fA0x, fA0z)) return false;
+		if (IsSeparating(fA1x, fA1z)) return false;
+		if (IsSeparating(fB0x, fB0z)) return false;
+		if (IsSeparating(fB1x, fB1z)) return false;
+		return true;
+	}
+
+	bool LayoutsIdentical(const DPProcLevel::LevelLayout& xA,
+	                      const DPProcLevel::LevelLayout& xB)
+	{
+		if (xA.uSeed                 != xB.uSeed)                 return false;
+		if (xA.axRooms.GetSize()     != xB.axRooms.GetSize())     return false;
+		if (xA.axDoorPoints.GetSize()!= xB.axDoorPoints.GetSize()) return false;
+		if (xA.axCorridors.GetSize() != xB.axCorridors.GetSize()) return false;
+		for (uint32_t i = 0; i < xA.axRooms.GetSize(); ++i)
+		{
+			const auto& rA = xA.axRooms.Get(i);
+			const auto& rB = xB.axRooms.Get(i);
+			if (rA.id != rB.id) return false;
+			if (rA.fCentreX     != rB.fCentreX)     return false;
+			if (rA.fCentreZ     != rB.fCentreZ)     return false;
+			if (rA.fHalfExtentX != rB.fHalfExtentX) return false;
+			if (rA.fHalfExtentZ != rB.fHalfExtentZ) return false;
+			if (rA.fYawRadians  != rB.fYawRadians)  return false;
+		}
+		for (uint32_t i = 0; i < xA.axDoorPoints.GetSize(); ++i)
+		{
+			const auto& dA = xA.axDoorPoints.Get(i);
+			const auto& dB = xB.axDoorPoints.Get(i);
+			if (dA.fX != dB.fX) return false;
+			if (dA.fZ != dB.fZ) return false;
+			if (dA.xRoomId != dB.xRoomId) return false;
+		}
+		for (uint32_t i = 0; i < xA.axCorridors.GetSize(); ++i)
+		{
+			const auto& cA = xA.axCorridors.Get(i);
+			const auto& cB = xB.axCorridors.Get(i);
+			if (cA.iDoorA != cB.iDoorA) return false;
+			if (cA.iDoorB != cB.iDoorB) return false;
+		}
+		return true;
+	}
+
+	bool LayoutConnected(const DPProcLevel::LevelLayout& xLayout)
+	{
+		const uint32_t uN = xLayout.axRooms.GetSize();
+		if (uN == 0) return true;
+		// BFS from room 0 over the corridor graph (corridors connect
+		// rooms via door points). Build adjacency on the fly.
+		Zenith_Vector<bool> abVisited;
+		for (uint32_t i = 0; i < uN; ++i) abVisited.PushBack(false);
+		abVisited.Get(0) = true;
+		Zenith_Vector<int32_t> axFrontier;
+		axFrontier.PushBack(0);
+		uint32_t uReached = 1;
+		while (axFrontier.GetSize() > 0)
+		{
+			const int32_t iCur = axFrontier.Get(axFrontier.GetSize() - 1);
+			axFrontier.Remove(axFrontier.GetSize() - 1);
+			for (uint32_t i = 0; i < xLayout.axCorridors.GetSize(); ++i)
+			{
+				const auto& xC = xLayout.axCorridors.Get(i);
+				const int32_t xRoomA = xLayout.axDoorPoints.Get(xC.iDoorA).xRoomId;
+				const int32_t xRoomB = xLayout.axDoorPoints.Get(xC.iDoorB).xRoomId;
+				int32_t iOther = -1;
+				if      (xRoomA == iCur) iOther = xRoomB;
+				else if (xRoomB == iCur) iOther = xRoomA;
+				if (iOther < 0) continue;
+				if (abVisited.Get(static_cast<uint32_t>(iOther))) continue;
+				abVisited.Get(static_cast<uint32_t>(iOther)) = true;
+				axFrontier.PushBack(iOther);
+				++uReached;
+			}
+		}
+		return uReached == uN;
+	}
+
+	bool LayoutInBounds(const DPProcLevel::LevelLayout& xLayout)
+	{
+		const float kTol = 0.001f;
+		// Project each room's 4 corners through its rotation matrix and
+		// check those world-space points stay inside the bounds. Using
+		// the bounding-circle radius as a conservative check would
+		// reject perfectly-fitting tall-thin rooms whose long axis
+		// happens to align parallel to the boundary.
+		for (uint32_t i = 0; i < xLayout.axRooms.GetSize(); ++i)
+		{
+			const auto& xR = xLayout.axRooms.Get(i);
+			const float fCos = std::cos(xR.fYawRadians);
+			const float fSin = std::sin(xR.fYawRadians);
+			const float aLocal[4][2] = {
+				{ -xR.fHalfExtentX, -xR.fHalfExtentZ },
+				{  xR.fHalfExtentX, -xR.fHalfExtentZ },
+				{  xR.fHalfExtentX,  xR.fHalfExtentZ },
+				{ -xR.fHalfExtentX,  xR.fHalfExtentZ },
+			};
+			for (uint32_t k = 0; k < 4; ++k)
+			{
+				const float fLx = aLocal[k][0];
+				const float fLz = aLocal[k][1];
+				const float fWx = xR.fCentreX + fLx * fCos + fLz * fSin;
+				const float fWz = xR.fCentreZ - fLx * fSin + fLz * fCos;
+				if (fWx < xLayout.fBoundsMinX - kTol) return false;
+				if (fWz < xLayout.fBoundsMinZ - kTol) return false;
+				if (fWx > xLayout.fBoundsMaxX + kTol) return false;
+				if (fWz > xLayout.fBoundsMaxZ + kTol) return false;
+			}
+		}
+		return true;
+	}
+
+	bool LayoutNoOverlap(const DPProcLevel::LevelLayout& xLayout)
+	{
+		for (uint32_t i = 0; i < xLayout.axRooms.GetSize(); ++i)
+		{
+			for (uint32_t j = i + 1; j < xLayout.axRooms.GetSize(); ++j)
+			{
+				if (OBBsOverlap(xLayout.axRooms.Get(i), xLayout.axRooms.Get(j)))
+					return false;
+			}
+		}
+		return true;
+	}
+
+	std::string TempPath(uint64_t uSeed)
+	{
+		std::error_code xErr;
+		std::filesystem::path xDir = std::filesystem::temp_directory_path(xErr);
+		if (xErr) xDir = ".";
+		char buf[64];
+		std::snprintf(buf, sizeof(buf), "dp_proclevel_seed_%llu.json",
+			static_cast<unsigned long long>(uSeed));
+		xDir /= buf;
+		return xDir.string();
+	}
+
+	bool Fail(const char* sz, int iSeed)
+	{
+		g_szFailureReason = sz;
+		g_iFailureSeed    = iSeed;
+		return false;
+	}
+
+	// Verifies the contract on a single seed AND emits a JSON for the
+	// visualiser. Returns false on first failed assertion.
+	bool RunOneSeed(uint64_t uSeed)
+	{
+		DPProcLevel::GenConfig xCfg;  // defaults
+		DPProcLevel::LevelLayout xA, xB;
+
+		if (!DPProcLevel::Generate(uSeed, xCfg, xA))
+			return Fail("Generate returned false", static_cast<int>(uSeed));
+		if (xA.axRooms.GetSize() == 0)
+			return Fail("zero rooms generated", static_cast<int>(uSeed));
+
+		// Determinism: run again, expect identical output.
+		if (!DPProcLevel::Generate(uSeed, xCfg, xB))
+			return Fail("second Generate returned false", static_cast<int>(uSeed));
+		if (!LayoutsIdentical(xA, xB))
+			return Fail("not deterministic across runs", static_cast<int>(uSeed));
+
+		if (!LayoutInBounds(xA))
+			return Fail("room exits world bounds", static_cast<int>(uSeed));
+		if (!LayoutNoOverlap(xA))
+			return Fail("rooms overlap", static_cast<int>(uSeed));
+		if (!LayoutConnected(xA))
+			return Fail("corridor graph is disconnected", static_cast<int>(uSeed));
+
+		// Emit JSON for the visualiser.
+		const std::string strPath = TempPath(uSeed);
+		if (!DPProcLevel::ExportLayoutJson(xA, strPath.c_str()))
+			return Fail("ExportLayoutJson returned false", static_cast<int>(uSeed));
+
+		std::printf("[ProcLevelBSP] seed=%llu rooms=%u doors=%u corridors=%u json=%s\n",
+			static_cast<unsigned long long>(uSeed),
+			xA.axRooms.GetSize(), xA.axDoorPoints.GetSize(), xA.axCorridors.GetSize(),
+			strPath.c_str());
+		std::fflush(stdout);
+		return true;
+	}
+}
+
+static void Setup_ProcLevelBSP()
+{
+	g_bPassed = false;
+	g_szFailureReason = "";
+	g_iFailureSeed = -1;
+
+	// Run a handful of seeds covering "default", a few small variations,
+	// and one large value to make sure the PRNG handles big seeds.
+	const uint64_t auSeeds[] = { 0ull, 1ull, 2ull, 42ull, 0xFEEDC0DEull };
+	for (uint64_t uSeed : auSeeds)
+	{
+		if (!RunOneSeed(uSeed)) return;
+	}
+
+	g_bPassed = true;
+}
+
+static bool Step_ProcLevelBSP(int /*iFrame*/) { return false; }
+
+static bool Verify_ProcLevelBSP()
+{
+	if (!g_bPassed)
+	{
+		Zenith_Log(LOG_CATEGORY_CORE,
+			"ProcLevelBSP: FAIL seed=%d %s",
+			g_iFailureSeed, g_szFailureReason);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xProcLevelBSPTest = {
+	"Test_ProcLevel_BSP",
+	&Setup_ProcLevelBSP,
+	&Step_ProcLevelBSP,
+	&Verify_ProcLevelBSP,
+	60
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xProcLevelBSPTest);
+
+#endif // ZENITH_INPUT_SIMULATOR

--- a/Tools/dp_proclevel_visualise.ps1
+++ b/Tools/dp_proclevel_visualise.ps1
@@ -1,0 +1,198 @@
+# dp_proclevel_visualise.ps1 -- render a top-down PNG of a procgen LevelLayout.
+#
+# Reads the JSON exported by DPProcLevel::ExportLayoutJson (per-seed file
+# under %TEMP%, or wherever Test_ProcLevel_BSP wrote it) and draws:
+#   * world bounds (the 100x100 m rectangle)
+#   * each room as a filled OBB (rotated by yawRadians)
+#   * each corridor as a line between its two door points
+#   * door points as small markers
+#   * a caption with seed + room count
+#
+# Uses the same world->image projection convention as
+# dp_telemetry_visualise.ps1 (Z flipped so +Z is screen up) so PNGs from
+# the two tools sit side-by-side without coordinate confusion.
+#
+# Usage:
+#   pwsh ./Tools/dp_proclevel_visualise.ps1
+#   pwsh ./Tools/dp_proclevel_visualise.ps1 -JsonPath C:\path\to\layout.json
+#   pwsh ./Tools/dp_proclevel_visualise.ps1 -OutPath my.png -Width 2048 -Height 2048
+#
+# ASCII-only script body (Windows PowerShell 5.1 + pwsh 7+).
+
+[CmdletBinding()]
+param(
+    [string]$JsonPath = "$env:TEMP/dp_proclevel_seed_0.json",
+    [string]$OutPath  = "",
+    [int]$Width       = 1024,
+    [int]$Height      = 1024,
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+if (-not (Test-Path $JsonPath)) {
+    Write-Error "Layout JSON not found: $JsonPath"
+    exit 1
+}
+
+if ($OutPath -eq "") {
+    $dir   = Split-Path -Parent $JsonPath
+    $stem  = [IO.Path]::GetFileNameWithoutExtension($JsonPath)
+    $OutPath = Join-Path $dir "$stem.png"
+}
+
+Add-Type -AssemblyName System.Drawing
+
+if (-not $Quiet) { Write-Host "Loading $JsonPath..." -ForegroundColor Cyan }
+$layout = Get-Content $JsonPath -Raw | ConvertFrom-Json
+
+$rooms      = if ($layout.rooms)      { @($layout.rooms) }      else { @() }
+$doors      = if ($layout.doorPoints) { @($layout.doorPoints) } else { @() }
+$corridors  = if ($layout.corridors)  { @($layout.corridors) }  else { @() }
+
+if (-not $Quiet) { Write-Host "  + $($rooms.Count) rooms, $($doors.Count) doors, $($corridors.Count) corridors" -ForegroundColor DarkGray }
+
+# ----------------------------------------------------------------------
+# World <-> image projection
+# ----------------------------------------------------------------------
+$bounds = $layout.header.bounds
+$minX = [double]$bounds.minX
+$maxX = [double]$bounds.maxX
+$minZ = [double]$bounds.minZ
+$maxZ = [double]$bounds.maxZ
+$worldW = $maxX - $minX
+$worldH = $maxZ - $minZ
+$worldAspect = $worldW / $worldH
+
+# 10% padding inside the image so room edges don't kiss the canvas
+$pad = 0.05
+$drawW = [int]($Width  * (1.0 - 2 * $pad))
+$drawH = [int]($Height * (1.0 - 2 * $pad))
+# Letterbox to maintain world aspect ratio
+if ($drawW / $drawH -gt $worldAspect) {
+    $drawW = [int]($drawH * $worldAspect)
+}
+else {
+    $drawH = [int]($drawW / $worldAspect)
+}
+$offsetX = [int](($Width  - $drawW) / 2)
+$offsetY = [int](($Height - $drawH) / 2)
+
+function Project([double]$wx, [double]$wz) {
+    $u = ($wx - $minX) / $worldW
+    $v = 1.0 - (($wz - $minZ) / $worldH)  # flip Z so +Z is up on screen
+    return @([int]($offsetX + $u * $drawW), [int]($offsetY + $v * $drawH))
+}
+
+# ----------------------------------------------------------------------
+# Render
+# ----------------------------------------------------------------------
+$bmp = New-Object System.Drawing.Bitmap($Width, $Height)
+$g   = [System.Drawing.Graphics]::FromImage($bmp)
+$g.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+$g.TextRenderingHint = [System.Drawing.Text.TextRenderingHint]::AntiAlias
+
+# Background
+$bgColor = [System.Drawing.Color]::FromArgb(20, 22, 28)
+$g.Clear($bgColor)
+
+# World-bounds rectangle
+$borderPen = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(80, 85, 95), 1.5)
+$g.DrawRectangle($borderPen, $offsetX, $offsetY, $drawW, $drawH)
+$borderPen.Dispose()
+
+# Per-room colour palette -- subtle pastel hues so adjacent rooms read
+# as distinct regions but the whole map feels coherent. Cycles for runs
+# with >palette-size rooms.
+$roomPalette = @(
+    @(80, 130, 180), @(180, 110, 90), @(110, 170, 110), @(180, 160, 90),
+    @(160, 100, 170), @(100, 170, 170), @(200, 130, 150), @(150, 150, 200)
+)
+
+# Rooms (filled OBB)
+for ($i = 0; $i -lt $rooms.Count; ++$i) {
+    $room = $rooms[$i]
+    $cx  = [double]$room.cx
+    $cz  = [double]$room.cz
+    $hx  = [double]$room.hx
+    $hz  = [double]$room.hz
+    $yaw = [double]$room.yaw
+    $cosY = [math]::Cos($yaw)
+    $sinY = [math]::Sin($yaw)
+    # Same R_y rotation matrix the telemetry visualiser uses (see
+    # PR #95). Local (lx, lz) -> world (lx*cos + lz*sin, -lx*sin + lz*cos).
+    $corners = @(
+        @(-$hx, -$hz), @( $hx, -$hz), @( $hx,  $hz), @(-$hx,  $hz)
+    )
+    $worldPts = @()
+    foreach ($lc in $corners) {
+        $wx = $cx + $lc[0] * $cosY + $lc[1] * $sinY
+        $wz = $cz - $lc[0] * $sinY + $lc[1] * $cosY
+        $pt = Project $wx $wz
+        $worldPts += New-Object System.Drawing.Point($pt[0], $pt[1])
+    }
+    $rgb = $roomPalette[$i % $roomPalette.Count]
+    # Fill with ~50% alpha so corridors + doors stay readable.
+    $fill = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(140, $rgb[0], $rgb[1], $rgb[2]))
+    $stroke = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(255, $rgb[0], $rgb[1], $rgb[2]), 2.0)
+    $g.FillPolygon($fill, [System.Drawing.Point[]]$worldPts)
+    $g.DrawPolygon($stroke, [System.Drawing.Point[]]$worldPts)
+    $fill.Dispose()
+    $stroke.Dispose()
+
+    # Room id label at the room centre
+    $centreImg = Project $cx $cz
+    $labelFont = New-Object System.Drawing.Font('Consolas', 11.0, [System.Drawing.FontStyle]::Bold)
+    $labelBrush = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::White)
+    $g.DrawString("R$($room.id)", $labelFont, $labelBrush, ($centreImg[0] - 10), ($centreImg[1] - 10))
+    $labelFont.Dispose()
+    $labelBrush.Dispose()
+}
+
+# Corridors (line between two door points)
+$corridorPen = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(220, 220, 220, 230), 2.0)
+foreach ($c in $corridors) {
+    if ($c.doorA -lt 0 -or $c.doorA -ge $doors.Count) { continue }
+    if ($c.doorB -lt 0 -or $c.doorB -ge $doors.Count) { continue }
+    $dA = $doors[$c.doorA]
+    $dB = $doors[$c.doorB]
+    $pA = Project ([double]$dA.x) ([double]$dA.z)
+    $pB = Project ([double]$dB.x) ([double]$dB.z)
+    $g.DrawLine($corridorPen, $pA[0], $pA[1], $pB[0], $pB[1])
+}
+$corridorPen.Dispose()
+
+# Door points (small dots) -- drawn last so they sit on top of rooms +
+# corridors.
+$doorFill = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(255, 255, 230, 100))
+$doorStroke = New-Object System.Drawing.Pen([System.Drawing.Color]::Black, 1.0)
+foreach ($d in $doors) {
+    $p = Project ([double]$d.x) ([double]$d.z)
+    $g.FillEllipse($doorFill, ($p[0] - 4), ($p[1] - 4), 8, 8)
+    $g.DrawEllipse($doorStroke, ($p[0] - 4), ($p[1] - 4), 8, 8)
+}
+$doorFill.Dispose()
+$doorStroke.Dispose()
+
+# Caption (top-left)
+$capFont = New-Object System.Drawing.Font('Consolas', 14.0, [System.Drawing.FontStyle]::Regular)
+$capBrush = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(220, 220, 230))
+$caption = "seed=$($layout.header.seed)  rooms=$($rooms.Count)  doors=$($doors.Count)  corridors=$($corridors.Count)"
+$g.DrawString($caption, $capFont, $capBrush, 10, 8)
+$boundsCaption = "world bounds: x=[{0:F1},{1:F1}]  z=[{2:F1},{3:F1}]  ({4:F1}m x {5:F1}m)" -f $minX, $maxX, $minZ, $maxZ, $worldW, $worldH
+$g.DrawString($boundsCaption, $capFont, $capBrush, 10, 30)
+$capFont.Dispose()
+$capBrush.Dispose()
+
+# Save
+$bmp.Save($OutPath, [System.Drawing.Imaging.ImageFormat]::Png)
+$g.Dispose()
+$bmp.Dispose()
+
+if (-not $Quiet) {
+    $size = [int]((Get-Item $OutPath).Length / 1024)
+    Write-Host "Wrote $OutPath ($size KB)" -ForegroundColor Green
+}


### PR DESCRIPTION
## Summary
P0 of the procgen level work. Pure-data BSP layout generator + standalone PowerShell visualiser. No engine integration yet — scene loading still uses the authored GameLevel. Lets us iterate on the algorithm via PNG output before any of the gameplay plumbing touches it.

## What lands
- **`Games/DevilsPlayground/Source/DPProcLevel/`** (new):
  - `LevelLayout` data structure (rooms with centre+halfExtents+yaw, door points, corridor graph, bounds, seed)
  - `Generator::Generate(seed, GenConfig, &out)` — recursive 2D BSP, per-room random yaw with overlap-rejection, rotation-safe sizing (room bounding-circle ≤ partition inscribed-circle), `std::mt19937_64` for determinism
  - `ExportLayoutJson()` for the visualiser
- **`Tests/Test_ProcLevel_BSP.cpp`** — pins determinism, world-bounds, no-overlap (OBB SAT across all pairs), connectivity (BFS over corridor graph). Emits a JSON per seed under `%TEMP%` as a side effect.
- **`Tools/dp_proclevel_visualise.ps1`** — reads layout JSON, renders rooms (filled rotated polygons with per-room colour), corridors (lines), door points (yellow dots), bounds, caption. Uses the same R_y rotation convention as the telemetry visualiser (#95) so the two tools' coordinate systems agree.

## Test plan
- [x] `Test_ProcLevel_BSP` passes for seeds {0, 1, 2, 42, 0xFEEDC0DE}
- [x] Rendered PNGs for seeds 0, 1, 2, 42 — each visibly distinct (different rooms, sizes, yaws, corridor topology)
- [x] Same seed produces byte-identical layouts across runs
- [ ] CI green

## What this DOESN'T do (future phases)
- P1: `LevelLayout → vector<Placement>` so walls + doors actually instantiate in a scene
- P2: pentagram, forge, key chain, 5 objectives, chest, noise machine placement
- P3: villager + priest spawning
- P4: scene-load integration + Tuning.json seed field + `--procgen-seed` CLI
- P5: remove authored GameLevel.zscen
- P6: personality matrix across N seeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)