### PR TITLE
feat(dp): HUD telegraph upgrades -- locked-door alert + awareness + scent bar + archetype line

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -297,6 +297,7 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp" />
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp" />
+    <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp" />
     <ClCompile Include="..\Tests\Test_P5Particles_BurstsOnGameplayEvents.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_PersonalityPlaythrough.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -290,6 +290,9 @@
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P5Particles_BurstsOnGameplayEvents.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -591,6 +591,7 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp" />
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp" />
+    <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp" />
     <ClCompile Include="..\Tests\Test_P5Particles_BurstsOnGameplayEvents.cpp" />
     <ClCompile Include="..\Tests\Test_PentagramVictory.cpp" />
     <ClCompile Include="..\Tests\Test_PersonalityPlaythrough.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -290,6 +290,9 @@
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P5Particles_BurstsOnGameplayEvents.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPHUDController_Behaviour.h
@@ -88,6 +88,29 @@ public:
 					Zenith_Maths::Vector4(0.9f, 0.2f, 0.2f, 1.0f),
 					/*fHoldSeconds=*/0.0f /* permanent */);
 			});
+
+		// 2026-05-21: locked-door alert. The DPDoor's F-press fail path
+		// dispatches DP_OnDoorLockRejected; the HUD turns that into a
+		// brief "LOCKED -- needs Key" line so the player understands
+		// why nothing happened. Tag is captured for the formatter so
+		// post-MVP keys (SkeletonKey) telegraph correctly.
+		m_xLockedDoorHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnDoorLockRejected>(
+			[this](const DP_OnDoorLockRejected& xEvt)
+			{
+				m_eLastLockedDoorRequiredKey = xEvt.m_eRequiredKey;
+				m_fLockedDoorAlertRemaining = 2.0f;
+			});
+
+		// 2026-05-21: priest-alerted -- bump the awareness indicator's
+		// recent-alert flash so the player notices the transition even
+		// if their eyes were on the playfield. Falling edge auto-clears
+		// when the priest returns to patrol.
+		m_xPriestAlertHandle = Zenith_EventDispatcher::Get().SubscribeLambda<DP_OnPriestAlerted>(
+			[this](const DP_OnPriestAlerted& xEvt)
+			{
+				m_fAwarenessFlashRemaining = 1.0f;
+				m_eLastAlertKind = xEvt.m_eKind;
+			});
 	}
 
 	void OnDisable() ZENITH_FINAL override { TearDown(); }
@@ -181,6 +204,15 @@ public:
 
 		// MVP-2.5.2: Scent indicator. Reads the possessed villager's
 		// scent value. Hidden when nothing possessed.
+		// 2026-05-21: paired ScentBar element shows the 10-segment
+		// ASCII bar with hound-bark threshold marker. Both elements
+		// share the colour-coded gradient so peripheral vision picks
+		// up rising scent without reading the number.
+		const float fScent = bPossessed ? DP_Player::GetDemonScent(xV) : 0.0f;
+		const float fScentThreshold =
+			DP_Tuning::Get<float>("possession.demon_scent_hound_bark_threshold");
+		const Zenith_Maths::Vector4 xScentColor = ScentBarColor(fScent, fScentThreshold);
+
 		if (auto* pxScent = xUI.FindElement<Zenith_UI::Zenith_UIText>("ScentIndicator"))
 		{
 			if (!bPossessed)
@@ -189,11 +221,26 @@ public:
 			}
 			else
 			{
-				const float fScent = DP_Player::GetDemonScent(xV);
 				char buf[32];
 				BuildScentText(buf, sizeof(buf), fScent);
 				pxScent->SetText(buf);
+				pxScent->SetColor(xScentColor);
 				pxScent->SetVisible(true);
+			}
+		}
+		if (auto* pxScentBar = xUI.FindElement<Zenith_UI::Zenith_UIText>("ScentBar"))
+		{
+			if (!bPossessed)
+			{
+				pxScentBar->SetVisible(false);
+			}
+			else
+			{
+				char buf[40];
+				BuildScentBar(buf, sizeof(buf), fScent, fScentThreshold);
+				pxScentBar->SetText(buf);
+				pxScentBar->SetColor(xScentColor);
+				pxScentBar->SetVisible(true);
 			}
 		}
 
@@ -209,12 +256,72 @@ public:
 			pxWhisper->SetVisible(true);
 		}
 
+		// 2026-05-21: tick the awareness flash timer (set by
+		// DP_OnPriestAlerted subscriber). Range 0..1 maps to
+		// AwarenessColor's flash mix.
+		if (m_fAwarenessFlashRemaining > 0.0f)
+		{
+			m_fAwarenessFlashRemaining = glm::max(0.0f, m_fAwarenessFlashRemaining - fDt);
+		}
+
 		if (auto* pxAwareness = xUI.FindElement<Zenith_UI::Zenith_UIText>("AelfricAwareness"))
 		{
-			char buf[48];
+			char buf[64];
 			BuildAwarenessText(buf, sizeof(buf), eState);
 			pxAwareness->SetText(buf);
+			pxAwareness->SetColor(AwarenessColor(eState, m_fAwarenessFlashRemaining));
 			pxAwareness->SetVisible(true);
+		}
+
+		// 2026-05-21: locked-door alert. Counts down from 2 s on
+		// DP_OnDoorLockRejected (set by the subscribe lambda).
+		// Visibility is gated on the timer being positive; the text
+		// is rebuilt each frame from m_eLastLockedDoorRequiredKey so
+		// post-MVP keys (SkeletonKey) telegraph correctly.
+		if (m_fLockedDoorAlertRemaining > 0.0f)
+		{
+			m_fLockedDoorAlertRemaining = glm::max(0.0f, m_fLockedDoorAlertRemaining - fDt);
+		}
+		if (auto* pxLocked = xUI.FindElement<Zenith_UI::Zenith_UIText>("LockedDoorAlert"))
+		{
+			if (m_fLockedDoorAlertRemaining > 0.0f)
+			{
+				char buf[64];
+				BuildLockedDoorAlertText(buf, sizeof(buf), m_eLastLockedDoorRequiredKey);
+				pxLocked->SetText(buf);
+				pxLocked->SetVisible(true);
+			}
+			else
+			{
+				pxLocked->SetVisible(false);
+			}
+		}
+
+		// 2026-05-21: archetype status. Reads the possessed villager's
+		// archetype id and shows the special-rule line below VillagerInfo.
+		// Hidden when not possessing, or possessing a Farmhand (baseline).
+		// Local resolve of the villager script because the broader
+		// detailed-HUD block (which has its own pxVB) sits below this.
+		if (auto* pxArch = xUI.FindElement<Zenith_UI::Zenith_UIText>("ArchetypeStatus"))
+		{
+			const char* szLine = nullptr;
+			const char* szArchetype = nullptr;
+			DPVillager_Behaviour* pxLocalVB = bPossessed ? TryGetVillager(xV) : nullptr;
+			if (pxLocalVB != nullptr && !pxLocalVB->GetArchetypeId().empty())
+			{
+				szArchetype = pxLocalVB->GetArchetypeId().c_str();
+				szLine = BuildArchetypeStatusText(szArchetype);
+			}
+			if (szLine != nullptr)
+			{
+				pxArch->SetText(szLine);
+				pxArch->SetColor(ArchetypeStatusColor(szArchetype));
+				pxArch->SetVisible(true);
+			}
+			else
+			{
+				pxArch->SetVisible(false);
+			}
 		}
 
 		// MVP-4.3.2: post-victory / post-run-lost "press any key to
@@ -498,6 +605,66 @@ public:
 		std::snprintf(szBuf, uBufSize, "Scent: %.2f", fScent);
 	}
 
+	// 2026-05-21: ScentBar -- 10-cell ASCII bar visualisation of the
+	// possessed villager's scent saturation (0..1 mapped to 0..10
+	// segments). Filled cells use '#', empty use '.', and the
+	// hound-bark threshold (0.5 by Tuning.json default) is marked with
+	// a '|' separator so the player can SEE when scent crosses it.
+	// Format example at fScent=0.42, fThreshold=0.5:
+	//   "Scent [####|.....]"
+	// At fScent=0.65:
+	//   "Scent [#####|##..]"
+	// At fScent=1.0:
+	//   "Scent [#####|#####]" (saturated)
+	static void BuildScentBar(char* szBuf, size_t uBufSize, float fScent, float fThreshold)
+	{
+		if (fScent < 0.0f)     fScent = 0.0f;
+		if (fScent > 1.0f)     fScent = 1.0f;
+		if (fThreshold < 0.0f) fThreshold = 0.0f;
+		if (fThreshold > 1.0f) fThreshold = 1.0f;
+		const int kBarLen = 10;
+		const int iThresholdCell = static_cast<int>(fThreshold * static_cast<float>(kBarLen) + 0.5f);
+		const int iFilledCells   = static_cast<int>(fScent     * static_cast<float>(kBarLen) + 0.5f);
+
+		char xBar[24] = { 0 };
+		int iWrite = 0;
+		xBar[iWrite++] = '[';
+		for (int i = 0; i < kBarLen; ++i)
+		{
+			// Insert the threshold separator just BEFORE the iThresholdCell
+			// (so the bar reads "filled segments | empty segments" with
+			// the bar showing scent vs threshold visually).
+			if (i == iThresholdCell && iThresholdCell > 0 && iThresholdCell < kBarLen)
+			{
+				xBar[iWrite++] = '|';
+			}
+			xBar[iWrite++] = (i < iFilledCells) ? '#' : '.';
+		}
+		xBar[iWrite++] = ']';
+		xBar[iWrite] = '\0';
+		std::snprintf(szBuf, uBufSize, "Scent %s", xBar);
+	}
+
+	// 2026-05-21: scent-bar colour. Grey/violet when below threshold,
+	// bright red once we cross the hound-bark line. Lets the player's
+	// peripheral vision catch the danger transition without parsing
+	// the numeric "0.51 -> 0.48".
+	static Zenith_Maths::Vector4 ScentBarColor(float fScent, float fThreshold)
+	{
+		if (fScent < fThreshold)
+		{
+			// Gradient from neutral grey to deep violet as scent climbs.
+			const float fT = (fThreshold > 0.0001f) ? (fScent / fThreshold) : 0.0f;
+			return Zenith_Maths::Vector4(
+				0.50f + 0.20f * fT,
+				0.30f + 0.05f * fT,
+				0.70f + 0.20f * fT,
+				1.0f);
+		}
+		// At/above threshold: alarm red.
+		return Zenith_Maths::Vector4(1.0f, 0.25f, 0.20f, 1.0f);
+	}
+
 	// MVP-2.5.1 + 2.5.3: Aelfric awareness state. Derived from the
 	// priest's blackboard each frame:
 	//   Pursuing   -- BB_KEY_TARGET_WITH_DEVIL is a valid villager
@@ -513,14 +680,63 @@ public:
 		Pursuing
 	};
 
-	// Awareness-icon text: the state name in caps. Placeholder per
-	// the roadmap (MVP-2.5.3) until a real icon asset lands.
+	// Awareness-icon text: state-named with an ASCII glyph that
+	// telegraphs the urgency at a glance. Pre-fix this was just
+	// "Aelfric: <state>" -- legible only if you parsed the word.
+	// 2026-05-21: glyph + parens prefix so the icon line reads
+	// distinctly from the surrounding HUD text.
+	//   Calm        -> "[ ~ ] Aelfric: Patrolling"  (idle wave)
+	//   Suspicious  -> "[ ? ] Aelfric: SUSPICIOUS"  (question mark)
+	//   Pursuing    -> "[ ! ] Aelfric: PURSUING"    (alarm)
 	static void BuildAwarenessText(char* szBuf, size_t uBufSize, AelfricState eState)
 	{
-		const char* szLabel = "CALM";
-		if      (eState == AelfricState::Pursuing)   szLabel = "PURSUING";
-		else if (eState == AelfricState::Suspicious) szLabel = "SUSPICIOUS";
-		std::snprintf(szBuf, uBufSize, "Aelfric: %s", szLabel);
+		const char* szGlyph = "~";
+		const char* szLabel = "Patrolling";
+		if (eState == AelfricState::Pursuing)
+		{
+			szGlyph = "!";
+			szLabel = "PURSUING";
+		}
+		else if (eState == AelfricState::Suspicious)
+		{
+			szGlyph = "?";
+			szLabel = "SUSPICIOUS";
+		}
+		std::snprintf(szBuf, uBufSize, "[ %s ] Aelfric: %s", szGlyph, szLabel);
+	}
+
+	// 2026-05-21: awareness-icon colour. Threshold maps state to a
+	// risk-band gradient so the player's peripheral vision can read
+	// the priest's danger level without parsing the glyph.
+	//   Calm        -> dim green (safe-but-watch)
+	//   Suspicious  -> amber (rising)
+	//   Pursuing    -> alarm red (immediate)
+	// A short "flash" boost (via fFlashT in [0..1]) brightens the
+	// colour for ~1 s after a rising-edge DP_OnPriestAlerted -- helps
+	// the player notice the transition.
+	static Zenith_Maths::Vector4 AwarenessColor(AelfricState eState, float fFlashT)
+	{
+		if (fFlashT < 0.0f) fFlashT = 0.0f;
+		if (fFlashT > 1.0f) fFlashT = 1.0f;
+		Zenith_Maths::Vector4 xBase(0.45f, 0.85f, 0.45f, 1.0f);  // calm green
+		if (eState == AelfricState::Suspicious)
+		{
+			xBase = Zenith_Maths::Vector4(0.95f, 0.75f, 0.30f, 1.0f);
+		}
+		else if (eState == AelfricState::Pursuing)
+		{
+			xBase = Zenith_Maths::Vector4(1.0f, 0.30f, 0.20f, 1.0f);
+		}
+		// Flash mix: lerp toward bright white over 0..0.4, back over 0.4..1.
+		const float fMix = (fFlashT > 0.4f)
+			? (1.0f - fFlashT) / 0.6f
+			: fFlashT / 0.4f;
+		const float fK = glm::clamp(fMix, 0.0f, 1.0f) * 0.5f;
+		return Zenith_Maths::Vector4(
+			xBase.x + (1.0f - xBase.x) * fK,
+			xBase.y + (1.0f - xBase.y) * fK,
+			xBase.z + (1.0f - xBase.z) * fK,
+			1.0f);
 	}
 
 	// Whisper-line text: vibe copy that reacts to the priest's state.
@@ -595,6 +811,56 @@ public:
 	{
 		const DP_ItemTag eTag = bPossessed ? DP_Player::GetHeldItemTag(xV) : DP_ItemTag::None;
 		return BuildTutorialHintForState(bPossessed, eTag, eState, bRunOver);
+	}
+
+	// 2026-05-21: archetype-specific status line. Each MVP archetype
+	// has a unique gameplay rule that the placeholder cube visual
+	// doesn't telegraph; this line surfaces the rule textually so the
+	// player knows "I'm a Devout, possession is slow" etc.
+	// Returns nullptr for Farmhand (baseline -- no special rule) so
+	// the HUD line is hidden in that case.
+	static const char* BuildArchetypeStatusText(const char* szArchetypeId)
+	{
+		if (szArchetypeId == nullptr) return nullptr;
+		// String compare against the canonical archetype IDs from
+		// Config/Archetypes.json. Beggar / Devout / Child are the
+		// MVP variants with special rules; Farmhand returns null
+		// (no surface needed).
+		if (std::strcmp(szArchetypeId, "Beggar") == 0)
+			return "BEGGAR -- Aelfric will not pursue you";
+		if (std::strcmp(szArchetypeId, "Devout") == 0)
+			return "DEVOUT -- possession requires a 0.8 s channel (priest LOS breaks it)";
+		if (std::strcmp(szArchetypeId, "Child") == 0)
+			return "CHILD -- cannot carry tools (Iron / Key); half life timer";
+		// Farmhand / unknown -> hide.
+		return nullptr;
+	}
+
+	// Per-archetype HUD tint matching DPVillager_Behaviour's per-tag
+	// villager-body tint, so the HUD line reads as "this villager".
+	static Zenith_Maths::Vector4 ArchetypeStatusColor(const char* szArchetypeId)
+	{
+		if (szArchetypeId == nullptr) return Zenith_Maths::Vector4(0.95f, 0.85f, 0.65f, 1.0f);
+		if (std::strcmp(szArchetypeId, "Beggar") == 0)
+			return Zenith_Maths::Vector4(0.85f, 0.85f, 1.0f, 1.0f);   // safe blue
+		if (std::strcmp(szArchetypeId, "Devout") == 0)
+			return Zenith_Maths::Vector4(0.95f, 0.85f, 0.50f, 1.0f);  // candlelight yellow
+		if (std::strcmp(szArchetypeId, "Child") == 0)
+			return Zenith_Maths::Vector4(0.90f, 0.60f, 0.85f, 1.0f);  // pink
+		return Zenith_Maths::Vector4(0.95f, 0.85f, 0.65f, 1.0f);      // farmhand neutral
+	}
+
+	// 2026-05-21: locked-door alert. Telegraphs the result of an
+	// F-press on a key-gated door when the villager has no matching
+	// key (or wrong tag). Reads the required key tag from the event
+	// payload so the player knows what they need to find.
+	static void BuildLockedDoorAlertText(char* szBuf, size_t uBufSize, DP_ItemTag eRequired)
+	{
+		const char* szKey = "a Key";
+		if      (eRequired == DP_ItemTag::Key)         szKey = "a Key";
+		else if (eRequired == DP_ItemTag::SkeletonKey) szKey = "a Skeleton Key";
+		else if (eRequired == DP_ItemTag::Iron)        szKey = "an Iron"; // unusual but possible
+		std::snprintf(szBuf, uBufSize, "LOCKED -- needs %s", szKey);
 	}
 
 	// =============== Detailed-HUD formatter helpers ===============
@@ -922,11 +1188,23 @@ private:
 			Zenith_EventDispatcher::Get().Unsubscribe(m_xRunLostHandle);
 			m_xRunLostHandle = INVALID_EVENT_HANDLE;
 		}
+		if (m_xLockedDoorHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(m_xLockedDoorHandle);
+			m_xLockedDoorHandle = INVALID_EVENT_HANDLE;
+		}
+		if (m_xPriestAlertHandle != INVALID_EVENT_HANDLE)
+		{
+			Zenith_EventDispatcher::Get().Unsubscribe(m_xPriestAlertHandle);
+			m_xPriestAlertHandle = INVALID_EVENT_HANDLE;
+		}
 	}
 
 	Zenith_EventHandle m_xVictoryHandle       = INVALID_EVENT_HANDLE;
 	Zenith_EventHandle m_xDeathHandle         = INVALID_EVENT_HANDLE;
 	Zenith_EventHandle m_xRunLostHandle       = INVALID_EVENT_HANDLE;
+	Zenith_EventHandle m_xLockedDoorHandle    = INVALID_EVENT_HANDLE;
+	Zenith_EventHandle m_xPriestAlertHandle   = INVALID_EVENT_HANDLE;
 	float              m_fStatusHoldRemaining = -1.0f;  // <0 = permanent / not set
 	bool               m_bRunLostReceived     = false;
 	// MVP-4.3.2: set by EITHER the Victory or RunLost subscriber. Drives
@@ -935,6 +1213,16 @@ private:
 	// watched "VICTORY" appear and just want to start a new run).
 	bool               m_bRunOver             = false;
 	DP_RunLostCause    m_eLastRunLostCause    = DP_RunLostCause::Apprehended;
+	// 2026-05-21 player-feedback fields. m_fLockedDoorAlertRemaining
+	// counts down from 2 s on DP_OnDoorLockRejected, gating the
+	// LockedDoorAlert UI element's visibility. m_fAwarenessFlashRemaining
+	// gates a brief "recently alerted" colour flash on the awareness
+	// indicator so the player notices priest-state transitions even when
+	// not looking at the icon.
+	float              m_fLockedDoorAlertRemaining = 0.0f;
+	DP_ItemTag         m_eLastLockedDoorRequiredKey = DP_ItemTag::Key;
+	float              m_fAwarenessFlashRemaining   = 0.0f;
+	DP_PriestAlertKind m_eLastAlertKind             = DP_PriestAlertKind::HeardNoise;
 	// Detailed-HUD: run timer. Starts ticking on first possession and
 	// freezes when the run ends (Victory or RunLost). Drives the
 	// RunTimer UI element.

--- a/Games/DevilsPlayground/DevilsPlayground.cpp
+++ b/Games/DevilsPlayground/DevilsPlayground.cpp
@@ -483,6 +483,44 @@ namespace
 		Zenith_EditorAutomation::AddStep_SetUIColor("Status", 0.9f, 0.2f, 0.2f, 1.0f);
 		Zenith_EditorAutomation::AddStep_SetUIVisible("Status", false);
 
+		// 2026-05-21: LockedDoorAlert. A short-lived warning under the Status
+		// banner that fires on DP_OnDoorLockRejected. Pre-fix the player got
+		// zero feedback that a door was locked -- F-press silently did
+		// nothing. The HUD now flashes "LOCKED -- needs Key" or similar
+		// for ~2 s. Hidden by default; the controller flips visibility.
+		Zenith_EditorAutomation::AddStep_CreateUIText("LockedDoorAlert", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("LockedDoorAlert", static_cast<int>(Zenith_UI::AnchorPreset::Center));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("LockedDoorAlert", static_cast<int>(Zenith_UI::TextAlignment::Center));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("LockedDoorAlert", 0.0f, -40.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("LockedDoorAlert", DPUI::fHUD_STATUS_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("LockedDoorAlert", 0.95f, 0.30f, 0.20f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("LockedDoorAlert", false);
+
+		// 2026-05-21: ScentBar. The companion bar visualisation to
+		// ScentIndicator (which is a numeric "Scent: 0.42"). The bar
+		// gives the player a glanceable readout of scent saturation
+		// across the 0-1 range, with colour signalling when scent
+		// crosses the hound-bark threshold (0.5).
+		Zenith_EditorAutomation::AddStep_CreateUIText("ScentBar", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("ScentBar", static_cast<int>(Zenith_UI::AnchorPreset::BottomLeft));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("ScentBar", static_cast<int>(Zenith_UI::TextAlignment::Left));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("ScentBar", DPUI::fEDGE_INSET, -DPUI::fEDGE_INSET - 25.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("ScentBar", DPUI::fHUD_SCENT_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("ScentBar", 0.7f, 0.3f, 0.9f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("ScentBar", false);
+
+		// 2026-05-21: ArchetypeStatus. A one-line description of the
+		// possessed villager's archetype-specific gameplay rule.
+		// Sits below VillagerInfo on the TopLeft stack. Hidden when
+		// not possessing or possessing a Farmhand (baseline).
+		Zenith_EditorAutomation::AddStep_CreateUIText("ArchetypeStatus", "");
+		Zenith_EditorAutomation::AddStep_SetUIAnchor("ArchetypeStatus", static_cast<int>(Zenith_UI::AnchorPreset::TopLeft));
+		Zenith_EditorAutomation::AddStep_SetUIAlignment("ArchetypeStatus", static_cast<int>(Zenith_UI::TextAlignment::Left));
+		Zenith_EditorAutomation::AddStep_SetUIPosition("ArchetypeStatus", DPUI::fEDGE_INSET, DPUI::fEDGE_INSET + 245.0f);
+		Zenith_EditorAutomation::AddStep_SetUIFontSize("ArchetypeStatus", DPUI::fHUD_VILLAGER_INFO_FONT);
+		Zenith_EditorAutomation::AddStep_SetUIColor("ArchetypeStatus", 0.95f, 0.85f, 0.65f, 1.0f);
+		Zenith_EditorAutomation::AddStep_SetUIVisible("ArchetypeStatus", false);
+
 		// MVP-2.5.4: Dawn sun-gauge -- text countdown at top-centre.
 		Zenith_EditorAutomation::AddStep_CreateUIText("DawnGauge", "");
 		Zenith_EditorAutomation::AddStep_SetUIAnchor("DawnGauge", static_cast<int>(Zenith_UI::AnchorPreset::TopCenter));

--- a/Games/DevilsPlayground/Tests/Test_P2HUD_AelfricStateReadouts.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P2HUD_AelfricStateReadouts.cpp
@@ -76,10 +76,15 @@ static void Setup_P2HUDAelfric()
 	}
 
 	// --- AelfricAwareness ---
+	// 2026-05-21: format upgraded to "[ glyph ] Aelfric: <state>" so
+	// the icon line reads as a distinct status badge. Calm uses
+	// "Patrolling" (more player-friendly than "CALM"). Suspicious /
+	// Pursuing keep their uppercase emphasis for urgency. Test still
+	// pins the "Aelfric: " prefix + the state-name substring.
 	DPHUDController_Behaviour::BuildAwarenessText(buf, sizeof(buf), AelfricState::Calm);
-	if (!Has(buf, "Aelfric: ") || !Has(buf, "CALM"))
+	if (!Has(buf, "Aelfric: ") || !Has(buf, "Patrolling"))
 	{
-		g_szFailureReason = "awareness for Calm doesn't contain 'Aelfric: CALM'";
+		g_szFailureReason = "awareness for Calm doesn't contain 'Aelfric: Patrolling'";
 		return;
 	}
 	DPHUDController_Behaviour::BuildAwarenessText(buf, sizeof(buf), AelfricState::Suspicious);

--- a/Games/DevilsPlayground/Tests/Test_P5HUD_TelegraphFormatters.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P5HUD_TelegraphFormatters.cpp
@@ -1,0 +1,224 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DevilsPlayground_Tags.h"
+#include "Components/DPHUDController_Behaviour.h"
+
+#include <cstdio>
+#include <cstring>
+
+// ============================================================================
+// Test_P5HUD_TelegraphFormatters (2026-05-21)
+//
+// Pins the pure-formatter helpers added in the 2026-05-21 HUD-upgrades
+// pass. Each formatter takes raw data + caller-supplied buffer and
+// returns formatted text; testing them in isolation lets the test stay
+// off the UI canvas while still pinning the player-facing strings.
+//
+// Surfaces covered:
+//   BuildAwarenessText(state)            -> "[ glyph ] Aelfric: <state>"
+//   AwarenessColor(state, flashT)        -> Vec4 risk-band gradient
+//   BuildScentBar(scent, threshold)      -> "Scent [###|##....]"
+//   ScentBarColor(scent, threshold)      -> Vec4 (red when >= threshold)
+//   BuildArchetypeStatusText(archetype)  -> "<archetype rule>" or nullptr
+//   BuildLockedDoorAlertText(tag)        -> "LOCKED -- needs <key>"
+//
+// Doesn't author a UI canvas. Pure synchronous Verify covers all six
+// surfaces in 0 frames.
+// ============================================================================
+
+static void Setup_P5HUDTelegraphs() {}
+
+static bool Step_P5HUDTelegraphs(int /*iFrame*/) { return false; }
+
+static bool Verify_P5HUDTelegraphs()
+{
+	char xBuf[80];
+
+	// ----- Awareness text + colour -----
+	DPHUDController_Behaviour::BuildAwarenessText(xBuf, sizeof(xBuf),
+		DPHUDController_Behaviour::AelfricState::Calm);
+	if (std::strstr(xBuf, "Patrolling") == nullptr || std::strstr(xBuf, "~") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Calm awareness text wrong: \"%s\"", xBuf);
+		return false;
+	}
+	DPHUDController_Behaviour::BuildAwarenessText(xBuf, sizeof(xBuf),
+		DPHUDController_Behaviour::AelfricState::Suspicious);
+	if (std::strstr(xBuf, "SUSPICIOUS") == nullptr || std::strstr(xBuf, "?") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Suspicious awareness text wrong: \"%s\"", xBuf);
+		return false;
+	}
+	DPHUDController_Behaviour::BuildAwarenessText(xBuf, sizeof(xBuf),
+		DPHUDController_Behaviour::AelfricState::Pursuing);
+	if (std::strstr(xBuf, "PURSUING") == nullptr || std::strstr(xBuf, "!") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Pursuing awareness text wrong: \"%s\"", xBuf);
+		return false;
+	}
+
+	// Awareness colours: Calm is green-dominant, Pursuing is red-dominant.
+	const Zenith_Maths::Vector4 xCalmColor =
+		DPHUDController_Behaviour::AwarenessColor(
+			DPHUDController_Behaviour::AelfricState::Calm, 0.0f);
+	const Zenith_Maths::Vector4 xPursuingColor =
+		DPHUDController_Behaviour::AwarenessColor(
+			DPHUDController_Behaviour::AelfricState::Pursuing, 0.0f);
+	if (!(xCalmColor.y > xCalmColor.x))
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Calm awareness colour not green-dominant (G=%.2f R=%.2f)",
+			xCalmColor.y, xCalmColor.x);
+		return false;
+	}
+	if (!(xPursuingColor.x > xPursuingColor.y))
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Pursuing awareness colour not red-dominant (R=%.2f G=%.2f)",
+			xPursuingColor.x, xPursuingColor.y);
+		return false;
+	}
+
+	// ----- Scent bar -----
+	// At fScent=0, fThreshold=0.5: bar should be 10 cells, all empty,
+	// with a threshold separator after the 5th cell.
+	DPHUDController_Behaviour::BuildScentBar(xBuf, sizeof(xBuf), 0.0f, 0.5f);
+	if (std::strstr(xBuf, "Scent") == nullptr
+		|| std::strstr(xBuf, "[") == nullptr
+		|| std::strstr(xBuf, "]") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: ScentBar(0, 0.5) missing brackets: \"%s\"", xBuf);
+		return false;
+	}
+	// At fScent=0.5, fThreshold=0.5: ~5 cells filled, separator at the
+	// halfway point. The exact format is "[#####|.....]" (10 cells +
+	// separator). We confirm it contains "|" (the threshold marker)
+	// and at least 4 '#' characters (one less than 5 is acceptable
+	// rounding slack).
+	DPHUDController_Behaviour::BuildScentBar(xBuf, sizeof(xBuf), 0.5f, 0.5f);
+	{
+		int iHashes = 0;
+		for (const char* p = xBuf; *p; ++p) if (*p == '#') ++iHashes;
+		bool bHasSeparator = std::strchr(xBuf, '|') != nullptr;
+		if (!bHasSeparator)
+		{
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P5HUDTelegraphs: ScentBar(0.5, 0.5) missing threshold separator: \"%s\"", xBuf);
+			return false;
+		}
+		if (iHashes < 4)
+		{
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P5HUDTelegraphs: ScentBar(0.5, 0.5) has only %d filled cells: \"%s\"",
+				iHashes, xBuf);
+			return false;
+		}
+	}
+	// At fScent=1.0, fThreshold=0.5: 10 cells filled.
+	DPHUDController_Behaviour::BuildScentBar(xBuf, sizeof(xBuf), 1.0f, 0.5f);
+	{
+		int iHashes = 0;
+		for (const char* p = xBuf; *p; ++p) if (*p == '#') ++iHashes;
+		if (iHashes < 9)
+		{
+			Zenith_Log(LOG_CATEGORY_AI,
+				"P5HUDTelegraphs: ScentBar(1.0) only %d filled cells, expected ~10: \"%s\"",
+				iHashes, xBuf);
+			return false;
+		}
+	}
+
+	// Scent colour: below threshold is purple-leaning, above threshold
+	// is red-dominant.
+	const Zenith_Maths::Vector4 xLowScent =
+		DPHUDController_Behaviour::ScentBarColor(0.2f, 0.5f);
+	const Zenith_Maths::Vector4 xHighScent =
+		DPHUDController_Behaviour::ScentBarColor(0.8f, 0.5f);
+	if (!(xLowScent.z > xLowScent.y))
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: low-scent colour not purple-leaning (B=%.2f G=%.2f)",
+			xLowScent.z, xLowScent.y);
+		return false;
+	}
+	if (!(xHighScent.x > xHighScent.y && xHighScent.x > xHighScent.z))
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: high-scent colour not red-dominant (R=%.2f G=%.2f B=%.2f)",
+			xHighScent.x, xHighScent.y, xHighScent.z);
+		return false;
+	}
+
+	// ----- Archetype status -----
+	const char* szBeggar = DPHUDController_Behaviour::BuildArchetypeStatusText("Beggar");
+	if (szBeggar == nullptr || std::strstr(szBeggar, "BEGGAR") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Beggar status text missing: \"%s\"",
+			szBeggar != nullptr ? szBeggar : "(null)");
+		return false;
+	}
+	const char* szDevout = DPHUDController_Behaviour::BuildArchetypeStatusText("Devout");
+	if (szDevout == nullptr || std::strstr(szDevout, "DEVOUT") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Devout status text missing: \"%s\"",
+			szDevout != nullptr ? szDevout : "(null)");
+		return false;
+	}
+	const char* szChild = DPHUDController_Behaviour::BuildArchetypeStatusText("Child");
+	if (szChild == nullptr || std::strstr(szChild, "CHILD") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Child status text missing: \"%s\"",
+			szChild != nullptr ? szChild : "(null)");
+		return false;
+	}
+	// Farmhand has no special rule -> nullptr (HUD line hides).
+	const char* szFarmhand = DPHUDController_Behaviour::BuildArchetypeStatusText("Farmhand");
+	if (szFarmhand != nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: Farmhand should return nullptr but got \"%s\"", szFarmhand);
+		return false;
+	}
+
+	// ----- Locked-door alert -----
+	DPHUDController_Behaviour::BuildLockedDoorAlertText(xBuf, sizeof(xBuf), DP_ItemTag::Key);
+	if (std::strstr(xBuf, "LOCKED") == nullptr || std::strstr(xBuf, "Key") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: LockedDoor(Key) text wrong: \"%s\"", xBuf);
+		return false;
+	}
+	DPHUDController_Behaviour::BuildLockedDoorAlertText(
+		xBuf, sizeof(xBuf), DP_ItemTag::SkeletonKey);
+	if (std::strstr(xBuf, "Skeleton") == nullptr)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5HUDTelegraphs: LockedDoor(SkeletonKey) text wrong: \"%s\"", xBuf);
+		return false;
+	}
+
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP5HUDTelegraphsTest = {
+	"Test_P5HUD_TelegraphFormatters",
+	&Setup_P5HUDTelegraphs,
+	&Step_P5HUDTelegraphs,
+	&Verify_P5HUDTelegraphs,
+	1
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP5HUDTelegraphsTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

**Stacked on top of PR #130** (particle telegraphs). Diff is against `dp/in-world-telegraphs-2026-05-21` -- on merge, GitHub will auto-rebase to master.

Closes the "no HUD signal for the state-level context" half of the in-game feedback work. PR #130's particle bursts tell the player WHAT happened in the world; this PR's HUD upgrades tell them WHY + the state.

## Four upgrades

1. **LockedDoorAlert (new)** -- subscribes to `DP_OnDoorLockRejected`, shows "LOCKED -- needs Key" under the Status banner for 2 s. Pre-fix the player got zero HUD feedback that the door was locked.

2. **AelfricAwareness format upgrade** -- was a bare `"Aelfric: CALM"` / `"SUSPICIOUS"` / `"PURSUING"`. Now reads `"[ ~ ] Aelfric: Patrolling"` / `"[ ? ] Aelfric: SUSPICIOUS"` / `"[ ! ] Aelfric: PURSUING"` with per-state colour band (green -> amber -> alarm-red). Plus a transient brightness flash triggered by `DP_OnPriestAlerted` (1 s decay) so the player notices rising-edge transitions even when not looking at the icon.

3. **ScentBar (new)** -- 10-cell ASCII bar visualisation alongside the existing numeric ScentIndicator:
   ```
   Scent [####|......]   (40% scent, threshold 0.5)
   Scent [#####|####.]   (90% scent, threshold 0.5)
   ```
   The `|` marks the hound-bark threshold from Tuning.json. Colour shifts from grey-violet (below threshold) to alarm-red (at/above).

4. **ArchetypeStatus (new)** -- one-line description of the possessed villager's archetype-specific rule:
   - **Beggar**: "BEGGAR -- Aelfric will not pursue you"
   - **Devout**: "DEVOUT -- possession requires a 0.8 s channel (priest LOS breaks it)"
   - **Child**: "CHILD -- cannot carry tools (Iron / Key); half life timer"
   - **Farmhand**: (hidden -- baseline has no special rule)
   Each gets a distinct colour tint matching the body tint.

## Test plan

- [x] Build green
- [x] Full DP suite: **119/119 pass** (+1 new test: `Test_P5HUD_TelegraphFormatters`)
- [x] Updated `Test_P2HUD_AelfricStateReadouts` to match the new "Patrolling" Calm format (Suspicious / Pursuing substring checks unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)