### PR TITLE
feat(dp,tools): procgen P1 -- wall segment emission with door gaps

### DIFF
--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_Generator.cpp
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_Generator.cpp
@@ -203,6 +203,182 @@ namespace DPProcLevel
 			return false;
 		}
 
+		// Build wall segments for the layout. Each room contributes 4
+		// edges (bottom, right, top, left in local frame); each edge is
+		// split into 1..N segments by the door gaps that fall on it.
+		// Door points are projected back into each room's local frame so
+		// we know which edge they belong to.
+		//
+		// Convention: emitted WallSegment uses (hx, hz) where hx is the
+		// half-length along the wall's local +X and hz is half-thickness
+		// along local +Z. For edges that run along the room's local +X
+		// (top + bottom), this maps directly: wall hx = segment half-length,
+		// wall hz = half-thickness, wall yaw = room yaw. For edges along
+		// local +Z (left + right) we SWAP into (hx = thickness, hz = length)
+		// so the wall still has yaw = room.yaw -- avoids a 90 deg yaw
+		// offset that would otherwise mess with the visualiser's coord
+		// expectations.
+		void BuildWallSegments(const LevelLayout& xLayoutIn,
+		                       const GenConfig& xCfg,
+		                       Zenith_Vector<WallSegment>& xOut)
+		{
+			xOut.Clear();
+			const float fHalfThick = xCfg.fWallHalfThickness;
+			const float fDoorHalf  = xCfg.fDoorGapHalfWidth;
+
+			for (uint32_t uR = 0; uR < xLayoutIn.axRooms.GetSize(); ++uR)
+			{
+				const Room& xRoom = xLayoutIn.axRooms.Get(uR);
+				const float fCos = std::cos(xRoom.fYawRadians);
+				const float fSin = std::sin(xRoom.fYawRadians);
+				const float fHx  = xRoom.fHalfExtentX;
+				const float fHz  = xRoom.fHalfExtentZ;
+
+				// Door positions in this room's local frame, classified by
+				// which edge they sit on. Index 0 = bottom (lz=-fHz),
+				// 1 = right (lx=+fHx), 2 = top (lz=+fHz), 3 = left (lx=-fHx).
+				Zenith_Vector<float> aaDoorsAlongEdge[4];
+
+				const float kEdgeTol = 0.01f;  // 1 cm; rotation is exact for door projection
+				for (uint32_t uD = 0; uD < xLayoutIn.axDoorPoints.GetSize(); ++uD)
+				{
+					const DoorPoint& xDP = xLayoutIn.axDoorPoints.Get(uD);
+					if (xDP.xRoomId != xRoom.id) continue;
+					// Inverse of R_y rotation (XZ): see PR #95 conventions.
+					//   wx = cx + lx*cos + lz*sin
+					//   wz = cz - lx*sin + lz*cos
+					// Inverse:
+					//   lx = dx*cos - dz*sin
+					//   lz = dx*sin + dz*cos
+					const float fDx = xDP.fX - xRoom.fCentreX;
+					const float fDz = xDP.fZ - xRoom.fCentreZ;
+					const float fLx = fDx * fCos - fDz * fSin;
+					const float fLz = fDx * fSin + fDz * fCos;
+					// Classify by closest edge (one of 4) using same logic as
+					// ProjectDoorPoint -- the door is guaranteed to sit on an
+					// edge because that's how it was authored.
+					const float fAbsLx = std::fabs(fLx);
+					const float fAbsLz = std::fabs(fLz);
+					if (fAbsLx * fHz > fAbsLz * fHx)
+					{
+						// X-edge: door is on left or right
+						const int iEdge = (fLx >= 0.0f) ? 1 : 3;  // right=1, left=3
+						aaDoorsAlongEdge[iEdge].PushBack(fLz);
+						(void)kEdgeTol;
+					}
+					else
+					{
+						// Z-edge: door is on bottom or top
+						const int iEdge = (fLz >= 0.0f) ? 2 : 0;  // top=2, bottom=0
+						aaDoorsAlongEdge[iEdge].PushBack(fLx);
+					}
+				}
+
+				// For each edge, sort door positions along the edge axis,
+				// then split [-half, +half] into segments with gaps.
+				//
+				// Edge 0 (bottom): axis = lx, fixed lz = -fHz
+				// Edge 1 (right):  axis = lz, fixed lx = +fHx
+				// Edge 2 (top):    axis = lx, fixed lz = +fHz
+				// Edge 3 (left):   axis = lz, fixed lx = -fHx
+				const float aLocalFixed[4][2] = {
+					{ 0.0f, -fHz },   // bottom: local (0, -hz), axis = lx
+					{ +fHx, 0.0f },   // right:  local (+hx, 0), axis = lz
+					{ 0.0f, +fHz },   // top:    local (0, +hz), axis = lx
+					{ -fHx, 0.0f },   // left:   local (-hx, 0), axis = lz
+				};
+				const bool abIsXEdge[4] = { true, false, true, false };
+
+				for (int iE = 0; iE < 4; ++iE)
+				{
+					const float fAxisMax = abIsXEdge[iE] ? fHx : fHz;
+					Zenith_Vector<float>& axDoors = aaDoorsAlongEdge[iE];
+
+					// Bubble-sort the door positions (small N -- typically <=2
+					// doors per edge in a BSP layout, so the cost is negligible).
+					for (uint32_t a = 0; a + 1 < axDoors.GetSize(); ++a)
+					{
+						for (uint32_t b = a + 1; b < axDoors.GetSize(); ++b)
+						{
+							if (axDoors.Get(b) < axDoors.Get(a))
+							{
+								const float t = axDoors.Get(a);
+								axDoors.Get(a) = axDoors.Get(b);
+								axDoors.Get(b) = t;
+							}
+						}
+					}
+
+					// Walk along the edge axis, emitting wall segments around
+					// the door gaps. A door at position d removes the interval
+					// [d - fDoorHalf, d + fDoorHalf] from the edge; we emit a
+					// wall for whatever's left.
+					float fCursor = -fAxisMax;
+					Zenith_Vector<float> axBreakpoints;  // pairs of (start, end)
+					for (uint32_t uD = 0; uD < axDoors.GetSize(); ++uD)
+					{
+						const float fDoorPos = axDoors.Get(uD);
+						const float fGapStart = fDoorPos - fDoorHalf;
+						const float fGapEnd   = fDoorPos + fDoorHalf;
+						if (fGapStart > fCursor)
+						{
+							axBreakpoints.PushBack(fCursor);
+							axBreakpoints.PushBack(fGapStart);
+						}
+						if (fGapEnd > fCursor) fCursor = fGapEnd;
+					}
+					if (fCursor < fAxisMax)
+					{
+						axBreakpoints.PushBack(fCursor);
+						axBreakpoints.PushBack(fAxisMax);
+					}
+
+					// Each pair in axBreakpoints is one wall segment.
+					for (uint32_t uP = 0; uP + 1 < axBreakpoints.GetSize(); uP += 2)
+					{
+						const float fA = axBreakpoints.Get(uP);
+						const float fB = axBreakpoints.Get(uP + 1);
+						const float fSegHalf = 0.5f * (fB - fA);
+						if (fSegHalf < 0.001f) continue;  // degenerate
+						const float fSegAxisCentre = 0.5f * (fA + fB);
+
+						// Wall's local-frame centre offset from room centre.
+						float fLocalCX, fLocalCZ;
+						if (abIsXEdge[iE])
+						{
+							fLocalCX = fSegAxisCentre;
+							fLocalCZ = aLocalFixed[iE][1];
+						}
+						else
+						{
+							fLocalCX = aLocalFixed[iE][0];
+							fLocalCZ = fSegAxisCentre;
+						}
+
+						// Rotate to world (R_y).
+						WallSegment xW;
+						xW.fCentreX = xRoom.fCentreX + fLocalCX * fCos + fLocalCZ * fSin;
+						xW.fCentreZ = xRoom.fCentreZ - fLocalCX * fSin + fLocalCZ * fCos;
+						xW.fYawRadians = xRoom.fYawRadians;
+						// Length along wall's local +X if it's an X-edge;
+						// along wall's local +Z if Z-edge. Swap hx/hz to
+						// match (see header comment).
+						if (abIsXEdge[iE])
+						{
+							xW.fHalfExtentX = fSegHalf;
+							xW.fHalfExtentZ = fHalfThick;
+						}
+						else
+						{
+							xW.fHalfExtentX = fHalfThick;
+							xW.fHalfExtentZ = fSegHalf;
+						}
+						xOut.PushBack(xW);
+					}
+				}
+			}
+		}
+
 		// Project the partition-edge midpoint onto a room's nearest edge
 		// to get a door point. The room may be rotated, so we work in the
 		// room's LOCAL frame: rotate the world midpoint into local, clamp
@@ -376,6 +552,10 @@ namespace DPProcLevel
 				xOut.axCorridors.PushBack(xC);
 			}
 		}
+
+		// 4. Wall segments derived from rooms + door points. Runs last so
+		//    every room + door point is finalised before we cut walls.
+		BuildWallSegments(xOut, xConfig, xOut.axWallSegments);
 
 		return true;
 	}

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_JsonExport.cpp
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_JsonExport.cpp
@@ -66,6 +66,22 @@ namespace DPProcLevel
 			xOut << buf;
 			if (i + 1 < uNC) xOut << ",";
 		}
+		xOut << "],\n";
+
+		// Wall segments (P1 geometry emission). Same OBB schema as
+		// rooms (cx, cz, hx, hz, yaw) so the visualiser can reuse its
+		// existing rotated-rectangle rendering.
+		xOut << "  \"walls\": [";
+		const uint32_t uNW = xLayout.axWallSegments.GetSize();
+		for (uint32_t i = 0; i < uNW; ++i)
+		{
+			const WallSegment& xW = xLayout.axWallSegments.Get(i);
+			std::snprintf(buf, sizeof(buf),
+				"{\"cx\":%.3f,\"cz\":%.3f,\"hx\":%.3f,\"hz\":%.3f,\"yaw\":%.5f}",
+				xW.fCentreX, xW.fCentreZ, xW.fHalfExtentX, xW.fHalfExtentZ, xW.fYawRadians);
+			xOut << buf;
+			if (i + 1 < uNW) xOut << ",";
+		}
 		xOut << "]\n";
 
 		xOut << "}\n";

--- a/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_LevelLayout.h
+++ b/Games/DevilsPlayground/Source/DPProcLevel/DPProcLevel_LevelLayout.h
@@ -63,6 +63,24 @@ namespace DPProcLevel
 		int32_t iDoorB = -1;
 	};
 
+	// Top-down OBB describing one straight wall segment. Same shape as
+	// Zenith_Telemetry::SceneObstacle so the segments are easy to
+	// visualise + later P4 can translate them 1:1 into Placement structs
+	// for AuthorPlacementBatch.
+	//
+	// Convention: half-extent X is the wall's "length" axis (along its
+	// own local +X), half-extent Z is the wall's "thickness" axis. The
+	// yaw places the wall in world XZ; a wall with yaw=0 is long along
+	// world +X.
+	struct WallSegment
+	{
+		float fCentreX     = 0.0f;
+		float fCentreZ     = 0.0f;
+		float fHalfExtentX = 0.0f;   // half-length along wall's local +X
+		float fHalfExtentZ = 0.0f;   // half-thickness along wall's local +Z
+		float fYawRadians  = 0.0f;
+	};
+
 	struct LevelLayout
 	{
 		// Bounds the entire level occupies in world XZ. Set by the
@@ -76,9 +94,14 @@ namespace DPProcLevel
 		uint64_t uSeed = 0;     // generator seed -- echoed back so the
 		                        //   visualiser caption can show it
 
-		Zenith_Vector<Room>      axRooms;
-		Zenith_Vector<DoorPoint> axDoorPoints;
-		Zenith_Vector<Corridor>  axCorridors;
+		Zenith_Vector<Room>        axRooms;
+		Zenith_Vector<DoorPoint>   axDoorPoints;
+		Zenith_Vector<Corridor>    axCorridors;
+		// Wall segments derived from rooms + door points (4 edges per
+		// room, split into multiple segments by door gaps). Populated
+		// at the end of Generate() so a caller of Generate() gets the
+		// full level description in one go.
+		Zenith_Vector<WallSegment> axWallSegments;
 	};
 
 	// Generator configuration. Defaults match the v1 design (100x100 m
@@ -112,5 +135,13 @@ namespace DPProcLevel
 		// bad. Set both to 1.0 to force square rooms.
 		float    fAspectMin      = 0.5f;
 		float    fAspectMax      = 2.0f;
+		// Wall geometry knobs. fWallHalfThickness is the perpendicular
+		// thickness of each emitted wall segment (default 0.15 -> 30 cm
+		// total thickness, matches the BuildingAssetKit convention).
+		// fDoorGapHalfWidth is the half-width of the gap left in a
+		// wall where a door point sits (default 1.0 -> 2 m clearance,
+		// enough for the bot's 0.5 m capsule with margin).
+		float    fWallHalfThickness = 0.15f;
+		float    fDoorGapHalfWidth  = 1.0f;
 	};
 }

--- a/Games/DevilsPlayground/Tests/Test_ProcLevel_BSP.cpp
+++ b/Games/DevilsPlayground/Tests/Test_ProcLevel_BSP.cpp
@@ -81,10 +81,21 @@ namespace
 	bool LayoutsIdentical(const DPProcLevel::LevelLayout& xA,
 	                      const DPProcLevel::LevelLayout& xB)
 	{
-		if (xA.uSeed                 != xB.uSeed)                 return false;
-		if (xA.axRooms.GetSize()     != xB.axRooms.GetSize())     return false;
-		if (xA.axDoorPoints.GetSize()!= xB.axDoorPoints.GetSize()) return false;
-		if (xA.axCorridors.GetSize() != xB.axCorridors.GetSize()) return false;
+		if (xA.uSeed                       != xB.uSeed)                       return false;
+		if (xA.axRooms.GetSize()           != xB.axRooms.GetSize())           return false;
+		if (xA.axDoorPoints.GetSize()      != xB.axDoorPoints.GetSize())      return false;
+		if (xA.axCorridors.GetSize()       != xB.axCorridors.GetSize())       return false;
+		if (xA.axWallSegments.GetSize()    != xB.axWallSegments.GetSize())    return false;
+		for (uint32_t i = 0; i < xA.axWallSegments.GetSize(); ++i)
+		{
+			const auto& wA = xA.axWallSegments.Get(i);
+			const auto& wB = xB.axWallSegments.Get(i);
+			if (wA.fCentreX != wB.fCentreX) return false;
+			if (wA.fCentreZ != wB.fCentreZ) return false;
+			if (wA.fHalfExtentX != wB.fHalfExtentX) return false;
+			if (wA.fHalfExtentZ != wB.fHalfExtentZ) return false;
+			if (wA.fYawRadians != wB.fYawRadians) return false;
+		}
 		for (uint32_t i = 0; i < xA.axRooms.GetSize(); ++i)
 		{
 			const auto& rA = xA.axRooms.Get(i);
@@ -239,14 +250,35 @@ namespace
 		if (!LayoutConnected(xA))
 			return Fail("corridor graph is disconnected", static_cast<int>(uSeed));
 
+		// P1 wall-emission invariants:
+		//   * Each room contributes >= 4 wall segments BEFORE doors are
+		//     subtracted (one per edge). With door gaps, some edges
+		//     might be fully removed only in the pathological case
+		//     where an edge has multiple wide doors -- not currently
+		//     possible because the BSP layout only puts one door per
+		//     shared partition edge. So the lower bound is 4*rooms -
+		//     doors, conservatively check >= 3*rooms which covers any
+		//     reasonable splitting.
+		//   * No degenerate (zero-half-extent) walls.
+		const uint32_t uExpectedMinWalls = 3u * xA.axRooms.GetSize();
+		if (xA.axWallSegments.GetSize() < uExpectedMinWalls)
+			return Fail("too few wall segments emitted", static_cast<int>(uSeed));
+		for (uint32_t i = 0; i < xA.axWallSegments.GetSize(); ++i)
+		{
+			const auto& xW = xA.axWallSegments.Get(i);
+			if (xW.fHalfExtentX < 0.001f || xW.fHalfExtentZ < 0.001f)
+				return Fail("degenerate wall segment", static_cast<int>(uSeed));
+		}
+
 		// Emit JSON for the visualiser.
 		const std::string strPath = TempPath(uSeed);
 		if (!DPProcLevel::ExportLayoutJson(xA, strPath.c_str()))
 			return Fail("ExportLayoutJson returned false", static_cast<int>(uSeed));
 
-		std::printf("[ProcLevelBSP] seed=%llu rooms=%u doors=%u corridors=%u json=%s\n",
+		std::printf("[ProcLevelBSP] seed=%llu rooms=%u doors=%u corridors=%u walls=%u json=%s\n",
 			static_cast<unsigned long long>(uSeed),
-			xA.axRooms.GetSize(), xA.axDoorPoints.GetSize(), xA.axCorridors.GetSize(),
+			xA.axRooms.GetSize(), xA.axDoorPoints.GetSize(),
+			xA.axCorridors.GetSize(), xA.axWallSegments.GetSize(),
 			strPath.c_str());
 		std::fflush(stdout);
 		return true;

--- a/Tools/dp_proclevel_visualise.ps1
+++ b/Tools/dp_proclevel_visualise.ps1
@@ -52,8 +52,9 @@ $layout = Get-Content $JsonPath -Raw | ConvertFrom-Json
 $rooms      = if ($layout.rooms)      { @($layout.rooms) }      else { @() }
 $doors      = if ($layout.doorPoints) { @($layout.doorPoints) } else { @() }
 $corridors  = if ($layout.corridors)  { @($layout.corridors) }  else { @() }
+$walls      = if ($layout.walls)      { @($layout.walls) }      else { @() }
 
-if (-not $Quiet) { Write-Host "  + $($rooms.Count) rooms, $($doors.Count) doors, $($corridors.Count) corridors" -ForegroundColor DarkGray }
+if (-not $Quiet) { Write-Host "  + $($rooms.Count) rooms, $($doors.Count) doors, $($corridors.Count) corridors, $($walls.Count) walls" -ForegroundColor DarkGray }
 
 # ----------------------------------------------------------------------
 # World <-> image projection
@@ -152,6 +153,38 @@ for ($i = 0; $i -lt $rooms.Count; ++$i) {
     $labelBrush.Dispose()
 }
 
+# Walls (filled rotated rectangles). Drawn on top of the room fills so
+# we can VISUALLY verify that wall segments hug the room edges and that
+# door gaps appear where expected. Each wall is a top-down OBB; reuse
+# the same R_y corner-rotation logic as the room pass.
+if ($walls.Count -gt 0) {
+    $wallFill   = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(255, 245, 245, 245))
+    $wallStroke = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(255, 30, 30, 35), 1.0)
+    foreach ($wall in $walls) {
+        $wcx  = [double]$wall.cx
+        $wcz  = [double]$wall.cz
+        $whx  = [double]$wall.hx
+        $whz  = [double]$wall.hz
+        $wyaw = [double]$wall.yaw
+        $wCos = [math]::Cos($wyaw)
+        $wSin = [math]::Sin($wyaw)
+        $wCorners = @(
+            @(-$whx, -$whz), @( $whx, -$whz), @( $whx,  $whz), @(-$whx,  $whz)
+        )
+        $wPts = @()
+        foreach ($lc in $wCorners) {
+            $wx = $wcx + $lc[0] * $wCos + $lc[1] * $wSin
+            $wz = $wcz - $lc[0] * $wSin + $lc[1] * $wCos
+            $pt = Project $wx $wz
+            $wPts += New-Object System.Drawing.Point($pt[0], $pt[1])
+        }
+        $g.FillPolygon($wallFill, [System.Drawing.Point[]]$wPts)
+        $g.DrawPolygon($wallStroke, [System.Drawing.Point[]]$wPts)
+    }
+    $wallFill.Dispose()
+    $wallStroke.Dispose()
+}
+
 # Corridors (line between two door points)
 $corridorPen = New-Object System.Drawing.Pen([System.Drawing.Color]::FromArgb(220, 220, 220, 230), 2.0)
 foreach ($c in $corridors) {
@@ -180,7 +213,7 @@ $doorStroke.Dispose()
 # Caption (top-left)
 $capFont = New-Object System.Drawing.Font('Consolas', 14.0, [System.Drawing.FontStyle]::Regular)
 $capBrush = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(220, 220, 230))
-$caption = "seed=$($layout.header.seed)  rooms=$($rooms.Count)  doors=$($doors.Count)  corridors=$($corridors.Count)"
+$caption = "seed=$($layout.header.seed)  rooms=$($rooms.Count)  doors=$($doors.Count)  corridors=$($corridors.Count)  walls=$($walls.Count)"
 $g.DrawString($caption, $capFont, $capBrush, 10, 8)
 $boundsCaption = "world bounds: x=[{0:F1},{1:F1}]  z=[{2:F1},{3:F1}]  ({4:F1}m x {5:F1}m)" -f $minX, $maxX, $minZ, $maxZ, $worldW, $worldH
 $g.DrawString($boundsCaption, $capFont, $capBrush, 10, 30)


### PR DESCRIPTION
## Summary
Second phase of the procgen level work. Given a `LevelLayout` from P0's BSP generator, derive the physical wall geometry: 4 edges per room, split into segments around door gaps. Output uses the same OBB schema as the telemetry's `SceneObstacle` so the visualiser reuses its rendering code and P4 will translate `WallSegment` 1:1 into `Placement` structs for `AuthorPlacementBatch`.

## What lands
- **`WallSegment` struct** in `LevelLayout` (cx, cz, hx, hz, yaw). Length along the wall's local +X, thickness along local +Z; for walls on a room's left/right edge we swap hx/hz so the wall's yaw stays equal to the room's yaw.
- **`BuildWallSegments()`** in `DPProcLevel_Generator.cpp` — inverse-rotates each door point to room-local, classifies which of the 4 edges it's on, sorts doors along each edge axis, splits the edge into segments around the gaps. Runs as step 4 of `Generate()`.
- **`GenConfig.fWallHalfThickness`** (default 0.15 → 30 cm walls) and **`fDoorGapHalfWidth`** (default 1.0 → 2 m door clearance).
- **JSON export** adds a `walls` array.
- **Visualiser** renders walls as opaque white-fill polygons on top of the room fills; caption shows wall count.
- **Unit test** extended: determinism, min-wall-count invariant (≥ 3·rooms), no-degenerate-wall check.

## Verification
- All 5 seeded layouts produce 47–50 wall segments each
- Re-rendered PNGs at 3200×3200 show walls hugging each room's perimeter with visible door gaps where corridor lines connect

## What's next
P2 — pentagram + forge + key chain + 5 objectives + chest + noise machine, with a solvability constraint check (key reachable without key, all objectives reachable, pentagram gated by door).

🤖 Generated with [Claude Code](https://claude.com/claude-code)