### PR TITLE
feat(dp): DP_PROCGEN_SEED env var + seed-matrix tooling

### DIFF
--- a/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPProcLevelBootstrap_Behaviour.h
@@ -48,6 +48,7 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 
 class DPProcLevelBootstrap_Behaviour ZENITH_FINAL : Zenith_ScriptBehaviour
@@ -66,10 +67,32 @@ public:
 		// before they themselves run.
 		s_pxInstance = this;
 
-		// Seed source TODO (P4 later): read from Tuning.json + allow
-		// --procgen-seed CLI override. For now we hardcode m_uSeed
-		// (default 0) so the bootstrap is deterministic + the unit
-		// test has a predictable layout to assert against.
+		// Seed source: env var DP_PROCGEN_SEED (decimal uint64) when
+		// present and non-empty; otherwise the m_uSeed value baked in
+		// at construction (default 0) so the bootstrap stays
+		// deterministic for the unit tests. Test_ProcLevelBootstrap +
+		// Test_ProcLevelScene still drive m_uSeed directly via
+		// SetSeedForTest before OnAwake fires, so they're unaffected
+		// by whatever the env var says.
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable: 4996)  // std::getenv "may be unsafe"
+#endif
+		if (const char* szEnv = std::getenv("DP_PROCGEN_SEED"))
+		{
+			if (szEnv[0] != '\0')
+			{
+				char* pszEnd = nullptr;
+				const unsigned long long uParsed = std::strtoull(szEnv, &pszEnd, 10);
+				if (pszEnd != szEnv)
+				{
+					m_uSeed = static_cast<uint64_t>(uParsed);
+				}
+			}
+		}
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 		DPProcLevel::GenConfig xConfig;  // defaults from header
 		// Override the wall half-thickness so total thickness (2*half =
 		// 0.8 m) exceeds the navmesh voxelizer's cell width (~0.36 m

--- a/Tools/dp_seed_matrix_analyse.py
+++ b/Tools/dp_seed_matrix_analyse.py
@@ -1,0 +1,391 @@
+"""dp_seed_matrix_analyse.py -- extract insights from a seed-matrix run.
+
+Reads the per-(seed, personality) .telemetry.json files produced by
+Tools/dp_seed_matrix_run.ps1 and emits a Markdown report covering:
+
+  * Procgen layout summary per seed (wall / room / obstacle counts).
+  * Per-(seed, personality) headline metrics.
+  * Event-type breakdown grouped by personality.
+  * New v3 telemetry insights:
+      - Held-item time fraction
+      - Life-timer at first death (per personality, per seed)
+      - Priest BT-intent distribution
+      - Perception contact counts
+      - Apprehend channel lifecycle stats
+      - Pause-toggle events
+  * Cross-seed insights (variance across procgen layouts).
+
+Usage:
+    python Tools/dp_seed_matrix_analyse.py [--root Build/dp_telemetry/seed_matrix]
+                                            [--out  Build/dp_telemetry/seed_matrix/REPORT.md]
+
+ASCII-only. Standard library only (json + pathlib + argparse).
+"""
+
+import argparse
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+
+PERSONALITIES = ["Casual", "Stealth", "Speedrunner", "Berserker", "Methodical"]
+
+# DP_ItemTag enum -> name (DPTelemetry::EntitySnapshot.uHeldItemTag uses
+# DP_ItemTag values; the canonical mapping is in DevilsPlayground_Tags.h).
+ITEM_TAGS = {
+    0: "None",
+    1: "Iron",
+    2: "Key",
+    3: "Objective1",
+    4: "Objective2",
+    5: "Objective3",
+    6: "Objective4",
+    7: "Objective5",
+    8: "SkeletonKey",
+    9: "Spike",
+}
+
+# DPTelemetry::PriestIntent -> name.
+PRIEST_INTENTS = {
+    0: "None",
+    1: "Idle",
+    2: "Patrol",
+    3: "Investigate",
+    4: "Pursue",
+    5: "Apprehend",
+}
+
+# DP_ApprehendInterruptReason -> name (PublicInterfaces.h).
+APPREHEND_REASONS = {
+    0: "Unknown",
+    1: "TargetSwitched",
+    2: "TargetLost",
+    3: "OutOfRange",
+    4: "PriestDespawned",
+}
+
+# StateFlags::IsPriest bit (DPTelemetry::StateFlags::IsPriest = 1u << 7).
+FLAG_IS_PRIEST = 1 << 7
+
+
+def load_run(path: Path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def analyse_run(tlm: dict) -> dict:
+    """Compute per-run stats from a single telemetry JSON."""
+    hdr = tlm.get("header", {})
+    frames = tlm.get("frames", [])
+    events = tlm.get("events", [])
+
+    res = {
+        "scene": hdr.get("sceneName", ""),
+        "seed": hdr.get("seed", 0),
+        "personality": hdr.get("personalityName", ""),
+        "build": hdr.get("buildConfig", ""),
+        "frames": len(frames),
+        "events": len(events),
+        "obstacleCount": len(hdr.get("obstacles", [])),
+    }
+
+    # Event-type histogram.
+    type_counts = Counter()
+    for e in events:
+        name = e.get("name") or "type_%d" % e.get("type", -1)
+        type_counts[name] += 1
+    res["eventCounts"] = dict(type_counts)
+
+    # Apprehend channel lifecycle pairing.
+    n_start  = type_counts.get("ApprehendChannelStart", 0)
+    n_done   = type_counts.get("ApprehendChannelComplete", 0)
+    n_intr   = type_counts.get("ApprehendChannelInterrupted", 0)
+    res["apprehendStart"]       = n_start
+    res["apprehendComplete"]    = n_done
+    res["apprehendInterrupted"] = n_intr
+
+    # Interrupt reason breakdown.
+    reason_counts = Counter()
+    for e in events:
+        if e.get("name") == "ApprehendChannelInterrupted":
+            r = e.get("payload", {}).get("ints", [0,0,0,0])[0]
+            reason_counts[APPREHEND_REASONS.get(r, str(r))] += 1
+    res["interruptReasons"] = dict(reason_counts)
+
+    # Perception contact counts.
+    res["perceptionBegin"] = type_counts.get("PerceptionContactBegin", 0)
+    res["perceptionEnd"]   = type_counts.get("PerceptionContactEnd", 0)
+
+    # Pause toggles -- count + total paused frames.
+    pause_events = sorted(
+        [e for e in events if e.get("name") == "PauseToggle"],
+        key=lambda e: e.get("frame", 0))
+    paused_frames = 0
+    pausing_at = None
+    for pe in pause_events:
+        pausing = bool(pe.get("payload", {}).get("ints", [0])[0])
+        if pausing and pausing_at is None:
+            pausing_at = pe.get("frame", 0)
+        elif (not pausing) and pausing_at is not None:
+            paused_frames += pe.get("frame", 0) - pausing_at
+            pausing_at = None
+    res["pauseToggleEvents"]  = len(pause_events)
+    res["pausedFramesTotal"]  = paused_frames
+
+    # Per-frame analyses.
+    held_item_distribution    = Counter()
+    held_item_frames_possessed = 0
+    total_possessed_frames     = 0
+    priest_intent_counts       = Counter()
+    villager_life_at_death     = []
+    last_alive_life_per_villager = {}  # entity_idx -> last positive life
+
+    for frame in frames:
+        for ent in frame.get("entities", []):
+            flags = int(ent.get("flags", 0))
+            is_priest = bool(flags & FLAG_IS_PRIEST)
+            is_possessed = bool(flags & 1)  # StateFlags::Possessed = 1<<0
+            is_alive     = bool(flags & 8)  # StateFlags::Alive     = 1<<3
+
+            if is_priest:
+                intent = int(ent.get("aiIntent", 0))
+                priest_intent_counts[PRIEST_INTENTS.get(intent, str(intent))] += 1
+                continue
+
+            # Villager bookkeeping.
+            ent_idx = ent.get("id", {}).get("idx", -1)
+            life    = float(ent.get("life", 0.0))
+
+            if is_possessed:
+                total_possessed_frames += 1
+                tag = int(ent.get("heldItem", 0))
+                if tag != 0:
+                    held_item_frames_possessed += 1
+                    held_item_distribution[ITEM_TAGS.get(tag, str(tag))] += 1
+
+            # Detect death: previous life > 0, this life == 0.
+            prev = last_alive_life_per_villager.get(ent_idx, None)
+            if prev is not None and prev > 0.5 and life < 0.01:
+                villager_life_at_death.append(prev)
+            last_alive_life_per_villager[ent_idx] = life
+
+    res["priestIntentFrames"] = dict(priest_intent_counts)
+    res["heldItemFractionWhilePossessed"] = (
+        held_item_frames_possessed / total_possessed_frames
+        if total_possessed_frames > 0 else 0.0)
+    res["heldItemDistributionWhilePossessed"] = dict(held_item_distribution)
+    res["possessedFrames"] = total_possessed_frames
+    res["villagerDeathLives"] = villager_life_at_death
+
+    # Frame perf (avg ms / sample).
+    frame_ms = [float(f.get("frameMs", 0.0)) for f in frames if float(f.get("frameMs", 0.0)) > 0.0]
+    if frame_ms:
+        res["frameMsAvg"]    = statistics.mean(frame_ms)
+        res["frameMsMedian"] = statistics.median(frame_ms)
+        res["frameMsMax"]    = max(frame_ms)
+    else:
+        res["frameMsAvg"] = res["frameMsMedian"] = res["frameMsMax"] = 0.0
+
+    return res
+
+
+def summarise_event_breakdown(stats_by_personality_by_seed):
+    """Aggregate per-personality event totals across all seeds."""
+    out = {}
+    for p in PERSONALITIES:
+        all_evt = Counter()
+        for seed_stats in stats_by_personality_by_seed.get(p, {}).values():
+            for k, v in seed_stats["eventCounts"].items():
+                all_evt[k] += v
+        out[p] = dict(all_evt)
+    return out
+
+
+def render_md(stats_table, seeds, out_path: Path):
+    lines = []
+    lines.append("# Personality x Procgen-Seed insights")
+    lines.append("")
+    lines.append("Generated by `Tools/dp_seed_matrix_analyse.py`.")
+    lines.append("")
+    lines.append("Source data: `Tools/dp_seed_matrix_run.ps1` ran 5 personalities x %d seeds = %d cells in `vs2022_Debug_Win64_False`."
+                 % (len(seeds), 5 * len(seeds)))
+    lines.append("Seeds tested: " + ", ".join(str(s) for s in seeds))
+    lines.append("")
+
+    # ---- Procgen variation table (per-seed obstacle counts).
+    lines.append("## Procgen layout variation by seed")
+    lines.append("")
+    lines.append("| Seed | Obstacle count (any personality) |")
+    lines.append("|---:|---:|")
+    for s in seeds:
+        any_p = next(iter(stats_table[s].values()))
+        lines.append("| %d | %d |" % (s, any_p["obstacleCount"]))
+    lines.append("")
+
+    # ---- Headline matrix.
+    lines.append("## Headline matrix (frames / events / pause-frames / apprehend)")
+    lines.append("")
+    lines.append("| Seed | Personality | Frames | Events | Possessed frames | Held-item %% | Pause events | Apprehend start/done/intr |")
+    lines.append("|---:|---|---:|---:|---:|---:|---:|---:|")
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None:
+                lines.append("| %d | %s | -- | -- | -- | -- | -- | -- |" % (s, p))
+                continue
+            lines.append("| %d | %s | %d | %d | %d | %.1f%% | %d | %d/%d/%d |" % (
+                s, p, r["frames"], r["events"], r["possessedFrames"],
+                100.0 * r["heldItemFractionWhilePossessed"],
+                r["pauseToggleEvents"],
+                r["apprehendStart"], r["apprehendComplete"], r["apprehendInterrupted"],
+            ))
+    lines.append("")
+
+    # ---- Priest intent distribution.
+    lines.append("## Priest BT-intent distribution (priest frames only)")
+    lines.append("")
+    lines.append("Fraction of priest-sampled frames spent in each BT branch. Idle ~= no intent yet, Patrol ~= roaming, Investigate ~= chasing a noise, Pursue ~= moving toward the possessed villager, Apprehend ~= channeling the catch.")
+    lines.append("")
+    lines.append("| Seed | Personality | Idle | Patrol | Investigate | Pursue | Apprehend |")
+    lines.append("|---:|---|---:|---:|---:|---:|---:|")
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None:
+                continue
+            d = r["priestIntentFrames"]
+            total = sum(d.values()) or 1
+            pct = lambda k: 100.0 * d.get(k, 0) / total
+            lines.append("| %d | %s | %.0f%% | %.0f%% | %.0f%% | %.0f%% | %.0f%% |"
+                % (s, p, pct("Idle"), pct("Patrol"), pct("Investigate"), pct("Pursue"), pct("Apprehend")))
+    lines.append("")
+
+    # ---- Perception contacts.
+    lines.append("## Perception contacts (begin/end pairs)")
+    lines.append("")
+    lines.append("How often the priest's awareness of a target crossed 0.4 (rising = begin, falling = end). Higher counts = more cat-and-mouse contact.")
+    lines.append("")
+    lines.append("| Seed | Personality | Begin | End |")
+    lines.append("|---:|---|---:|---:|")
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None: continue
+            lines.append("| %d | %s | %d | %d |" % (s, p, r["perceptionBegin"], r["perceptionEnd"]))
+    lines.append("")
+
+    # ---- Apprehend reasons.
+    lines.append("## Apprehend interrupt reasons")
+    lines.append("")
+    lines.append("When the priest's apprehend channel ended early, why?")
+    lines.append("")
+    lines.append("| Seed | Personality | TargetSwitched | TargetLost | OutOfRange |")
+    lines.append("|---:|---|---:|---:|---:|")
+    any_intr = False
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None: continue
+            ir = r["interruptReasons"]
+            if not ir: continue
+            any_intr = True
+            lines.append("| %d | %s | %d | %d | %d |" % (
+                s, p,
+                ir.get("TargetSwitched", 0),
+                ir.get("TargetLost", 0),
+                ir.get("OutOfRange", 0)))
+    if not any_intr:
+        lines.append("| -- | -- | 0 | 0 | 0 |")
+        lines.append("")
+        lines.append("(No apprehend interrupts fired in this matrix.)")
+    lines.append("")
+
+    # ---- Held item.
+    lines.append("## Held-item distribution while possessed")
+    lines.append("")
+    lines.append("Fraction of possessed-frames the bot was carrying each tag. Adds up to <100%% when the bot was empty-handed for the rest.")
+    lines.append("")
+    lines.append("| Seed | Personality | Iron | Key | Objectives | SkeletonKey | Empty-handed |")
+    lines.append("|---:|---|---:|---:|---:|---:|---:|")
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None: continue
+            d   = r["heldItemDistributionWhilePossessed"]
+            tot = r["possessedFrames"] or 1
+            iron  = 100.0 * d.get("Iron", 0)  / tot
+            key   = 100.0 * d.get("Key", 0)   / tot
+            objs  = 100.0 * sum(d.get(f"Objective{i}", 0) for i in range(1,6)) / tot
+            skel  = 100.0 * d.get("SkeletonKey", 0) / tot
+            empty = max(0.0, 100.0 - (iron + key + objs + skel))
+            lines.append("| %d | %s | %.1f%% | %.1f%% | %.1f%% | %.1f%% | %.1f%% |"
+                % (s, p, iron, key, objs, skel, empty))
+    lines.append("")
+
+    # ---- Villager deaths.
+    lines.append("## Villager deaths")
+    lines.append("")
+    lines.append("Two ways to count: the DP_OnVillagerDied event (canonical -- fires per death), and the per-frame life-timer rising/falling-edge detection (under-counts because 10 Hz sample period can miss deaths that happen + respawn within 100ms). First-death-life is only available for the per-frame method.")
+    lines.append("")
+    lines.append("| Seed | Personality | VillagerDied events | Per-frame deaths | First-death life (s) |")
+    lines.append("|---:|---|---:|---:|---:|")
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None: continue
+            event_deaths = r["eventCounts"].get("VillagerDied", 0)
+            deaths = r["villagerDeathLives"]
+            first = "%.2f" % deaths[0] if deaths else "--"
+            lines.append("| %d | %s | %d | %d | %s |" % (s, p, event_deaths, len(deaths), first))
+    lines.append("")
+
+    # ---- Frame perf.
+    lines.append("## Frame perf (wall-clock ms between samples)")
+    lines.append("")
+    lines.append("Time between consecutive 10 Hz samples in real wall-clock. Median is the better signal (mean is skewed by occasional GC / asset-load spikes).")
+    lines.append("")
+    lines.append("| Seed | Personality | Median ms | Avg ms | Max ms |")
+    lines.append("|---:|---|---:|---:|---:|")
+    for s in seeds:
+        for p in PERSONALITIES:
+            r = stats_table[s].get(p)
+            if r is None: continue
+            lines.append("| %d | %s | %.1f | %.1f | %.1f |"
+                % (s, p, r["frameMsMedian"], r["frameMsAvg"], r["frameMsMax"]))
+    lines.append("")
+
+    out_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="Build/dp_telemetry/seed_matrix")
+    ap.add_argument("--out",  default="Build/dp_telemetry/seed_matrix/REPORT.md")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"Matrix root not found: {root}")
+        return 1
+
+    seed_dirs = sorted([d for d in root.iterdir() if d.is_dir() and d.name.startswith("seed_")],
+                       key=lambda d: int(d.name.split("_")[1]))
+    seeds = [int(d.name.split("_")[1]) for d in seed_dirs]
+
+    # stats_table[seed][personality] -> result dict.
+    stats_table = defaultdict(dict)
+    for seed, sd in zip(seeds, seed_dirs):
+        for p in PERSONALITIES:
+            jp = sd / f"{p}.telemetry.json"
+            if not jp.is_file():
+                continue
+            tlm = load_run(jp)
+            stats_table[seed][p] = analyse_run(tlm)
+
+    render_md(stats_table, seeds, Path(args.out))
+    print(f"Wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/dp_seed_matrix_run.ps1
+++ b/Tools/dp_seed_matrix_run.ps1
@@ -1,0 +1,152 @@
+# dp_seed_matrix_run.ps1 -- run all 5 personality playthroughs against
+# multiple procgen seeds and collect v3 telemetry artifacts. Used to
+# extract per-seed / per-personality insights from the captured data.
+#
+# Each (seed, personality) cell runs the DP exe once with
+# DP_PROCGEN_SEED set in the environment, then copies the resulting
+# .ztlm + .json + frames.csv + events.csv into
+#   Build/dp_telemetry/seed_matrix/seed_<seed>/<personality>.{ext}
+#
+# Also generates per-cell PNGs via Tools/dp_telemetry_visualise.ps1.
+#
+# ASCII-only.
+
+[CmdletBinding()]
+param(
+    [string]$ConfigName    = "Debug_False",
+    [string]$OutRoot       = "Build/dp_telemetry/seed_matrix",
+    [int]$ExitAfterFrames  = 8500,
+    [switch]$Headless      = $true,
+    [uint64[]]$Seeds       = @(0, 12345, 99999)
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$exeMap = @{
+    "Debug_True"    = "Games/DevilsPlayground/Build/output/win64/vs2022_debug_win64_true/devilsplayground.exe"
+    "Debug_False"   = "Games/DevilsPlayground/Build/output/win64/vs2022_debug_win64_false/devilsplayground.exe"
+    "Release_False" = "Games/DevilsPlayground/Build/output/win64/vs2022_release_win64_false/devilsplayground.exe"
+}
+$exe = $exeMap[$ConfigName]
+if (-not (Test-Path $exe)) {
+    Write-Error "exe not found: $exe"
+    exit 1
+}
+
+$personalities = @("Casual","Stealth","Speedrunner","Berserker","Methodical")
+$tempDir = $env:TEMP
+if (-not $tempDir) { $tempDir = $env:TMP }
+
+$summary = @()
+
+foreach ($seed in $Seeds) {
+    $destDir = Join-Path $OutRoot "seed_$seed"
+    New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    Write-Host ""
+    Write-Host "==================== SEED $seed ====================" -ForegroundColor Magenta
+
+    foreach ($p in $personalities) {
+        $testName = "PersonalityPlaythrough_$p"
+        Write-Host ""
+        Write-Host "==== seed=$seed  $testName ====" -ForegroundColor Cyan
+
+        # Wipe %TEMP% telemetry from prior runs so we don't accidentally
+        # copy stale artifacts on a failed run.
+        $srcBin    = Join-Path $tempDir "dp_personality_${p}_playthrough.ztlm"
+        $srcJson   = Join-Path $tempDir "dp_personality_${p}_playthrough.json"
+        $srcFrames = Join-Path $tempDir "dp_personality_${p}_frames.csv"
+        $srcEvents = Join-Path $tempDir "dp_personality_${p}_events.csv"
+        Remove-Item $srcBin,$srcJson,$srcFrames,$srcEvents -ErrorAction SilentlyContinue
+
+        # Per-test result JSON. Use a scratch dir per cell so we don't
+        # contaminate Build/dp_test_results across cells.
+        $resultDir = Join-Path $destDir "_result_$p"
+        if (Test-Path $resultDir) { Remove-Item -Recurse -Force $resultDir }
+        New-Item -ItemType Directory -Path $resultDir -Force | Out-Null
+        $resultJson = Join-Path $resultDir "$testName.result.json"
+
+        # Set the seed env var for THIS process invocation only -- restore
+        # the prior value afterwards so the outer shell's env stays clean.
+        $oldSeedEnv = $env:DP_PROCGEN_SEED
+        $env:DP_PROCGEN_SEED = "$seed"
+
+        $startTime = Get-Date
+        $procArgs = @(
+            "--automated-test", $testName,
+            "--exit-after-frames", "$ExitAfterFrames",
+            "--fixed-dt", "0.01666",
+            "--test-results", $resultJson
+        )
+        if ($Headless) { $procArgs += "--headless" }
+        & $exe @procArgs 2>&1 | Out-Null
+        $testExit = $LASTEXITCODE
+        $elapsed = (Get-Date) - $startTime
+
+        $env:DP_PROCGEN_SEED = $oldSeedEnv
+
+        Write-Host ("  exit={0}  elapsed={1:F1}s" -f $testExit, $elapsed.TotalSeconds)
+
+        # Copy artifacts (always, so a failed run leaves diagnosable data).
+        $dstBin    = Join-Path $destDir "$p.telemetry.ztlm"
+        $dstJson   = Join-Path $destDir "$p.telemetry.json"
+        $dstFrames = Join-Path $destDir "$p.frames.csv"
+        $dstEvents = Join-Path $destDir "$p.events.csv"
+        $dstRes    = Join-Path $destDir "$p.result.json"
+
+        if (Test-Path $srcBin)    { Copy-Item $srcBin    $dstBin    -Force }
+        if (Test-Path $srcJson)   { Copy-Item $srcJson   $dstJson   -Force }
+        if (Test-Path $srcFrames) { Copy-Item $srcFrames $dstFrames -Force }
+        if (Test-Path $srcEvents) { Copy-Item $srcEvents $dstEvents -Force }
+        if (Test-Path $resultJson) { Copy-Item $resultJson $dstRes -Force }
+
+        # PNG (best-effort).
+        if (Test-Path $dstJson) {
+            $dstPng = Join-Path $destDir "$p.png"
+            & pwsh.exe -NoProfile -ExecutionPolicy Bypass `
+                -File Tools/dp_telemetry_visualise.ps1 `
+                -JsonPath $dstJson `
+                -OutPath $dstPng `
+                -Quiet 2>&1 | Out-Null
+        }
+
+        # Headline numbers for the summary table.
+        $frames = 0; $events = 0; $passed = $false
+        if (Test-Path $dstJson) {
+            try {
+                $tlm = (Get-Content $dstJson -Raw) | ConvertFrom-Json
+                if ($tlm.frames) { $frames = ($tlm.frames | Measure-Object).Count }
+                if ($tlm.events) { $events = ($tlm.events | Measure-Object).Count }
+            } catch {}
+        }
+        if (Test-Path $dstRes) {
+            try {
+                $res = (Get-Content $dstRes -Raw) | ConvertFrom-Json
+                $passed = [bool]$res.passed
+            } catch {}
+        }
+
+        $summary += [pscustomobject]@{
+            Seed        = $seed
+            Personality = $p
+            Passed      = $passed
+            Frames      = $frames
+            Events      = $events
+            ElapsedSec  = [math]::Round($elapsed.TotalSeconds,1)
+            ExitCode    = $testExit
+        }
+
+        # Clean up the per-cell _result dir; the .result.json is already
+        # copied next to the telemetry artifacts.
+        Remove-Item -Recurse -Force $resultDir -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host ""
+Write-Host "==================== Summary ====================" -ForegroundColor Magenta
+$summary | Format-Table -AutoSize | Out-String | Write-Host
+
+$summaryJsonPath = Join-Path $OutRoot "matrix_summary.json"
+$summary | ConvertTo-Json -Depth 4 | Set-Content $summaryJsonPath -Encoding utf8
+Write-Host "Wrote summary JSON: $summaryJsonPath"


### PR DESCRIPTION
## Summary

Three pieces of tooling for exploring procgen-layout variation with the personality bots, plus a Markdown analyser that turns v3 telemetry into per-(seed, personality) insights.

### 1. \`DP_PROCGEN_SEED\` env var override

\`DPProcLevelBootstrap_Behaviour::OnAwake\` now reads \`DP_PROCGEN_SEED\` from the environment and overrides \`m_uSeed\` when present. Empty / missing env preserves the existing default of 0. The \`Test_ProcLevel*\` suites that drive \`m_uSeed\` via \`SetSeedForTest\` before OnAwake fires are unaffected (their override path runs first).

### 2. \`Tools/dp_seed_matrix_run.ps1\`

Walks a 5 x 3 matrix (5 personalities x 3 seeds, configurable) and for each cell:
- spawns the DP exe with the cell's seed in \`DP_PROCGEN_SEED\`
- runs the matching \`PersonalityPlaythrough_*\` automated test
- copies the v3 telemetry artifacts (\`.ztlm\` + \`.json\` + \`frames.csv\` + \`events.csv\`) into \`Build/dp_telemetry/seed_matrix/seed_N/\`
- renders the visualiser PNG

### 3. \`Tools/dp_seed_matrix_analyse.py\`

Reads every cell's telemetry JSON and emits a Markdown report covering:
- procgen obstacle variation per seed
- per-cell headline metrics
- priest BT-intent distribution (Idle / Patrol / Investigate / Pursue / Apprehend fractions)
- perception contact counts (Begin/End pairs)
- apprehend interrupt reasons
- held-item time fraction
- villager-death counts (canonical event vs per-frame edge detection)
- frame perf (median / mean / max ms between samples)

The analyser is the heaviest consumer of the v3 telemetry fields that PR #120 added — without them the report would only show seed + headline frame/event counts.

## Test plan

- [x] \`DP_PROCGEN_SEED=12345 devilsplayground.exe --automated-test Test_ProcLevelScene\` emits \`[DPProcLevelBootstrap] seed=12345\` (vs the default \`seed=0\`).
- [x] Empty / missing \`DP_PROCGEN_SEED\` keeps \`m_uSeed = 0\`; existing \`Test_ProcLevel_DeterminismCheck\` still passes.
- [x] \`Tools/dp_seed_matrix_run.ps1 -ConfigName Debug_False\` runs 15 cells (~4 minutes) and produces 15 PNGs + 15 telemetry triples.
- [x] \`python Tools/dp_seed_matrix_analyse.py\` emits a \`REPORT.md\` with 8 insight tables.

Diff stat: **3 files changed, 570 insertions(+), 4 deletions(-)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)