### PR TITLE
feat(dp): procgen P4c -- spawn game-element entities from layout

### DIFF
--- a/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
@@ -29,6 +29,17 @@
 
 #include "Source/DPProcLevel/DPProcLevel_Generator.h"
 #include "Source/DPProcLevel/DPProcLevel_LevelLayout.h"
+#include "Source/DevilsPlayground_Tags.h"
+
+// Behaviour types attached to procgen-spawned game elements. The bootstrap
+// is the canonical place game scripts get wired up onto procgen-generated
+// geometry, so it owns the include list rather than forwarding.
+#include "Components/DPPentagram_Behaviour.h"
+#include "Components/DPForge_Behaviour.h"
+#include "Components/DPDoor_Behaviour.h"
+#include "Components/DPChest_Behaviour.h"
+#include "Components/DummyNoiseMachine_Behaviour.h"
+#include "Components/DPItemBase_Behaviour.h"
 
 #include <cstdio>
 #include <cstdint>
@@ -75,6 +86,13 @@ public:
 		// pathfinder (which raycasts downward from y=10) sees these
 		// as "tall obstacles" (top > y=1.5) and routes around them.
 		SpawnWalls();
+
+		// P4c: instantiate the gameplay elements (pentagram, forge,
+		// door, chest, noise machine, iron + 5 objective pickups).
+		// SpawnPoint elements are skipped here -- they're consumed
+		// by SpawnVillagers (P4d) as the player-first-possession
+		// anchor, not entities in their own right.
+		SpawnGameElements();
 	}
 
 	void OnDestroy() ZENITH_FINAL override
@@ -97,6 +115,11 @@ public:
 	// less than axWallSegments.GetSize() if entity creation failed).
 	// Useful for the P4b smoke test.
 	uint32_t GetSpawnedWallCount() const { return m_uSpawnedWalls; }
+
+	// Count of game-element entities the bootstrap created. Excludes
+	// SpawnPoint elements (P4c skips those -- the spawn anchor is
+	// consumed by P4d's villager-spawn pass). Useful for the smoke test.
+	uint32_t GetSpawnedGameElementCount() const { return m_uSpawnedGameElements; }
 
 private:
 	// Spawn one entity per WallSegment. SM_Cube has mesh-local bounds
@@ -163,8 +186,184 @@ private:
 		std::fflush(stdout);
 	}
 
+	// Spawn one entity per GameElement. Each element type maps to a
+	// behaviour script + a collider profile that mirrors the GameLevel
+	// authoring patterns in DevilsPlayground.cpp:
+	//   * Pentagram: AABB collider, scaled 2x for "ritual disc" look,
+	//     y=1 anchor (matching the authored pentagram).
+	//   * Door: OBB collider so the navmesh blocker registers correctly
+	//     on the wall-aligned door footprint.
+	//   * Chest: AABB collider (mirrors AuthorPlacementBatch's default).
+	//   * Forge, NoiseMachine: no collider -- the F-press interaction
+	//     reads transform position directly via HandleInteract; the
+	//     collider would only be needed for click-to-interact raycasts
+	//     which the GameLevel forge/noise authoring also omits.
+	//   * Iron + Objective1..5: sphere collider, DPItemBase + SetTag.
+	//     Matches DPItemManager_Behaviour::SpawnItemEntity exactly so
+	//     pickup + tinting work identically to authored-spawn items.
+	//
+	// SpawnPoint elements are intentionally skipped here -- the
+	// villager-spawn pass (P4d) consumes the SpawnPoint as the first
+	// possessable villager's anchor, not as a free-standing entity.
+	void SpawnGameElements()
+	{
+		Zenith_Scene xScene = Zenith_SceneManager::GetActiveScene();
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneData(xScene);
+		if (pxScene == nullptr) return;
+
+		const std::string strMeshPath =
+			std::string(GAME_ASSETS_DIR) + "Meshes/LevelPrototyping_Meshes_SM_Cube" + ZENITH_MODEL_EXT;
+
+		uint32_t uSpawned = 0;
+		uint32_t uSkipped = 0;
+		const uint32_t uN = m_xLayout.axGameElements.GetSize();
+		for (uint32_t i = 0; i < uN; ++i)
+		{
+			const DPProcLevel::GameElement& xElem = m_xLayout.axGameElements.Get(i);
+
+			if (xElem.eType == DPProcLevel::GameElementType::SpawnPoint)
+			{
+				++uSkipped;
+				continue;
+			}
+
+			char szName[64];
+			std::snprintf(szName, sizeof(szName), "ProcElem_%u_%s",
+				i, GameElementTypeToShortName(xElem.eType));
+			Zenith_Entity xEntity(pxScene, std::string(szName));
+			if (!xEntity.IsValid()) continue;
+
+			// Transform: world XZ from element, y per-type (most live at
+			// y=0 with the cube anchored to the floor; pentagram floats
+			// to y=1 + 0.5y scale so it reads as a flat ritual disc).
+			if (xEntity.HasComponent<Zenith_TransformComponent>())
+			{
+				Zenith_TransformComponent& xT = xEntity.GetComponent<Zenith_TransformComponent>();
+				if (xElem.eType == DPProcLevel::GameElementType::Pentagram)
+				{
+					xT.SetPosition(Zenith_Maths::Vector3(xElem.fX, 1.0f, xElem.fZ));
+					xT.SetScale(Zenith_Maths::Vector3(2.0f, 0.5f, 2.0f));
+				}
+				else
+				{
+					xT.SetPosition(Zenith_Maths::Vector3(xElem.fX, 0.0f, xElem.fZ));
+				}
+			}
+
+			Zenith_ModelComponent& xModel = xEntity.AddComponent<Zenith_ModelComponent>();
+			xModel.LoadModel(strMeshPath);
+
+			switch (xElem.eType)
+			{
+			case DPProcLevel::GameElementType::Pentagram:
+			{
+				xEntity.AddComponent<Zenith_ColliderComponent>()
+					.AddCollider(COLLISION_VOLUME_TYPE_AABB, RIGIDBODY_TYPE_STATIC);
+				xEntity.AddComponent<Zenith_ScriptComponent>()
+					.AddScript<DPPentagram_Behaviour>();
+				break;
+			}
+			case DPProcLevel::GameElementType::Forge:
+			{
+				xEntity.AddComponent<Zenith_ScriptComponent>()
+					.AddScript<DPForge_Behaviour>();
+				break;
+			}
+			case DPProcLevel::GameElementType::Door:
+			{
+				xEntity.AddComponent<Zenith_ColliderComponent>()
+					.AddCollider(COLLISION_VOLUME_TYPE_OBB, RIGIDBODY_TYPE_STATIC);
+				xEntity.AddComponent<Zenith_ScriptComponent>()
+					.AddScript<DPDoor_Behaviour>();
+				break;
+			}
+			case DPProcLevel::GameElementType::Chest:
+			{
+				xEntity.AddComponent<Zenith_ColliderComponent>()
+					.AddCollider(COLLISION_VOLUME_TYPE_AABB, RIGIDBODY_TYPE_STATIC);
+				xEntity.AddComponent<Zenith_ScriptComponent>()
+					.AddScript<DPChest_Behaviour>();
+				break;
+			}
+			case DPProcLevel::GameElementType::NoiseMachine:
+			{
+				xEntity.AddComponent<Zenith_ScriptComponent>()
+					.AddScript<DummyNoiseMachine_Behaviour>();
+				break;
+			}
+			case DPProcLevel::GameElementType::Iron:
+			case DPProcLevel::GameElementType::Objective1:
+			case DPProcLevel::GameElementType::Objective2:
+			case DPProcLevel::GameElementType::Objective3:
+			case DPProcLevel::GameElementType::Objective4:
+			case DPProcLevel::GameElementType::Objective5:
+			{
+				xEntity.AddComponent<Zenith_ColliderComponent>()
+					.AddCollider(COLLISION_VOLUME_TYPE_SPHERE, RIGIDBODY_TYPE_STATIC);
+				DPItemBase_Behaviour* pxItem = xEntity
+					.AddComponent<Zenith_ScriptComponent>()
+					.AddScript<DPItemBase_Behaviour>();
+				if (pxItem != nullptr)
+				{
+					pxItem->SetTag(GameElementToItemTag(xElem.eType));
+				}
+				break;
+			}
+			case DPProcLevel::GameElementType::SpawnPoint:
+				// Already handled above (continue). Listed here so the
+				// switch is exhaustive and a future GameElementType
+				// addition forces a deliberate decision.
+				break;
+			}
+
+			++uSpawned;
+		}
+		m_uSpawnedGameElements = uSpawned;
+		std::printf("[DPProcLevelBootstrap] spawned %u game-element entities "
+			"(skipped %u spawn-points, total elements=%u)\n",
+			uSpawned, uSkipped, uN);
+		std::fflush(stdout);
+	}
+
+	static const char* GameElementTypeToShortName(DPProcLevel::GameElementType eType)
+	{
+		using T = DPProcLevel::GameElementType;
+		switch (eType)
+		{
+		case T::SpawnPoint:   return "Spawn";
+		case T::Pentagram:    return "Pentagram";
+		case T::Forge:        return "Forge";
+		case T::Door:         return "Door";
+		case T::Chest:        return "Chest";
+		case T::NoiseMachine: return "Noise";
+		case T::Iron:         return "Iron";
+		case T::Objective1:   return "Obj1";
+		case T::Objective2:   return "Obj2";
+		case T::Objective3:   return "Obj3";
+		case T::Objective4:   return "Obj4";
+		case T::Objective5:   return "Obj5";
+		}
+		return "Unknown";
+	}
+
+	static DP_ItemTag GameElementToItemTag(DPProcLevel::GameElementType eType)
+	{
+		using T = DPProcLevel::GameElementType;
+		switch (eType)
+		{
+		case T::Iron:       return DP_ItemTag::Iron;
+		case T::Objective1: return DP_ItemTag::Objective1;
+		case T::Objective2: return DP_ItemTag::Objective2;
+		case T::Objective3: return DP_ItemTag::Objective3;
+		case T::Objective4: return DP_ItemTag::Objective4;
+		case T::Objective5: return DP_ItemTag::Objective5;
+		default:            return DP_ItemTag::None;
+		}
+	}
+
 	uint64_t                  m_uSeed = 0ull;
 	uint32_t                  m_uSpawnedWalls = 0u;
+	uint32_t                  m_uSpawnedGameElements = 0u;
 	DPProcLevel::LevelLayout  m_xLayout;
 
 	static inline DPProcLevelBootstrap_Behaviour* s_pxInstance = nullptr;

--- a/Games/DevilsPlayground/Tests/Test_ProcLevelBootstrap.cpp
+++ b/Games/DevilsPlayground/Tests/Test_ProcLevelBootstrap.cpp
@@ -123,18 +123,40 @@ static bool Step_ProcLevelBootstrap(int iFrame)
 	// segment. Allow a small slack for entity creation failure (e.g.
 	// scene full) -- in practice the count should match exactly with
 	// an empty test scene.
-	const uint32_t uSpawned = pxBootstrap->GetSpawnedWallCount();
-	if (uSpawned != xLayout.axWallSegments.GetSize())
+	const uint32_t uSpawnedWalls = pxBootstrap->GetSpawnedWallCount();
+	if (uSpawnedWalls != xLayout.axWallSegments.GetSize())
 	{
 		g_szFailureReason = "Spawned wall count != layout wall-segment count";
 		return false;
 	}
 
+	// P4c -- the bootstrap should have spawned one entity per game
+	// element (pentagram, forge, doors, chests, noise machines, iron,
+	// objectives). SpawnPoint elements are skipped (consumed by P4d).
+	uint32_t uExpectedElements = 0;
+	for (uint32_t i = 0; i < xLayout.axGameElements.GetSize(); ++i)
+	{
+		if (xLayout.axGameElements.Get(i).eType
+		    != DPProcLevel::GameElementType::SpawnPoint)
+		{
+			++uExpectedElements;
+		}
+	}
+	const uint32_t uSpawnedElements = pxBootstrap->GetSpawnedGameElementCount();
+	if (uSpawnedElements != uExpectedElements)
+	{
+		g_szFailureReason =
+			"Spawned game-element count != expected (layout minus SpawnPoints)";
+		return false;
+	}
+
 	g_bPassed = true;
-	std::printf("[ProcLevelBootstrap] PASS: rooms=%u walls=%u elements=%u villagers=%u priest=%d\n",
+	std::printf("[ProcLevelBootstrap] PASS: rooms=%u walls=%u elements=%u "
+		"(spawned %u) villagers=%u priest=%d\n",
 		xLayout.axRooms.GetSize(),
 		xLayout.axWallSegments.GetSize(),
 		xLayout.axGameElements.GetSize(),
+		uSpawnedElements,
 		xLayout.axVillagerSpawns.GetSize(),
 		(int)xLayout.xPriestSpawn.bValid);
 	std::fflush(stdout);


### PR DESCRIPTION
## Summary
- DPProcLevelBootstrap_Behaviour now spawns one entity per non-SpawnPoint GameElement in the layout: pentagram, forge, doors, chests, noise machines, iron + 5 objective items. Each maps to the behaviour + collider profile used by the authored GameLevel.
- Test_ProcLevelBootstrap verifies `GetSpawnedGameElementCount() == axGameElements.size() - num_SpawnPoints`. Seed 0 spawns 12/13 game-element entities (1 SpawnPoint skipped — consumed later by P4d's villager-spawn pass).
- Full DP suite remains 125/125 green.

## Element-type mapping
| Layout type | Collider | Behaviour |
|---|---|---|
| Pentagram | AABB, scaled 2x y=1 | DPPentagram_Behaviour |
| Forge | (none) | DPForge_Behaviour |
| Door | OBB | DPDoor_Behaviour |
| Chest | AABB | DPChest_Behaviour |
| NoiseMachine | (none) | DummyNoiseMachine_Behaviour |
| Iron / Obj1..5 | Sphere | DPItemBase_Behaviour + SetTag |
| SpawnPoint | n/a | skipped (P4d will consume as villager anchor) |

## Test plan
- [x] Test_ProcLevelBootstrap green: 8 rooms / 48 walls / 13 elements (12 spawned)
- [x] Full DP suite (125 tests) green
- [ ] CI to confirm (auto-merge on green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)