### PR TITLE
refactor(dp): remove omniscient-priest test fallback, use real perception

### DIFF
--- a/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
@@ -66,23 +66,6 @@ public:
 		// before they themselves run.
 		s_pxInstance = this;
 
-		// Disable the test-only "omniscient" priest fallback that
-		// Priest_Behaviour::BridgePerceptionToBlackboard normally
-		// applies when ZENITH_INPUT_SIMULATOR is defined (which it
-		// is in every config of this codebase, including the
-		// vs2022_Release_Win64_False build the user plays the demo
-		// in). The fallback sets BB_KEY_TARGET_WITH_DEVIL to the
-		// possessed villager whenever no perception target qualifies,
-		// which makes the priest omniscient -- the HUD's
-		// AelfricState then sticks at Pursuing and the WhisperLine
-		// constantly says "He sees you!" even when the priest is
-		// blind on the far side of the level. User reported
-		// 2026-05-19. Disabling it routes pursuit through real
-		// sight-cone perception, which is the GDD intent and the
-		// production-build behaviour (production compiles the
-		// fallback out entirely).
-		DP_Player::SetTestOmniscientFallback(false);
-
 		// Seed source TODO (P4 later): read from Tuning.json + allow
 		// --procgen-seed CLI override. For now we hardcode m_uSeed
 		// (default 0) so the bootstrap is deterministic + the unit

--- a/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
@@ -66,6 +66,23 @@ public:
 		// before they themselves run.
 		s_pxInstance = this;
 
+		// Disable the test-only "omniscient" priest fallback that
+		// Priest_Behaviour::BridgePerceptionToBlackboard normally
+		// applies when ZENITH_INPUT_SIMULATOR is defined (which it
+		// is in every config of this codebase, including the
+		// vs2022_Release_Win64_False build the user plays the demo
+		// in). The fallback sets BB_KEY_TARGET_WITH_DEVIL to the
+		// possessed villager whenever no perception target qualifies,
+		// which makes the priest omniscient -- the HUD's
+		// AelfricState then sticks at Pursuing and the WhisperLine
+		// constantly says "He sees you!" even when the priest is
+		// blind on the far side of the level. User reported
+		// 2026-05-19. Disabling it routes pursuit through real
+		// sight-cone perception, which is the GDD intent and the
+		// production-build behaviour (production compiles the
+		// fallback out entirely).
+		DP_Player::SetTestOmniscientFallback(false);
+
 		// Seed source TODO (P4 later): read from Tuning.json + allow
 		// --procgen-seed CLI override. For now we hardcode m_uSeed
 		// (default 0) so the bootstrap is deterministic + the unit
@@ -646,11 +663,23 @@ private:
 		// braces against the DPVillager_Behaviour / Priest_Behaviour
 		// HasValidBody() check failing on the OnAwake immediately after
 		// AddScript fires.
+		//
+		// LockRotation differs from the GameLevel character pattern:
+		// GameLevel locks X+Z but leaves Y (yaw) free so character
+		// meshes can face their movement direction. For ProcLevel's
+		// SM_Cube placeholders, leaving Y free makes the cube SWING
+		// around its corner anchor every time the script updates yaw
+		// (the corner-offset compensation in this method's transform
+		// setup only holds for the SPAWN yaw -- runtime yaw changes
+		// reveal the offset). User reported "the priest and villagers
+		// are still rotating" on 2026-05-19; locking yaw too makes the
+		// cubes statically translate through the level which is the
+		// correct visual for placeholders.
 		if (xCol.HasValidBody())
 		{
 			const JPH::BodyID& xBodyID = xCol.GetBodyID();
 			Zenith_Physics::SetGravityEnabled(xBodyID, false);
-			Zenith_Physics::LockRotation(xBodyID, /*X=*/true, /*Y=*/false, /*Z=*/true);
+			Zenith_Physics::LockRotation(xBodyID, /*X=*/true, /*Y=*/true, /*Z=*/true);
 		}
 
 		if (bIsPriest)

--- a/Games/DevilsPlayground/Components/Priest_Behaviour.h
+++ b/Games/DevilsPlayground/Components/Priest_Behaviour.h
@@ -357,31 +357,16 @@ private:
 				break;
 			}
 		}
-#ifdef ZENITH_INPUT_SIMULATOR
-		// MVP-1.9: the omniscient fallback is now opt-in via a test
-		// flag. Production builds (no ZENITH_INPUT_SIMULATOR) compile
-		// it out entirely -- the priest is sight-driven only, matching
-		// the GDD's intent. In test builds the flag defaults to true
-		// so existing pursuit/apprehend tests keep working without
-		// having to position priests with line-of-sight setup; the
-		// MVP-1.9 sight tests turn the flag off in their Setup to
-		// exercise the production-shape detection path.
-		if (!xTargetWithDevil.IsValid()
-			&& DP_Player::IsTestOmniscientFallbackEnabled())
-		{
-			// Fallback path -- DP_Player::GetPossessedVillager is the
-			// source of truth without needing perception. Matches the
-			// source UE BT_Priest's blackboard setter which uses the
-			// global possession pointer.
-			const Zenith_EntityID xPossessed = DP_Player::GetPossessedVillager();
-			if (xPossessed.IsValid()
-				&& IsPossessedVillager(xPossessed)
-				&& !IsBeggarVillager(xPossessed))
-			{
-				xTargetWithDevil = xPossessed;
-			}
-		}
-#endif
+		// MVP-1.9 cleanup (2026-05-19): the priest is sight-driven
+		// only. The historical "omniscient fallback" -- which wrote
+		// the possessed villager into BB_KEY_TARGET_WITH_DEVIL when
+		// perception found nothing -- was a test backdoor that leaked
+		// into every build because ZENITH_INPUT_SIMULATOR is defined
+		// unconditionally in this codebase. With it gone, tests that
+		// need the priest to acquire a target call
+		// Zenith_PerceptionSystem::RegisterTarget(villager, hostile)
+		// and position the villager inside the priest's sight cone --
+		// exercising the same code path production gameplay uses.
 		xBB.SetEntityID(DP_AI::BB_KEY_TARGET_WITH_DEVIL, xTargetWithDevil);
 
 		// EXT-6: typed sound accessor. Bridge the freshest hearing stimulus

--- a/Games/DevilsPlayground/Docs/Status.md
+++ b/Games/DevilsPlayground/Docs/Status.md
@@ -153,7 +153,7 @@ Public APIs new on `DP_Player`:
 - `TryVoluntaryPossessSwitch(EntityID) -> bool` — player-driven path (cooldown + range gates).
 - `TickPossessionCooldown(fDt)` / `GetPossessionCooldownRemaining()` — MVP-1.5.
 - `GetDemonScent(EntityID)` / `TickDemonScent(fDt)` / `WriteHighestScentToBlackboard()` — MVP-1.6.
-- `SetTestOmniscientFallback(bool)` / `IsTestOmniscientFallbackEnabled()` — MVP-1.9, test-only.
+- ~~`SetTestOmniscientFallback(bool)` / `IsTestOmniscientFallbackEnabled()`~~ — removed 2026-05-19. The omniscient fallback in `Priest_Behaviour::BridgePerceptionToBlackboard` was a test backdoor that leaked into every build (`ZENITH_INPUT_SIMULATOR` is defined unconditionally). Replaced by real perception: tests that need the priest to acquire a target now call `Zenith_PerceptionSystem::RegisterTarget(villager, /*hostile=*/true)` and teleport the villager into the priest's sight cone — same code path production uses.
 - `ResetForNewRun()` (PR #77) — clears every per-run state owner. Called by `DPPauseMenuController::HandleRestart/HandleQuit` AND the harness between-tests hook. Was named `ResetForTest`; renamed because the "ForTest" suffix was misleading after MVP-2.5.5 wired it into production. Backward-compat alias `ResetForTest()` retained under `ZENITH_INPUT_SIMULATOR`.
 
 New on `DP_AI`:

--- a/Games/DevilsPlayground/Source/PublicInterfaces.cpp
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.cpp
@@ -64,14 +64,6 @@ namespace
 	float           g_fChannelRemaining = 0.0f;
 	bool            g_bChannelActive    = false;
 
-#ifdef ZENITH_INPUT_SIMULATOR
-	// MVP-1.9: test-build omniscient fallback toggle. Default ON so
-	// pre-1.9 tests work without code changes. New sight-based tests
-	// set this false in Setup to verify the production-shape (no
-	// fallback) detection path.
-	bool g_bTestOmniscientFallback = true;
-#endif
-
 	// Resolves a villager handle to its world position. Returns false
 	// if the entity has no transform / no scene-data binding (e.g.,
 	// passed a stale handle after the villager was destroyed).
@@ -436,17 +428,6 @@ namespace DP_Player
 		return g_fPossessionCooldownRemaining;
 	}
 
-#ifdef ZENITH_INPUT_SIMULATOR
-	void SetTestOmniscientFallback(bool bEnabled)
-	{
-		g_bTestOmniscientFallback = bEnabled;
-	}
-	bool IsTestOmniscientFallbackEnabled()
-	{
-		return g_bTestOmniscientFallback;
-	}
-#endif
-
 	// 2026-05-17 scene-ownership refactor: all per-villager side
 	// tables (held item, demon scent) live on
 	// DPPlayerController_Behaviour::m_xHeldItems / m_xDemonScent so
@@ -562,12 +543,6 @@ namespace DP_Player
 		g_xChannelTarget    = INVALID_ENTITY_ID;
 		g_fChannelRemaining = 0.0f;
 		g_bChannelActive    = false;
-#ifdef ZENITH_INPUT_SIMULATOR
-		// Restore the omniscient fallback default so each batched
-		// test starts from a known state. MVP-1.9 sight tests
-		// re-disable it in their own Setup.
-		g_bTestOmniscientFallback = true;
-#endif
 	}
 }
 

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -266,24 +266,6 @@ namespace DP_Player
 	void            TickChannel(float fDt);
 	void            InterruptChannel();
 
-#ifdef ZENITH_INPUT_SIMULATOR
-	// MVP-1.9: opt-in test-only "omniscient fallback" toggle. Pre-1.9,
-	// `Priest_Behaviour::BridgePerceptionToBlackboard` unconditionally
-	// dropped back to `DP_Player::GetPossessedVillager` if no perceived
-	// target qualified, making the priest effectively omniscient. That
-	// behaviour stays in TEST builds by default (true) so existing
-	// pursuit/apprehend tests don't have to position priests with
-	// line-of-sight setup; new MVP-1.9 sight tests call
-	// `SetTestOmniscientFallback(false)` in Setup to disable it and
-	// verify the production-shaped sight-driven detection path.
-	//
-	// Production builds (no ZENITH_INPUT_SIMULATOR) don't compile the
-	// fallback at all -- the priest is sight-driven only, matching
-	// the GDD's intent.
-	void SetTestOmniscientFallback(bool bEnabled);
-	bool IsTestOmniscientFallbackEnabled();
-#endif
-
 	DP_ItemTag GetHeldItemTag(Zenith_EntityID xVillager);
 	Zenith_EntityID GetHeldItemEntity(Zenith_EntityID xVillager);
 	void SetHeldItem(Zenith_EntityID xVillager, Zenith_EntityID xItem);

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_OutOfRangeIgnored.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_OutOfRangeIgnored.cpp
@@ -12,6 +12,7 @@
 #include "Source/PublicInterfaces.h"
 #include "Components/Priest_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 
 #include <cmath>
 
@@ -161,13 +162,39 @@ static bool Step_P1ApprehendOutOfRange(int iFrame)
 	}
 
 	case kOR_Possess:
-		// Do NOT teleport the priest -- leave it at authored separation
-		// (~4.4m). The whole point of the test is that Apprehend stays
-		// quiet until the priest physically closes that gap via Pursue.
+	{
+		// MVP-1.9 cleanup: explicit LOS so the priest's sight cone
+		// catches the villager. RegisterTarget puts the villager into
+		// the priest's perception scan; teleport places it 4 m IN
+		// FRONT of the priest (authored priest yaw = 0, facing +Z).
+		// 4 m is outside apprehend_range (2 m) so the Apprehend BT
+		// branch must return FAILURE -- the original assertion of
+		// this test, preserved at a known-deterministic distance now
+		// that perception is no longer faked.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillager, /*hostile=*/true);
+		Zenith_Maths::Vector3 xPriestPos;
+		if (TryGetEntityPos(g_xPriest, xPriestPos))
+		{
+			Zenith_SceneData* pxScene =
+				Zenith_SceneManager::GetSceneDataForEntity(g_xVillager);
+			if (pxScene != nullptr)
+			{
+				Zenith_Entity xEnt = pxScene->TryGetEntity(g_xVillager);
+				if (xEnt.IsValid()
+				 && xEnt.HasComponent<Zenith_TransformComponent>())
+				{
+					xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(
+						Zenith_Maths::Vector3(
+							xPriestPos.x, xPriestPos.y, xPriestPos.z + 4.0f));
+					g_fInitialSeparation = 4.0f;
+				}
+			}
+		}
 		DP_Player::SetPossessedVillager(g_xVillager);
 		g_iRunFrames = 0;
 		g_iPhase = kOR_RunFrames;
 		return true;
+	}
 
 	case kOR_RunFrames:
 		++g_iRunFrames;

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_PriestCatchesPlayer.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_PriestCatchesPlayer.cpp
@@ -13,6 +13,7 @@
 #include "Components/Priest_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
 #include "Source/DP_Tuning.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 
 #include <cmath>
 
@@ -163,6 +164,13 @@ static bool Step_P1Apprehend(int iFrame)
 	}
 
 	case kAP_Possess:
+		// MVP-1.9 cleanup: register the villager so the priest's sight
+		// pass considers it. (Production DPVillager_Behaviour doesn't
+		// self-register today; the omniscient fallback obviated that.)
+		// Real perception now drives BB_KEY_TARGET_WITH_DEVIL once the
+		// priest teleports within sight range of the villager in the
+		// next phase.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillager, /*hostile=*/true);
 		DP_Player::SetPossessedVillager(g_xVillager);
 		g_iPhase = kAP_TeleportPriest;
 		return true;

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_PriestStandsStillDuringChannel.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_PriestStandsStillDuringChannel.cpp
@@ -12,6 +12,7 @@
 #include "Source/PublicInterfaces.h"
 #include "Components/Priest_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 
 #include <cmath>
 #include <cstdio>
@@ -214,6 +215,9 @@ static bool Step_P1ApprehendStill(int iFrame)
 	}
 
 	case kSS_Possess:
+		// MVP-1.9 cleanup: register the villager so the priest's
+		// sight pass considers it once teleported into range.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillager, /*hostile=*/true);
 		DP_Player::SetPossessedVillager(g_xVillager);
 		g_iPhase = kSS_TeleportPriest;
 		return true;

--- a/Games/DevilsPlayground/Tests/Test_P1Apprehend_SwitchBreaksChannel.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Apprehend_SwitchBreaksChannel.cpp
@@ -12,6 +12,7 @@
 #include "Source/PublicInterfaces.h"
 #include "Components/Priest_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 
 #include <cmath>
 
@@ -175,6 +176,14 @@ static bool Step_P1ApprehendSwitch(int iFrame)
 	}
 
 	case kSB_Possess:
+		// MVP-1.9 cleanup: register both villagers so the priest's
+		// sight pass considers either as a target. The test then
+		// teleports priest within range of villager A; after the
+		// switch to villager B the priest is far from B (~67 m, well
+		// out of sight) so perception drops the target -- the same
+		// invariant the test asserts via the channel-broken check.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillagerA, /*hostile=*/true);
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillagerB, /*hostile=*/true);
 		DP_Player::SetPossessedVillager(g_xVillagerA);
 		g_iPhase = kSB_TeleportPriest;
 		return true;

--- a/Games/DevilsPlayground/Tests/Test_P1Priest_DoesNotChasePossessedOutOfSight.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Priest_DoesNotChasePossessedOutOfSight.cpp
@@ -27,10 +27,7 @@
 //
 // Procedure:
 //   1. Load GameLevel.
-//   2. Call `DP_Player::SetTestOmniscientFallback(false)` to enter
-//      the production-shape detection path (no scan of
-//      DP_Player::GetPossessedVillager in the bridge).
-//   3. Find the priest. Possess the FARTHEST villager (~100 m away
+//   2. Find the priest. Possess the FARTHEST villager (~100 m away
 //      in stock GameLevel authoring -- well outside priest sight
 //      range, no LOS).
 //   4. Run a ~2 s window (~120 frames). In this window the priest
@@ -101,9 +98,6 @@ static void Setup_P1NoChaseOutOfSight()
 	g_iRunFrames = 0;
 	g_bMidWindowTargetInvalid = false;
 	g_xFinalBBTarget = INVALID_ENTITY_ID;
-	// Disable the test-build omniscient fallback so the bridge uses
-	// only real perception output -- the production-shape path.
-	DP_Player::SetTestOmniscientFallback(false);
 }
 
 static bool Step_P1NoChaseOutOfSight(int iFrame)
@@ -194,8 +188,6 @@ static bool Step_P1NoChaseOutOfSight(int iFrame)
 			"P1NoChaseOOS: midInvalid=%d finalTarget=(%u/%u)",
 			(int)g_bMidWindowTargetInvalid,
 			g_xFinalBBTarget.m_uIndex, g_xFinalBBTarget.m_uGeneration);
-		// Restore default for the next batched test.
-		DP_Player::SetTestOmniscientFallback(true);
 		g_iPhase = kNS_Done;
 		return false;
 

--- a/Games/DevilsPlayground/Tests/Test_P1Priest_PursuesAfterLineOfSight.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P1Priest_PursuesAfterLineOfSight.cpp
@@ -27,9 +27,8 @@
 //
 // Procedure:
 //   1. Load GameLevel.
-//   2. `SetTestOmniscientFallback(false)`.
-//   3. Find the priest. Pick a villager.
-//   4. Teleport the villager to a position 4 m IN FRONT of the priest
+//   2. Find the priest. Pick a villager.
+//   3. Teleport the villager to a position 4 m IN FRONT of the priest
 //      (priest's authored yaw=0 means facing +Z, so put the villager
 //      at priest_pos + (0, 0, +4)).
 //   5. Possess the villager.
@@ -100,7 +99,6 @@ static void Setup_P1PursuesAfterLOS()
 	g_iRunFrames = 0;
 	g_iFrameTargetFirstSeen = -1;
 	g_xTargetAtFirstSighting = INVALID_ENTITY_ID;
-	DP_Player::SetTestOmniscientFallback(false);
 }
 
 static bool Step_P1PursuesAfterLOS(int iFrame)
@@ -191,7 +189,6 @@ static bool Step_P1PursuesAfterLOS(int iFrame)
 			g_iFrameTargetFirstSeen,
 			g_xTargetAtFirstSighting.m_uIndex, g_xTargetAtFirstSighting.m_uGeneration,
 			g_xVillager.m_uIndex, g_xVillager.m_uGeneration);
-		DP_Player::SetTestOmniscientFallback(true);
 		g_iPhase = kLS_Done;
 		return false;
 

--- a/Games/DevilsPlayground/Tests/Test_P2Archetype_BeggarIgnoredByAelfric.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2Archetype_BeggarIgnoredByAelfric.cpp
@@ -11,6 +11,9 @@
 #include "Source/PublicInterfaces.h"
 #include "Components/Priest_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
+#include "Maths/Zenith_Maths.h"
 
 #include <cstdio>
 
@@ -36,10 +39,9 @@
 //      ApplyArchetype("Beggar"). This re-resolves life/speed AND
 //      stamps the m_strArchetypeId so the priest's filter can read
 //      it back.
-//   3. Enable the omniscient fallback (SetTestOmniscientFallback) so
-//      we don't have to position the priest with explicit line-of-
-//      sight. The fallback path goes through the same Beggar filter
-//      that the perception path does, so the assertion covers both.
+//   3. Register the Beggar villager + teleport it 4 m into the
+//      priest's facing direction so the priest's sight cone catches
+//      it through real perception.
 //   4. SetPossessedVillager(beggarId). System path; the priest's
 //      BridgePerceptionToBlackboard will fire on the next OnUpdate.
 //   5. Tick ~60 frames so the priest's perception bridge runs at
@@ -141,12 +143,34 @@ static bool Step_P2BeggarIgnored(int iFrame)
 	{
 		DPVillager_Behaviour* pxV = GetVillagerBehaviour(g_xBeggar);
 		if (pxV != nullptr) pxV->ApplyArchetype("Beggar");
-		// Enable the omniscient fallback so the priest sees the
-		// possession without needing physical line-of-sight (which
-		// would require positioning that's outside this test's scope).
-		// The fallback path runs through the SAME IsBeggarVillager
-		// filter, so the assertion still covers both perception paths.
-		DP_Player::SetTestOmniscientFallback(true);
+		// MVP-1.9 cleanup: real perception only. Register the Beggar
+		// villager as a hostile target + teleport it 4 m IN FRONT of
+		// the priest (authored priest yaw = 0, facing +Z) so the
+		// priest's sight cone catches it. Without the Beggar filter,
+		// this setup would make the priest target the villager; the
+		// test asserts that the IsBeggarVillager check in
+		// BridgePerceptionToBlackboard rejects it instead.
+		Zenith_PerceptionSystem::RegisterTarget(g_xBeggar, /*hostile=*/true);
+		Zenith_SceneData* pxPriestScene =
+			Zenith_SceneManager::GetSceneDataForEntity(g_xPriest);
+		Zenith_SceneData* pxVillagerScene =
+			Zenith_SceneManager::GetSceneDataForEntity(g_xBeggar);
+		if (pxPriestScene != nullptr && pxVillagerScene != nullptr)
+		{
+			Zenith_Entity xPriestEnt = pxPriestScene->TryGetEntity(g_xPriest);
+			Zenith_Entity xBeggarEnt  = pxVillagerScene->TryGetEntity(g_xBeggar);
+			if (xPriestEnt.IsValid() && xBeggarEnt.IsValid()
+			 && xPriestEnt.HasComponent<Zenith_TransformComponent>()
+			 && xBeggarEnt.HasComponent<Zenith_TransformComponent>())
+			{
+				Zenith_Maths::Vector3 xPriestPos;
+				xPriestEnt.GetComponent<Zenith_TransformComponent>()
+					.GetPosition(xPriestPos);
+				xBeggarEnt.GetComponent<Zenith_TransformComponent>()
+					.SetPosition(Zenith_Maths::Vector3(
+						xPriestPos.x, xPriestPos.y, xPriestPos.z + 4.0f));
+			}
+		}
 		g_iPhase = kBG_PossessBeggar;
 		return true;
 	}

--- a/Games/DevilsPlayground/Tests/Test_P2HUD_AelfricStateInRealScene.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2HUD_AelfricStateInRealScene.cpp
@@ -9,6 +9,9 @@
 #include "Components/DPHUDController_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
 #include "Components/Priest_Behaviour.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
+#include "Maths/Zenith_Maths.h"
 
 #include <cstdio>
 
@@ -30,11 +33,10 @@
 //     BB has neither TargetWithDevil nor HasInvestigatePos set.
 //
 //   PHASE B: possessed villager (priest's BB.TargetWithDevil set).
-//     Setup: SetTestOmniscientFallback(true) so the priest's
-//     BridgePerceptionToBlackboard fills TargetWithDevil from
-//     DP_Player::GetPossessedVillager without needing physical
-//     line-of-sight. Possess a villager. Tick a few frames so the
-//     priest's OnUpdate runs.
+//     Setup: register the villager + teleport it 4 m into the
+//     priest's facing direction so real sight-cone perception
+//     catches it. Possess. Tick until awareness gain crosses the
+//     detection threshold (kBRIDGE_TICKS frames).
 //     Expectation: ComputeAelfricState() == Pursuing.
 //
 // What this catches (vs the formatter unit test):
@@ -63,10 +65,12 @@ namespace
 	DPHUDController_Behaviour::AelfricState g_ePursuingSnapshot =
 		DPHUDController_Behaviour::AelfricState::Calm;       // sentinel
 
-	// 10 frames is enough for the priest's OnUpdate (which fires
-	// each frame regardless of BT throttle) to call
-	// BridgePerceptionToBlackboard at least once.
-	constexpr int kBRIDGE_TICKS = 10;
+	// Awareness gain rate ~2.0/s means the priest's awareness of a
+	// villager in its sight cone crosses any reasonable detection
+	// threshold within ~1 s. 90 frames at 60 Hz = 1.5 s -- comfortable
+	// margin so the test isn't flaky on slow CI even though the bridge
+	// itself runs every frame.
+	constexpr int kBRIDGE_TICKS = 90;
 
 	const char* StateName(DPHUDController_Behaviour::AelfricState e)
 	{
@@ -124,18 +128,43 @@ static bool Step_P2HUDAelfricRealScene(int iFrame)
 	}
 
 	case kAS_SnapshotCalm:
-		// Disable omniscient fallback so the priest's BB doesn't
-		// spuriously fill TargetWithDevil from a stale state.
-		DP_Player::SetTestOmniscientFallback(false);
-		// No possession yet -- priest's BB should be empty.
+		// MVP-1.9 cleanup: no possession yet + no LOS setup -- the
+		// priest's BB has nothing in TargetWithDevil so the
+		// classifier should report Calm.
 		g_eCalmSnapshot = DPHUDController_Behaviour::ComputeAelfricState();
 		g_iPhase = kAS_EnableOmni;
 		return true;
 
 	case kAS_EnableOmni:
-		DP_Player::SetTestOmniscientFallback(true);
+	{
+		// MVP-1.9 cleanup (omniscient fallback removed): use real
+		// perception instead. Register the villager + teleport it
+		// 4 m IN FRONT of the priest (authored priest yaw = 0,
+		// facing +Z) so the priest's sight cone catches it.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillager, /*hostile=*/true);
+		Zenith_SceneData* pxPriestScene =
+			Zenith_SceneManager::GetSceneDataForEntity(g_xPriest);
+		Zenith_SceneData* pxVillagerScene =
+			Zenith_SceneManager::GetSceneDataForEntity(g_xVillager);
+		if (pxPriestScene != nullptr && pxVillagerScene != nullptr)
+		{
+			Zenith_Entity xPriestEnt = pxPriestScene->TryGetEntity(g_xPriest);
+			Zenith_Entity xVillagerEnt = pxVillagerScene->TryGetEntity(g_xVillager);
+			if (xPriestEnt.IsValid() && xVillagerEnt.IsValid()
+			 && xPriestEnt.HasComponent<Zenith_TransformComponent>()
+			 && xVillagerEnt.HasComponent<Zenith_TransformComponent>())
+			{
+				Zenith_Maths::Vector3 xPriestPos;
+				xPriestEnt.GetComponent<Zenith_TransformComponent>()
+					.GetPosition(xPriestPos);
+				xVillagerEnt.GetComponent<Zenith_TransformComponent>()
+					.SetPosition(Zenith_Maths::Vector3(
+						xPriestPos.x, xPriestPos.y, xPriestPos.z + 4.0f));
+			}
+		}
 		g_iPhase = kAS_PossessVillager;
 		return true;
+	}
 
 	case kAS_PossessVillager:
 		DP_Player::SetPossessedVillager(g_xVillager);

--- a/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByApprehend.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P4Playthrough_LossByApprehend.cpp
@@ -15,6 +15,7 @@
 #include "Components/Priest_Behaviour.h"
 #include "Components/DPVillager_Behaviour.h"
 #include "Components/DPHUDController_Behaviour.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 
 #include <cmath>
 #include <cstdio>
@@ -206,6 +207,9 @@ static bool Step_P4LossApprehend(int iFrame)
 	}
 
 	case kLA_Possess:
+		// MVP-1.9 cleanup: register the villager so the priest's
+		// sight pass considers it once teleported into range.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillager, /*hostile=*/true);
 		DP_Player::SetPossessedVillager(g_xVillager);
 		g_iPhase = kLA_TeleportPriest;
 		return true;

--- a/Games/DevilsPlayground/Tests/Test_PriestPursuit.cpp
+++ b/Games/DevilsPlayground/Tests/Test_PriestPursuit.cpp
@@ -15,6 +15,7 @@
 #include "AI/Navigation/Zenith_NavMeshAgent.h"
 #include "AI/Navigation/Zenith_NavMesh.h"
 #include "AI/Navigation/Zenith_Pathfinding.h"
+#include "AI/Perception/Zenith_PerceptionSystem.h"
 
 // ============================================================================
 // PriestPursuit_Test (NavMesh + BT + perception bridge end-to-end)
@@ -63,6 +64,17 @@ namespace
 		if (!xEnt.IsValid()) return false;
 		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
 		xEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xOut);
+		return true;
+	}
+
+	bool TrySetEntityPos(Zenith_EntityID xId, const Zenith_Maths::Vector3& xPos)
+	{
+		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+		if (pxScene == nullptr) return false;
+		Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+		if (!xEnt.IsValid()) return false;
+		if (!xEnt.HasComponent<Zenith_TransformComponent>()) return false;
+		xEnt.GetComponent<Zenith_TransformComponent>().SetPosition(xPos);
 		return true;
 	}
 }
@@ -136,6 +148,23 @@ static bool Step_PriestPursuit(int iFrame)
 	}
 
 	case kPP_Possess:
+	{
+		// MVP-1.9 cleanup (omniscient fallback removed): the priest's
+		// BridgePerceptionToBlackboard now reads BB_KEY_TARGET_WITH_DEVIL
+		// from real perception only. Set up explicit LOS so the priest's
+		// sight cone catches this villager: register it as a hostile
+		// target + teleport it 6 m into the priest's facing direction
+		// (authored priest yaw = 0 → facing +Z). 6 m is inside priest
+		// sight_range_m and outside apprehend_range, so the pursue branch
+		// engages while the apprehend channel waits for the priest to
+		// close the gap.
+		Zenith_PerceptionSystem::RegisterTarget(g_xVillager, /*hostile=*/true);
+		Zenith_Maths::Vector3 xPriestPos;
+		if (TryGetEntityPos(g_xPriest, xPriestPos))
+		{
+			TrySetEntityPos(g_xVillager,
+				Zenith_Maths::Vector3(xPriestPos.x, xPriestPos.y, xPriestPos.z + 6.0f));
+		}
 		// Possess the chosen villager. The villager will then satisfy
 		// Priest_Behaviour::IsPossessedVillager(), and the priest's BB-bridge
 		// will write its EntityID into BB.TargetWithDevil — driving the
@@ -143,6 +172,7 @@ static bool Step_PriestPursuit(int iFrame)
 		DP_Player::SetPossessedVillager(g_xVillager);
 		g_iPPPhase = kPP_RecordInitial;
 		return true;
+	}
 
 	case kPP_RecordInitial:
 	{


### PR DESCRIPTION
## Why
User asked: *"Why are we faking anything at all?"*

The omniscient fallback in `Priest_Behaviour::BridgePerceptionToBlackboard` was a test backdoor that compiled into every build (`ZENITH_INPUT_SIMULATOR` is defined unconditionally in `Zenith/Core/Zenith.h`). When `g_bTestOmniscientFallback` was true (default) and no real perception target qualified, the bridge fell back to writing the currently-possessed villager directly into `BB_KEY_TARGET_WITH_DEVIL`. That made the priest see through walls / across the map by design — broke the procgen demo (HUD stuck at "He sees you") and meant pursuit tests were really testing "given a BB target, does the BT pursue" — downstream of the actual perception question.

## What's removed
- `Priest_Behaviour::BridgePerceptionToBlackboard`'s `ZENITH_INPUT_SIMULATOR`-gated fallback branch (~25 lines)
- `DP_Player::SetTestOmniscientFallback` / `IsTestOmniscientFallbackEnabled` in `PublicInterfaces.{h,cpp}`
- `g_bTestOmniscientFallback` global + its `ResetForNewRun` reset
- The redundant `SetTestOmniscientFallback(false)` call I added in PR #114 to the procgen bootstrap

## Test migration
Tests that needed the priest to acquire a target now set up **real perception** through the same code path production uses:

```cpp
Zenith_PerceptionSystem::RegisterTarget(villager, /*hostile=*/true);
// Teleport villager to priest_pos + (0, 0, distance) -- priest faces +Z
// Possess + wait ~60 frames for awareness gain to cross detection threshold
```

| Test | Change |
|---|---|
| `Test_PriestPursuit` | + RegisterTarget + teleport to 6m in front of priest |
| `Test_P1Apprehend_PriestCatchesPlayer` | + RegisterTarget (priest already teleports within range) |
| `Test_P1Apprehend_OutOfRangeIgnored` | + RegisterTarget + teleport villager to 4m in front (>apprehend_range) |
| `Test_P1Apprehend_PriestStandsStillDuringChannel` | + RegisterTarget |
| `Test_P1Apprehend_SwitchBreaksChannel` | + RegisterTarget for both villagers |
| `Test_P2Archetype_BeggarIgnoredByAelfric` | + RegisterTarget + LOS teleport |
| `Test_P2HUD_AelfricStateInRealScene` | + RegisterTarget + LOS teleport for Pursuing snapshot; `kBRIDGE_TICKS` 10 → 90 |
| `Test_P4Playthrough_LossByApprehend` | + RegisterTarget |
| `Test_P1Priest_DoesNotChasePossessedOutOfSight` / `PursuesAfterLineOfSight` | Removed the now-noop `SetTestOmniscientFallback` calls |

## Net effect
- **+49 lines** (mostly LOS-setup comments + `RegisterTarget` calls)
- Fallback branch + flag + accessors are **gone**
- Tests now exercise the same perception code path as the procgen demo + any future production build
- ProcLevel demo's HUD shows actual sight-cone state, not "He sees you" stuck

## Verification
Full DP suite **127/127 green** including 5 PersonalityPlaythrough variants, ProcLevelDemo, every priest/apprehend/archetype/HUD test.

Docs/Status.md updated to note the removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)