### PR TITLE
chore(dp): drop dead PFX_Witch surface + rename navmesh perf test

### DIFF
--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -89,9 +89,6 @@ namespace DevilsPlayground
 		// Assets/Materials/*.json. Idempotent — safe across Editor Stop/Play.
 		DPMaterials::Initialize();
 
-		// B6 fog: register PFX_Witch particle config for runtime instantiation.
-		DPFogPass::RegisterParticleConfigs();
-
 #ifdef ZENITH_INPUT_SIMULATOR
 		// Tell the automated-test harness how to wipe DP-specific persistent
 		// globals between batched tests. The harness force-loads scene 0
@@ -120,9 +117,6 @@ namespace DevilsPlayground
 		DP_Player::SetPossessedVillager(INVALID_ENTITY_ID);
 		DP_AI::ResetLevelNavMesh();
 		DPMaterials::Shutdown();
-
-		// B6 fog: drop the PFX_Witch config so a relaunch doesn't double-register.
-		DPFogPass::UnregisterParticleConfigs();
 
 		// Drop the archetype cache before tuning -- archetypes don't depend on
 		// tuning, but keep teardown order paired so future cross-deps are

--- a/Games/DevilsPlayground/Source/DPFogPass.cpp
+++ b/Games/DevilsPlayground/Source/DPFogPass.cpp
@@ -10,7 +10,6 @@
 #include "Flux/HDR/Flux_HDR.h"
 #include "Flux/RenderGraph/Flux_RenderGraph.h"
 #include "Flux/Slang/Flux_ShaderBinder.h"
-#include "Flux/Particles/Flux_ParticleEmitterConfig.h"
 
 #ifdef ZENITH_TOOLS
 #include "Flux/Slang/Flux_ShaderHotReload.h"
@@ -235,80 +234,4 @@ namespace
 
 		pxCommandList->AddCommand<Flux_CommandDrawIndexed>(6);
 	}
-}
-
-// =====================================================================
-// Particle config registration
-//
-// Called from DevilsPlayground::InitializeResources via the project's
-// Project_RegisterScriptBehaviours hook. Registers the PFX_Witch
-// emitter config for runtime instantiation by ParticleEmitterComponent
-// or scripted spawners. Pattern mirrors Combat::g_pxHitSparkConfig
-// (Combat.cpp:648-664).
-// =====================================================================
-namespace
-{
-	Flux_ParticleEmitterConfig* g_pxWitchConfig = nullptr;
-}
-
-namespace DPFogPass
-{
-	void RegisterParticleConfigs()
-	{
-		if (g_pxWitchConfig != nullptr) return; // idempotent
-
-		g_pxWitchConfig = new Flux_ParticleEmitterConfig();
-		g_pxWitchConfig->m_fSpawnRate            = 15.0f;
-		g_pxWitchConfig->m_uBurstCount           = 0;
-		g_pxWitchConfig->m_uMaxParticles         = 30;
-		g_pxWitchConfig->m_fSpawnRadius          = 0.1f;
-		g_pxWitchConfig->m_fLifetimeMin          = 1.5f;
-		g_pxWitchConfig->m_fLifetimeMax          = 2.0f;
-		g_pxWitchConfig->m_fSpeedMin             = 0.4f;
-		g_pxWitchConfig->m_fSpeedMax             = 0.9f;
-		g_pxWitchConfig->m_fSpreadAngleDegrees   = 18.0f;
-		g_pxWitchConfig->m_xEmitDirection        = Zenith_Maths::Vector3(0.0f, 1.0f, 0.0f);
-		g_pxWitchConfig->m_xGravity              = Zenith_Maths::Vector3(0.0f, 0.6f, 0.0f); // light updraft
-		g_pxWitchConfig->m_fDrag                 = 0.5f;
-		g_pxWitchConfig->m_xColorStart           = Zenith_Maths::Vector4(0.6f, 0.2f, 0.8f, 0.9f); // witch purple
-		g_pxWitchConfig->m_xColorEnd             = Zenith_Maths::Vector4(0.2f, 0.0f, 0.4f, 0.0f);
-		g_pxWitchConfig->m_fSizeStart            = 0.20f;
-		g_pxWitchConfig->m_fSizeEnd              = 0.04f;
-		g_pxWitchConfig->m_bAdditiveBlending     = true;
-		g_pxWitchConfig->m_fTurbulence           = 0.8f;
-		g_pxWitchConfig->m_bUseGPUCompute        = false;
-		Flux_ParticleEmitterConfig::Register("PFX_Witch", g_pxWitchConfig);
-	}
-
-	void UnregisterParticleConfigs()
-	{
-		if (g_pxWitchConfig == nullptr) return;
-		Flux_ParticleEmitterConfig::Unregister("PFX_Witch");
-		delete g_pxWitchConfig;
-		g_pxWitchConfig = nullptr;
-	}
-}
-
-// =====================================================================
-// Scene-authoring hook for the VisualWiring agent.
-//
-// VisualWiring owns Project_RegisterEditorAutomationSteps so we don't
-// touch it from this TU. Instead we expose a stand-alone function the
-// VisualWiring agent calls from the GameLevel scene-author block. The
-// witch position is taken from the L_GameLevel.json NiagaraActor_2:
-//   UE loc (cm)  = (8582.63, 2575.46, 200.00)
-//   Engine (m)   ≈ (85.83,    25.75,    2.00)  (UE: X-fwd, Y-right, Z-up
-//                                               -> Zenith: X, Y=Z, Z=Y)
-// We also register the PFX_Witch fog hole on the same entity so the
-// witch silhouette is visible through the fog at gameplay distance.
-// =====================================================================
-namespace DPFogPass
-{
-	// PFX_Witch spawn position (Zenith X-Y-Z metres). Originally
-	// imported from the UE map's Niagara[0] placement; values kept
-	// inline so the fog-hole infrastructure is decoupled from any
-	// per-scene level-data table.
-	float GetWitchSpawnX() { return 85.8263f; }
-	float GetWitchSpawnY() { return 2.0000f;  }
-	float GetWitchSpawnZ() { return 25.7546f; }
 }

--- a/Games/DevilsPlayground/Source/DPFogPass.h
+++ b/Games/DevilsPlayground/Source/DPFogPass.h
@@ -17,18 +17,4 @@ namespace DPFogPass
 {
 	void Init();
 	void Shutdown();
-
-	// Particle config registration (PFX_Witch). Called from
-	// DevilsPlayground::InitializeResources alongside other CPU-only
-	// resource setup. Idempotent.
-	void RegisterParticleConfigs();
-	void UnregisterParticleConfigs();
-
-	// Witch fog-hole spawn position (Zenith metres). Originally imported
-	// from the UE map's NiagaraActor placement; values are kept inline
-	// in DPFogPass.cpp so scene authoring can place a PFX_Witch emitter
-	// without depending on per-scene level-data tables.
-	float GetWitchSpawnX();
-	float GetWitchSpawnY();
-	float GetWitchSpawnZ();
 }

--- a/Games/DevilsPlayground/Tests/Test_DPFogPass.cpp
+++ b/Games/DevilsPlayground/Tests/Test_DPFogPass.cpp
@@ -4,13 +4,11 @@
 
 #include "Core/Zenith_AutomatedTest.h"
 #include "Source/PublicInterfaces.h"
-#include "Flux/Particles/Flux_ParticleEmitterConfig.h"
 
 // ============================================================================
 // DPFogPass_Test — verifies the DP_Fog game-side render pass boots cleanly,
 // the per-frame CBV upload survives a few frames without Vulkan validation
-// errors, the simulated origin fog hole reaches the CBV gather hook, and the
-// PFX_Witch particle emitter config is registered.
+// errors, and the simulated origin fog hole reaches the CBV gather hook.
 //
 // Structurally a Hello_Test sibling — full screenshot regression is EXT-3b
 // polish work outside the scope of this skeleton-grade pass.
@@ -19,17 +17,11 @@
 static int  g_iSetupCalls           = 0;
 static int  g_iStepCalls            = 0;
 static int  g_iVerifyCalls          = 0;
-static bool g_bWitchConfigSeen      = false;
 static bool g_bFogHoleGatheredOK    = false;
 
 static void Setup_DPFogPass()
 {
 	++g_iSetupCalls;
-
-	// PFX_Witch must be registered by Project_RegisterScriptBehaviours →
-	// DevilsPlayground::InitializeResources → DPFogPass::RegisterParticleConfigs
-	// before the harness reaches Setup.
-	g_bWitchConfigSeen = (Flux_ParticleEmitterConfig::Find("PFX_Witch") != nullptr);
 
 	// Inject a synthetic fog hole so we can verify the gather hook regardless
 	// of whether DPFogPass_Behaviour has run yet on the current scene.
@@ -59,7 +51,6 @@ static bool Verify_DPFogPass()
 	return g_iSetupCalls == 1
 	    && g_iStepCalls  >= 8
 	    && g_iVerifyCalls == 1
-	    && g_bWitchConfigSeen
 	    && g_bFogHoleGatheredOK;
 }
 

--- a/Games/DevilsPlayground/Tests/Test_T1NavMesh_GeneratorPerf.cpp
+++ b/Games/DevilsPlayground/Tests/Test_T1NavMesh_GeneratorPerf.cpp
@@ -15,11 +15,12 @@
 #include <cmath>
 
 // ============================================================================
-// Test_T1NavMesh_GeneratorPerfOnGameLevel (diagnostic)
+// Test_T1NavMesh_GeneratorPerfOnProcLevel (diagnostic)
 //
-// Loads GameLevel, scans every static collider for its world-space AABB,
-// then calls Zenith_NavMeshGenerator::GenerateFromScene under the
-// profiling system and dumps a per-stage report.
+// Loads the ProcLevel scene (build index 1, the only gameplay scene since
+// 2026-05-19), scans every static collider for its world-space AABB, then
+// calls Zenith_NavMeshGenerator::GenerateFromScene under the profiling
+// system and dumps a per-stage report.
 //
 // Surfaces:
 //   * The outlier collider(s) stretching the navmesh bounding box.
@@ -138,7 +139,7 @@ static bool Step_T1NavMeshGeneratorPerf(int iFrame)
 		const std::chrono::duration<float, std::milli> xMs = xEnd - xStart;
 		const uint32_t uPolyCount = (pxNavMesh != nullptr) ? pxNavMesh->GetPolygonCount() : 0;
 
-		std::printf("[T1NavMeshPerf] GenerateFromScene on GameLevel: %.2f ms, %u polygons\n",
+		std::printf("[T1NavMeshPerf] GenerateFromScene on ProcLevel: %.2f ms, %u polygons\n",
 			xMs.count(), uPolyCount);
 		std::printf("[T1NavMeshPerf] ---- profiling report ----\n");
 		std::fflush(stdout);
@@ -164,7 +165,7 @@ static bool Verify_T1NavMeshGeneratorPerf()
 }
 
 static const Zenith_AutomatedTest g_xT1NavMeshGeneratorPerfTest = {
-	"Test_T1NavMesh_GeneratorPerfOnGameLevel",
+	"Test_T1NavMesh_GeneratorPerfOnProcLevel",
 	&Setup_T1NavMeshGeneratorPerf,
 	&Step_T1NavMeshGeneratorPerf,
 	&Verify_T1NavMeshGeneratorPerf,


### PR DESCRIPTION
## Summary

Follow-up to #117. The previous PR description flagged two leftover GameLevel-era surfaces; this PR cleans both up.

### 1. PFX_Witch + GetWitchSpawn{X,Y,Z}

The witch silhouette was a UE-imported Niagara placement that only existed in GameLevel. With GameLevel gone, nothing instantiates a witch entity, so the supporting infrastructure is dead. Removed:

- ~50-line `g_pxWitchConfig` setup in `Source/DPFogPass.cpp`
- `DPFogPass::RegisterParticleConfigs` / `UnregisterParticleConfigs` functions + their declarations in `DPFogPass.h`
- `DPFogPass::GetWitchSpawnX/Y/Z` static-coord getters
- `#include "Flux/Particles/Flux_ParticleEmitterConfig.h"` in DPFogPass.cpp
- `DPFogPass::RegisterParticleConfigs()` / `UnregisterParticleConfigs()` calls in `DevilsPlayground::InitializeResources` / `CleanupResources`
- The `g_bWitchConfigSeen` check inside `Test_DPFogPass`

The gather-hook half of Test_DPFogPass survives untouched — that exercises the general DP_Fog fog-hole-CBV pipeline, not anything witch-specific.

### 2. Test rename

`Test_T1NavMesh_GeneratorPerf.cpp` registered itself with the id `Test_T1NavMesh_GeneratorPerfOnGameLevel` even though it now loads ProcLevel (scene 1 is procgen since #117). Renamed:

- Test id string: `Test_T1NavMesh_GeneratorPerfOnGameLevel` → `Test_T1NavMesh_GeneratorPerfOnProcLevel`
- File header comment + printf banner updated to match
- `.cpp` filename keeps the generic `GeneratorPerf` stem

## Verification

- Full DP suite green: **119 / 119** in `vs2022_Debug_Win64_True` (`Tools/run_dp_tests.ps1 -Headless`).
- `vs2022_Debug_Win64_False` + `vs2022_Release_Win64_False` build clean.
- `grep -rn "PFX_Witch\|GetWitchSpawn\|\bWitch\b" Games/DevilsPlayground/` returns no matches.

Diff stat: **5 files changed, 8 insertions(+), 113 deletions(-)**.

## Test plan

- [x] `Tools/run_dp_tests.ps1 -Headless` green in `vs2022_Debug_Win64_True`
- [x] Both False configs build clean
- [x] No remaining witch references in DP source
- [x] `Test_T1NavMesh_GeneratorPerfOnProcLevel` appears in test output (was `OnGameLevel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)