### PR TITLE
feat(dp): procgen P5 -- author ProcLevel scene + scene-load test

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -312,6 +312,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_ProcLevelBootstrap.cpp" />
+    <ClCompile Include="..\Tests\Test_ProcLevelScene.cpp" />
     <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -335,6 +335,9 @@
     <ClCompile Include="..\Tests\Test_ProcLevelBootstrap.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_ProcLevelScene.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -606,6 +606,7 @@
     <ClCompile Include="..\Tests\Test_PriestBBBridge.cpp" />
     <ClCompile Include="..\Tests\Test_PriestPursuit.cpp" />
     <ClCompile Include="..\Tests\Test_ProcLevelBootstrap.cpp" />
+    <ClCompile Include="..\Tests\Test_ProcLevelScene.cpp" />
     <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp" />
     <ClCompile Include="..\Tests\Test_PublicInterfaces.cpp" />
     <ClCompile Include="..\Tests\Test_T0AudioBus_EmitsAndRecords.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -335,6 +335,9 @@
     <ClCompile Include="..\Tests\Test_ProcLevelBootstrap.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_ProcLevelScene.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_ProcLevel_BSP.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -1542,6 +1542,142 @@ namespace
 		Zenith_EditorAutomation::AddStep_SaveScene(GAME_ASSETS_DIR "Scenes/Gym_Forge" ZENITH_SCENE_EXT);
 		Zenith_EditorAutomation::AddStep_UnloadScene();
 	}
+
+	// ============================================================================
+	// ProcLevel scene -- the procgen-driven counterpart to GameLevel.
+	//
+	// Static authoring is intentionally lean: GameManager + UI scaffolding,
+	// PauseManager, GroundPlane, a handful of corner lights, plus a single
+	// "ProcLevelBootstrap" entity carrying DPProcLevelBootstrap_Behaviour.
+	//
+	// At runtime, the bootstrap's OnAwake calls DPProcLevel::Generate() with
+	// seed = m_uSeed (default 0) and then spawns the full level under the
+	// active scene:
+	//   * 48 wall entities (P4b)
+	//   * 12 game elements: pentagram, forge, doors, chests, noise, iron + 5
+	//     objectives (P4c)
+	//   * 17 villagers + 1 priest (P4d)
+	//
+	// The saved .zscen file therefore stays small (a half-dozen authored
+	// entities). Every level layout cell, item, character is conjured at
+	// load-time -- so changing the seed produces a different level without
+	// re-authoring anything. Useful both for human play + automated tests
+	// that want a non-GameLevel surface to drive personality bots against.
+	// ============================================================================
+	void AuthorProcLevelScene()
+	{
+		Zenith_EditorAutomation::AddStep_CreateScene("ProcLevel");
+
+		// ------ GameManager: hosts global controllers + HUD UI ----------------
+		Zenith_EditorAutomation::AddStep_CreateEntity("GameManager");
+
+		Zenith_EditorAutomation::AddStep_AddCamera();
+		// Overview camera centred on the procgen bounds. The GenConfig
+		// defaults place the level at XZ in [0, 100] so the centre is
+		// (50, _, 50). Pull back/up so the player sees most of the
+		// playable area before clicking a villager.
+		Zenith_EditorAutomation::AddStep_SetCameraPosition(50.0f, 35.0f, -15.0f);
+		Zenith_EditorAutomation::AddStep_SetCameraPitch(-0.85f);  // ~49° down
+		Zenith_EditorAutomation::AddStep_SetCameraFOV(glm::radians(55.0f));
+		Zenith_EditorAutomation::AddStep_SetAsMainCamera();
+
+		Zenith_EditorAutomation::AddStep_AddUI();
+		// Minimum HUD: LifeBar / HeldItem / Status / Objectives. Mirrors
+		// the GymCommon authoring (same DPUI constants, same anchors).
+		Zenith_EditorAutomation::AddStep_CreateUIText("LifeBar", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("LifeBar", static_cast<int>(Zenith_UI::AnchorPreset::TopLeft));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("LifeBar", static_cast<int>(Zenith_UI::TextAlignment::Left));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("LifeBar", DPUI::fEDGE_INSET, DPUI::fEDGE_INSET);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("LifeBar", DPUI::fHUD_LIFEBAR_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("LifeBar", 0.3f, 1.0f, 0.3f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("LifeBar", false);
+
+		Zenith_EditorAutomation::AddStep_CreateUIText("HeldItem", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("HeldItem", static_cast<int>(Zenith_UI::AnchorPreset::TopLeft));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("HeldItem", static_cast<int>(Zenith_UI::TextAlignment::Left));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("HeldItem", DPUI::fEDGE_INSET, DPUI::fEDGE_INSET + 50.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("HeldItem", DPUI::fHUD_HELDITEM_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("HeldItem", 1.0f, 1.0f, 1.0f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("HeldItem", false);
+
+		Zenith_EditorAutomation::AddStep_CreateUIText("Status", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("Status", static_cast<int>(Zenith_UI::AnchorPreset::Center));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("Status", static_cast<int>(Zenith_UI::TextAlignment::Center));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("Status", 0.0f, -80.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("Status", DPUI::fHUD_STATUS_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("Status", 0.9f, 0.2f, 0.2f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("Status", false);
+
+		Zenith_EditorAutomation::AddStep_CreateUIText("Objectives", "Objectives: 0/5");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("Objectives", static_cast<int>(Zenith_UI::AnchorPreset::TopRight));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("Objectives", static_cast<int>(Zenith_UI::TextAlignment::Right));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("Objectives", -DPUI::fEDGE_INSET, DPUI::fEDGE_INSET);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("Objectives", DPUI::fHUD_OBJECTIVES_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("Objectives", 0.95f, 0.7f, 0.7f, 1.0f);
+
+		// Global controller scripts (matches GymCommon).
+		Zenith_EditorAutomation::AddStep_AttachScript("DPPlayerController_Behaviour");
+		Zenith_EditorAutomation::AddStep_AttachScript("DPFogPass_Behaviour");
+		Zenith_EditorAutomation::AddStep_AttachScript("DPHUDController_Behaviour");
+		Zenith_EditorAutomation::AddStep_AttachScript("DPOrbitCamera_Behaviour");
+		Zenith_EditorAutomation::AddStep_AttachScript("DPItemManager_Behaviour");
+
+		// ------ PauseManager (dedicated entity, mirrors GameLevel) ------------
+		Zenith_EditorAutomation::AddStep_CreateEntity("PauseManager");
+		Zenith_EditorAutomation::AddStep_AddUI();
+		Zenith_EditorAutomation::AddStep_CreateUIText("PauseOverlay",
+			"PAUSED\nEsc: Resume   R: Restart   Q: Quit");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("PauseOverlay", static_cast<int>(Zenith_UI::AnchorPreset::Center));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("PauseOverlay", static_cast<int>(Zenith_UI::TextAlignment::Center));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("PauseOverlay", 0.0f, 0.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("PauseOverlay", DPUI::fHUD_PAUSE_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("PauseOverlay", 1.0f, 1.0f, 1.0f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("PauseOverlay", false);
+		Zenith_EditorAutomation::AddStep_AttachScript("DPPauseMenuController_Behaviour");
+
+		// ------ Ground plane --------------------------------------------------
+		// Procgen bounds are XZ in [0, 100]. Author a 100×100 m flush slab
+		// centred on (50, 0, 50) so the navmesh generator picks up a
+		// single connected walkable surface across the whole map.
+		Zenith_EditorAutomation::AddStep_CreateEntity("GroundPlane");
+		Zenith_EditorAutomation::AddStep_SetTransformPosition(50.0f, 0.0f, 50.0f);
+		Zenith_EditorAutomation::AddStep_SetTransformScale(50.0f, 0.5f, 50.0f);
+		AuthorMeshAndCollider(
+			"/Game/LevelPrototyping/Meshes/SM_Cube.SM_Cube",
+			/*bAddCollider=*/true,
+			COLLISION_VOLUME_TYPE_OBB,
+			RIGIDBODY_TYPE_STATIC);
+
+		// ------ Four corner lights for general visibility ---------------------
+		// Hand-authored point lights at high y so the procgen-spawned walls
+		// + items light up across the bounds. Intensity matches the GameLevel
+		// "candle minimum" so the scene isn't over-bloomed.
+		const float afLightXZ[4][2] = {
+			{ 25.0f, 25.0f }, { 75.0f, 25.0f },
+			{ 25.0f, 75.0f }, { 75.0f, 75.0f },
+		};
+		for (uint32_t i = 0; i < 4; ++i)
+		{
+			Zenith_EditorAutomation::AddStep_CreateEntity(InternEntityName("ProcLight", i));
+			Zenith_EditorAutomation::AddStep_SetTransformPosition(
+				afLightXZ[i][0], 10.0f, afLightXZ[i][1]);
+			Zenith_EditorAutomation::AddStep_AddComponent("Light");
+			Zenith_EditorAutomation::AddStep_SetLightIntensity(2000.0f);
+			Zenith_EditorAutomation::AddStep_SetLightRange(60.0f);
+			Zenith_EditorAutomation::AddStep_SetLightColor(1.0f, 0.95f, 0.85f);
+		}
+
+		// ------ The bootstrap entity ------------------------------------------
+		// Attaching this script is the ENTIRE level-content authoring. Every
+		// wall, item, character is materialised by the script's OnAwake at
+		// scene-load time. Changing m_uSeed (or the upcoming Tuning.json
+		// seed source) produces a different level without re-authoring.
+		Zenith_EditorAutomation::AddStep_CreateEntity("ProcLevelBootstrap");
+		Zenith_EditorAutomation::AddStep_AttachScript("DPProcLevelBootstrap_Behaviour");
+
+		Zenith_EditorAutomation::AddStep_SaveScene(GAME_ASSETS_DIR "Scenes/ProcLevel" ZENITH_SCENE_EXT);
+		Zenith_EditorAutomation::AddStep_UnloadScene();
+	}
 }
 
 void Project_RegisterEditorAutomationSteps()
@@ -1552,6 +1688,7 @@ void Project_RegisterEditorAutomationSteps()
 	AuthorGymNoiseScene();    // build index 3
 	AuthorGymDoorsScene();    // build index 4
 	AuthorGymForgeScene();    // build index 5
+	AuthorProcLevelScene();   // build index 6
 
 	Zenith_EditorAutomation::AddStep_LoadInitialScene(&Project_LoadInitialScene);
 }
@@ -1565,5 +1702,6 @@ void Project_LoadInitialScene()
 	Zenith_SceneManager::RegisterSceneBuildIndex(3, GAME_ASSETS_DIR "Scenes/Gym_Noise"  ZENITH_SCENE_EXT);
 	Zenith_SceneManager::RegisterSceneBuildIndex(4, GAME_ASSETS_DIR "Scenes/Gym_Doors"  ZENITH_SCENE_EXT);
 	Zenith_SceneManager::RegisterSceneBuildIndex(5, GAME_ASSETS_DIR "Scenes/Gym_Forge"  ZENITH_SCENE_EXT);
+	Zenith_SceneManager::RegisterSceneBuildIndex(6, GAME_ASSETS_DIR "Scenes/ProcLevel"  ZENITH_SCENE_EXT);
 	Zenith_SceneManager::LoadSceneByIndexBlockingForBootstrap(0, SCENE_LOAD_SINGLE);
 }

--- a/Games/DevilsPlayground/Tests/Test_ProcLevelScene.cpp
+++ b/Games/DevilsPlayground/Tests/Test_ProcLevelScene.cpp
@@ -1,0 +1,195 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_ScriptComponent.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Components/DPProcLevelBootstrap_Behaviour.h"
+#include "Components/DPVillager_Behaviour.h"
+#include "Components/Priest_Behaviour.h"
+#include "Components/DPItemBase_Behaviour.h"
+#include "Components/DPPentagram_Behaviour.h"
+#include "Components/DPForge_Behaviour.h"
+#include "Components/DPDoor_Behaviour.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_ProcLevelScene (P5) -- end-to-end scene load + bootstrap-spawn check.
+//
+// Loads the authored ProcLevel scene (build index 6) and verifies that the
+// bootstrap's OnAwake spawned a fully-populated level: walls + game elements
+// + AI agents. Sits alongside Test_ProcLevelBootstrap (which is a synthetic
+// "create empty scene + add bootstrap manually" smoke test) -- this test
+// exercises the real load path used by the runtime + the demo personality
+// playthrough.
+//
+// Pass criteria (seed 0, default GenConfig):
+//   - Bootstrap singleton registered.
+//   - Layout has >0 rooms / walls / elements / villager spawns / patrol /
+//     valid priest spawn.
+//   - At least 1 DPVillager_Behaviour script in the active scene.
+//   - Exactly 1 Priest_Behaviour script.
+//   - At least 1 DPPentagram_Behaviour + 1 DPForge_Behaviour.
+//   - At least 1 DPItemBase script (iron + objectives).
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kLoading, kVerify, kDone };
+
+	int g_iPhase = kLoading;
+	int g_iWaitFrames = 0;
+
+	bool g_bPassed = false;
+	const char* g_szFailureReason = "";
+
+	template<typename T>
+	int CountScripts()
+	{
+		int iCount = 0;
+		DP_Query::ForEachScriptInActiveScene<T>(
+			[&iCount](Zenith_EntityID, T&) { ++iCount; });
+		return iCount;
+	}
+}
+
+static void Setup_ProcLevelScene()
+{
+	g_iPhase = kLoading;
+	g_iWaitFrames = 0;
+	g_bPassed = false;
+	g_szFailureReason = "";
+
+	// Build index 6 is the authored ProcLevel scene (see
+	// DevilsPlayground.cpp::Project_LoadInitialScene).
+	Zenith_SceneManager::LoadSceneByIndex(6, SCENE_LOAD_SINGLE);
+}
+
+static bool Step_ProcLevelScene(int /*iFrame*/)
+{
+	switch (g_iPhase)
+	{
+	case kLoading:
+		// Give the scene swap + bootstrap OnAwake time to settle.
+		// The bootstrap spawns ~75 entities and the navmesh generator
+		// runs at the end -- 30 frames is generous but conservative.
+		if (++g_iWaitFrames < 30) return true;
+		g_iPhase = kVerify;
+		return true;
+
+	case kVerify:
+	{
+		DPProcLevelBootstrap_Behaviour* pxBootstrap =
+			DPProcLevelBootstrap_Behaviour::Instance();
+		if (pxBootstrap == nullptr)
+		{
+			g_szFailureReason = "Bootstrap singleton not set after scene load";
+			g_iPhase = kDone;
+			return false;
+		}
+
+		const DPProcLevel::LevelLayout& xLayout = pxBootstrap->GetLayout();
+		if (xLayout.axRooms.GetSize() == 0u
+		 || xLayout.axWallSegments.GetSize() == 0u
+		 || xLayout.axGameElements.GetSize() == 0u
+		 || xLayout.axVillagerSpawns.GetSize() == 0u
+		 || !xLayout.xPriestSpawn.bValid)
+		{
+			g_szFailureReason = "Layout missing expected procgen output";
+			g_iPhase = kDone;
+			return false;
+		}
+
+		// Wall + game-element + villager + priest counts (already
+		// covered by Test_ProcLevelBootstrap but verifying here too
+		// in case the scene-load path diverges).
+		if (pxBootstrap->GetSpawnedWallCount() != xLayout.axWallSegments.GetSize())
+		{
+			g_szFailureReason = "Wall entity count != layout WallSegment count";
+			g_iPhase = kDone;
+			return false;
+		}
+		if (pxBootstrap->GetSpawnedVillagerCount() != xLayout.axVillagerSpawns.GetSize())
+		{
+			g_szFailureReason = "Villager entity count != layout VillagerSpawn count";
+			g_iPhase = kDone;
+			return false;
+		}
+		if (!pxBootstrap->GetSpawnedPriest())
+		{
+			g_szFailureReason = "Priest entity not spawned";
+			g_iPhase = kDone;
+			return false;
+		}
+
+		// Cross-check the script-side query: the spawned entities have
+		// their behaviours actually attached + registered with the
+		// script component manager. Counting via DP_Query confirms the
+		// AddScript<T>(...) calls in the bootstrap actually produced
+		// queryable scripts (not just "entity exists with type name").
+		const int iVillagers = CountScripts<DPVillager_Behaviour>();
+		const int iPriests   = CountScripts<Priest_Behaviour>();
+		const int iItems     = CountScripts<DPItemBase_Behaviour>();
+		const int iPents     = CountScripts<DPPentagram_Behaviour>();
+		const int iForges    = CountScripts<DPForge_Behaviour>();
+		const int iDoors     = CountScripts<DPDoor_Behaviour>();
+
+		if (iVillagers < 1) { g_szFailureReason = "No villager scripts"; g_iPhase = kDone; return false; }
+		if (iPriests != 1)  { g_szFailureReason = "Priest script count != 1"; g_iPhase = kDone; return false; }
+		if (iItems < 1)     { g_szFailureReason = "No DPItemBase scripts"; g_iPhase = kDone; return false; }
+		if (iPents < 1)     { g_szFailureReason = "No pentagram script"; g_iPhase = kDone; return false; }
+		if (iForges < 1)    { g_szFailureReason = "No forge script"; g_iPhase = kDone; return false; }
+		// Doors are optional -- a level layout where the pentagram has
+		// only one incident corridor still places at least 1 door
+		// (door always on a gated corridor); current default seed has
+		// >= 1 door but we don't hard-require it here for forward-compat.
+		(void)iDoors;
+
+		std::printf("[ProcLevelScene] PASS: rooms=%u walls=%u elements=%u "
+			"villagers(spawned=%u, scripts=%d) priest(spawned=%d, scripts=%d) "
+			"items=%d pentagrams=%d forges=%d doors=%d\n",
+			xLayout.axRooms.GetSize(),
+			xLayout.axWallSegments.GetSize(),
+			xLayout.axGameElements.GetSize(),
+			pxBootstrap->GetSpawnedVillagerCount(), iVillagers,
+			(int)pxBootstrap->GetSpawnedPriest(), iPriests,
+			iItems, iPents, iForges, iDoors);
+		std::fflush(stdout);
+
+		g_bPassed = true;
+		g_iPhase = kDone;
+		return false;
+	}
+
+	case kDone:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_ProcLevelScene()
+{
+	if (!g_bPassed)
+	{
+		Zenith_Log(LOG_CATEGORY_CORE,
+			"Test_ProcLevelScene: %s", g_szFailureReason);
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xProcLevelSceneTest = {
+	"Test_ProcLevelScene",
+	&Setup_ProcLevelScene,
+	&Step_ProcLevelScene,
+	&Verify_ProcLevelScene,
+	120  // up to 120 frames -- scene load + bootstrap + verify
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xProcLevelSceneTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary
- DevilsPlayground.cpp now authors a 7th build-index scene **ProcLevel**. The .zscen file is intentionally lean (GameManager + PauseManager + GroundPlane + 4 corner lights + 1 ProcLevelBootstrap entity). Everything else materialises at runtime from the bootstrap's OnAwake.
- New Test_ProcLevelScene loads build-index 6, waits for the bootstrap + navmesh to settle, and asserts script-side counts cross-check the layout. The full procgen pipeline now has end-to-end coverage from a real scene load.
- DP suite: 125 → 126 (added Test_ProcLevelScene). Green.

## What runs at scene load
1. ProcLevel.zscen deserialised — recreates GameManager, PauseManager, GroundPlane, lights, ProcLevelBootstrap.
2. Bootstrap's OnAwake fires → `DPProcLevel::Generate(seed=0, defaults)`.
3. Bootstrap spawns 48 walls + 12 elements + 17 villagers + 1 priest.
4. Navmesh generator runs over the static scene (walls + ground plane = 1691 polygons).
5. Script-side queries report the expected counts.

Seed 0 verified:
```
[ProcLevelScene] PASS: rooms=8 walls=48 elements=13 villagers(spawned=17, scripts=17) priest(spawned=1, scripts=1) items=6 pentagrams=1 forges=1 doors=2
```

## Remaining
- **Demo**: run the personality-playthrough test against ProcLevel with a visible window so the bot is seen end-to-end. May need a personality test variant that defaults to scene 6.

## Test plan
- [x] Test_ProcLevelScene PASSES on the real scene-load path
- [x] Full DP suite (126 tests) green
- [ ] CI confirm (auto-merge on green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)