### PR TITLE
fix(dp): procgen characters still rotating + HUD stuck at 'He sees you'

### DIFF
--- a/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
@@ -66,6 +66,23 @@ public:
 		// before they themselves run.
 		s_pxInstance = this;
 
+		// Disable the test-only "omniscient" priest fallback that
+		// Priest_Behaviour::BridgePerceptionToBlackboard normally
+		// applies when ZENITH_INPUT_SIMULATOR is defined (which it
+		// is in every config of this codebase, including the
+		// vs2022_Release_Win64_False build the user plays the demo
+		// in). The fallback sets BB_KEY_TARGET_WITH_DEVIL to the
+		// possessed villager whenever no perception target qualifies,
+		// which makes the priest omniscient -- the HUD's
+		// AelfricState then sticks at Pursuing and the WhisperLine
+		// constantly says "He sees you!" even when the priest is
+		// blind on the far side of the level. User reported
+		// 2026-05-19. Disabling it routes pursuit through real
+		// sight-cone perception, which is the GDD intent and the
+		// production-build behaviour (production compiles the
+		// fallback out entirely).
+		DP_Player::SetTestOmniscientFallback(false);
+
 		// Seed source TODO (P4 later): read from Tuning.json + allow
 		// --procgen-seed CLI override. For now we hardcode m_uSeed
 		// (default 0) so the bootstrap is deterministic + the unit
@@ -646,11 +663,23 @@ private:
 		// braces against the DPVillager_Behaviour / Priest_Behaviour
 		// HasValidBody() check failing on the OnAwake immediately after
 		// AddScript fires.
+		//
+		// LockRotation differs from the GameLevel character pattern:
+		// GameLevel locks X+Z but leaves Y (yaw) free so character
+		// meshes can face their movement direction. For ProcLevel's
+		// SM_Cube placeholders, leaving Y free makes the cube SWING
+		// around its corner anchor every time the script updates yaw
+		// (the corner-offset compensation in this method's transform
+		// setup only holds for the SPAWN yaw -- runtime yaw changes
+		// reveal the offset). User reported "the priest and villagers
+		// are still rotating" on 2026-05-19; locking yaw too makes the
+		// cubes statically translate through the level which is the
+		// correct visual for placeholders.
 		if (xCol.HasValidBody())
 		{
 			const JPH::BodyID& xBodyID = xCol.GetBodyID();
 			Zenith_Physics::SetGravityEnabled(xBodyID, false);
-			Zenith_Physics::LockRotation(xBodyID, /*X=*/true, /*Y=*/false, /*Z=*/true);
+			Zenith_Physics::LockRotation(xBodyID, /*X=*/true, /*Y=*/true, /*Z=*/true);
 		}
 
 		if (bIsPriest)


### PR DESCRIPTION
## Symptoms
After PR #112 + #113 landed, user reported:
> "The priest and villagers are still rotating, and the HUD constantly says 'He sees you'"

## Two independent root causes

### 1. Cubes still rotating
PR #112's `LockRotation(X=true, Y=false, Z=true)` was correct for GameLevel character meshes (lets characters yaw to face their movement direction). For ProcLevel's `SM_Cube` placeholders it's wrong — the cube's mesh is corner-anchored, and `SpawnCharacterEntity`'s corner-offset compensation only holds for the SPAWN yaw. At runtime when the NavMeshAgent / possessed-villager logic updates yaw, the cube swings around its (0, 0, 0) corner instead of rotating in place.

**Fix**: lock all three rotation axes for cube placeholders. Tradeoff: characters can't face their movement direction — fine for placeholders.

The `DPVillager_Behaviour` / `Priest_Behaviour` `OnAwake` calls `LockRotation(X=true, Y=false, Z=true)` themselves, but `LockRotation` only *zeroes* inverse inertia (doesn't *restore* it), so the `Y=false` in the script's later call leaves my `Y=0` intact. No race.

### 2. HUD constantly says "He sees you"
`Priest_Behaviour::BridgePerceptionToBlackboard` has a `ZENITH_INPUT_SIMULATOR`-gated **omniscient fallback** — if no perception target qualifies, it sets `BB_KEY_TARGET_WITH_DEVIL` to the currently possessed villager via `DP_Player::GetPossessedVillager()`. The flag `g_bTestOmniscientFallback` defaults to `true` so pursuit tests pass without precise LOS setup.

`ZENITH_INPUT_SIMULATOR` is defined unconditionally in this codebase (`Zenith/Core/Zenith.h:190`), so the fallback compiles into every config including `vs2022_Release_Win64_False` — the priest is effectively omniscient while the user plays. AelfricState sticks at `Pursuing`, WhisperLine sticks at "He sees you!".

**Fix**: bootstrap calls `DP_Player::SetTestOmniscientFallback(false)` in `OnAwake`. ProcLevel uses real sight-cone perception (matches the GDD intent + production-build behaviour where the fallback is compiled out entirely). `DP_Player::ResetForNewRun` restores the flag between automated tests so GameLevel personality / pursuit tests keep working.

## Verification
600-frame run in `vs2022_Release_Win64_False` PASSED. User-observable changes:
- Cubes are stationary in rotation, only translating through the level
- HUD priest-awareness state is driven by actual sight cone (priest blind across walls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)