### PR TITLE
feat(dp): archetype in-world telegraphs -- Beggar aura + Devout channel + Child refusal

### DIFF
--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj
@@ -299,6 +299,7 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp" />
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp" />
+    <ClCompile Include="..\Tests\Test_P5Archetype_Telegraphs.cpp" />
     <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp" />
     <ClCompile Include="..\Tests\Test_P5Particles_BurstsOnGameplayEvents.cpp" />
     <ClCompile Include="..\Tests\Test_P5Scent_PriestPatrolBiasedByScent.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_agde.vcxproj.filters
@@ -293,6 +293,9 @@
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P5Archetype_Telegraphs.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj
@@ -593,6 +593,7 @@
     <ClCompile Include="..\Tests\Test_P4Playthrough_LossByNoVessels.cpp" />
     <ClCompile Include="..\Tests\Test_P4Playthrough_Night1WinGolden.cpp" />
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp" />
+    <ClCompile Include="..\Tests\Test_P5Archetype_Telegraphs.cpp" />
     <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp" />
     <ClCompile Include="..\Tests\Test_P5Particles_BurstsOnGameplayEvents.cpp" />
     <ClCompile Include="..\Tests\Test_P5Scent_PriestPatrolBiasedByScent.cpp" />

--- a/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
+++ b/Games/DevilsPlayground/Build/devilsplayground_win64.vcxproj.filters
@@ -293,6 +293,9 @@
     <ClCompile Include="..\Tests\Test_P4UI_RestartPromptAfterRunOver.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Tests\Test_P5Archetype_Telegraphs.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\Tests\Test_P5HUD_TelegraphFormatters.cpp">
       <Filter>Tests</Filter>
     </ClCompile>

--- a/Games/DevilsPlayground/Components/DPItemBase_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPItemBase_Behaviour.h
@@ -141,6 +141,19 @@ public:
 				&& pxV->GetArchetypeId() == "Child"
 				&& DP_IsToolTag(m_eTag))
 			{
+				// 2026-05-21: telegraph the refusal so the player can
+				// SEE that the Child silently can't carry tools.
+				// Pre-fix this branch was a bare return -- the only
+				// indication was "I walked over an Iron and nothing
+				// happened." The DP_OnChildToolRefused event drives
+				// the ChildToolRefusal particle burst (red X) at the
+				// villager position.
+				Zenith_EventDispatcher::Get().Dispatch(
+					DP_OnChildToolRefused{
+						xVillager,
+						m_xParentEntity.GetEntityID(),
+						m_eTag,
+						xVPos });
 				return;
 			}
 		}

--- a/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
+++ b/Games/DevilsPlayground/Components/DPPlayerController_Behaviour.h
@@ -203,6 +203,44 @@ public:
 				xHighestId, fHighestScent >= fThreshold);
 		}
 
+		// 2026-05-21: archetype-aware aura updates.
+		//
+		// BeggarStealthAura: emit while the player is possessing a
+		// Beggar -- telegraphs "the priest will not pursue this body."
+		// Without the visual the Beggar-ignored rule is a silent
+		// BridgePerceptionToBlackboard filter the player can't observe.
+		//
+		// DevoutChannel: emit while DP_Player is mid-channel onto a
+		// Devout target. The 0.8 s channel is otherwise invisible --
+		// the player clicks, nothing happens for 0.8 s, then possession
+		// snaps. The candlelight aura makes the "ritual in progress"
+		// state legible.
+		{
+			Zenith_EntityID xPossessed = DP_Player::GetPossessedVillager();
+			bool bIsBeggar = false;
+			if (xPossessed.IsValid())
+			{
+				Zenith_SceneData* pxScene =
+					Zenith_SceneManager::GetSceneDataForEntity(xPossessed);
+				if (pxScene != nullptr)
+				{
+					Zenith_Entity xV = pxScene->TryGetEntity(xPossessed);
+					if (xV.IsValid() && xV.HasComponent<Zenith_ScriptComponent>())
+					{
+						DPVillager_Behaviour* pxV =
+							xV.GetComponent<Zenith_ScriptComponent>()
+							  .GetScript<DPVillager_Behaviour>();
+						bIsBeggar = (pxV != nullptr && pxV->GetArchetypeId() == "Beggar");
+					}
+				}
+			}
+			DP_Particles::UpdateBeggarStealthAura(xPossessed, bIsBeggar);
+
+			const Zenith_EntityID xChannelTarget = DP_Player::GetChannelTarget();
+			const bool bChanneling = DP_Player::IsChanneling();
+			DP_Particles::UpdateDevoutChannelAura(xChannelTarget, bChanneling);
+		}
+
 		// MVP-2.1.1/2 Devout channel: per-frame countdown + priest
 		// interrupt check. Quiet no-op until TryVoluntaryPossessSwitch
 		// starts a channel onto a Devout target.

--- a/Games/DevilsPlayground/Source/DPParticles.cpp
+++ b/Games/DevilsPlayground/Source/DPParticles.cpp
@@ -36,6 +36,9 @@ namespace DP_Particles
 			"DP_BogWaterSteam",
 			"DP_PriestAlert",
 			"DP_HighScentAura",
+			"DP_DevoutChannel",
+			"DP_BeggarStealthAura",
+			"DP_ChildToolRefusal",
 		};
 
 		// Per-Kind burst count. The Flux_ParticleEmitterConfig has
@@ -51,7 +54,10 @@ namespace DP_Particles
 			48,  // BellSoulRing     -- biggest; radial ring
 			20,  // BogWaterSteam
 			12,  // PriestAlert
-			0,   // HighScentAura   -- continuous emission, no per-burst count
+			0,   // HighScentAura     -- continuous emission, no per-burst count
+			0,   // DevoutChannel     -- continuous emission
+			0,   // BeggarStealthAura -- continuous emission
+			10,  // ChildToolRefusal  -- small sharp red-X burst
 		};
 
 		// Vertical offset added to burst-position Y. PriestAlert needs
@@ -67,6 +73,9 @@ namespace DP_Particles
 			0.1f,  // BogWaterSteam     (puddle level)
 			2.2f,  // PriestAlert       (above priest head; priest ~1.8 m)
 			0.9f,  // HighScentAura     (mid-body; the demonic stain reads as torso-emitted)
+			1.2f,  // DevoutChannel     (above villager head; candlelight reads as halo)
+			0.7f,  // BeggarStealthAura (mid-body; subtle ground-level haze)
+			1.1f,  // ChildToolRefusal  (chest level; the X "blocks" the item visually)
 		};
 
 		Flux_ParticleEmitterConfig* g_apxConfigs[kNumKinds] = { nullptr };
@@ -83,6 +92,7 @@ namespace DP_Particles
 		Zenith_EventHandle g_xSubBellRing             = INVALID_EVENT_HANDLE;
 		Zenith_EventHandle g_xSubItemEvaporated       = INVALID_EVENT_HANDLE;
 		Zenith_EventHandle g_xSubPriestAlerted        = INVALID_EVENT_HANDLE;
+		Zenith_EventHandle g_xSubChildToolRefused     = INVALID_EVENT_HANDLE;
 
 		// Test accessor backing storage.
 		uint32_t g_auBurstCounts[kNumKinds] = { 0 };
@@ -319,6 +329,89 @@ namespace DP_Particles
 			return p;
 		}
 
+		Flux_ParticleEmitterConfig* MakeDevoutChannel()
+		{
+			// Continuous emission while the player channels a Devout
+			// possession. Soft yellow / candlelight motes rising slowly
+			// around the channel target -- reads as ritualistic charge.
+			auto* p = new Flux_ParticleEmitterConfig();
+			p->m_fSpawnRate         = 26.0f;
+			p->m_uBurstCount        = 0;
+			p->m_uMaxParticles      = 72;
+			p->m_fLifetimeMin       = 0.6f;
+			p->m_fLifetimeMax       = 1.1f;
+			p->m_fSpawnRadius       = 0.5f;
+			p->m_xEmitDirection     = { 0.0f, 1.0f, 0.0f };
+			p->m_fSpreadAngleDegrees = 25.0f;
+			p->m_fSpeedMin          = 0.8f;
+			p->m_fSpeedMax          = 1.4f;
+			p->m_xGravity           = { 0.0f, 0.6f, 0.0f };
+			p->m_fDrag              = 0.4f;
+			p->m_xColorStart        = { 1.0f, 0.92f, 0.55f, 0.9f };  // candleflame
+			p->m_xColorEnd          = { 1.0f, 0.70f, 0.20f, 0.0f };
+			p->m_fSizeStart         = 0.10f;
+			p->m_fSizeEnd           = 0.05f;
+			p->m_bAdditiveBlending  = true;
+			p->m_bUseGPUCompute     = false;
+			return p;
+		}
+
+		Flux_ParticleEmitterConfig* MakeBeggarStealthAura()
+		{
+			// Continuous, dim grey haze around a possessed Beggar.
+			// Reads as "this villager is overlooked / unseen" -- the
+			// player learns that this body is functionally invisible
+			// to Aelfric.
+			auto* p = new Flux_ParticleEmitterConfig();
+			p->m_fSpawnRate         = 12.0f;
+			p->m_uBurstCount        = 0;
+			p->m_uMaxParticles      = 48;
+			p->m_fLifetimeMin       = 1.0f;
+			p->m_fLifetimeMax       = 1.8f;
+			p->m_fSpawnRadius       = 0.50f;
+			p->m_xEmitDirection     = { 0.0f, 1.0f, 0.0f };
+			p->m_fSpreadAngleDegrees = 40.0f;
+			p->m_fSpeedMin          = 0.2f;
+			p->m_fSpeedMax          = 0.6f;
+			p->m_xGravity           = { 0.0f, 0.0f, 0.0f };
+			p->m_fDrag              = 1.5f;
+			p->m_xColorStart        = { 0.55f, 0.55f, 0.55f, 0.35f }; // dim grey
+			p->m_xColorEnd          = { 0.70f, 0.70f, 0.75f, 0.0f };
+			p->m_fSizeStart         = 0.20f;
+			p->m_fSizeEnd           = 0.45f;
+			p->m_bAdditiveBlending  = false;
+			p->m_fTurbulence        = 0.3f;
+			p->m_bUseGPUCompute     = false;
+			return p;
+		}
+
+		Flux_ParticleEmitterConfig* MakeChildToolRefusal()
+		{
+			// Sharp red-X-like burst when a Child villager's
+			// auto-pickup is rejected. Bright, fast, brief -- meant to
+			// read as "no, blocked".
+			auto* p = new Flux_ParticleEmitterConfig();
+			p->m_fSpawnRate         = 0.0f;
+			p->m_uBurstCount        = 0;
+			p->m_uMaxParticles      = 20;
+			p->m_fLifetimeMin       = 0.25f;
+			p->m_fLifetimeMax       = 0.45f;
+			p->m_fSpawnRadius       = 0.10f;
+			p->m_xEmitDirection     = { 0.0f, 1.0f, 0.0f };
+			p->m_fSpreadAngleDegrees = 60.0f;
+			p->m_fSpeedMin          = 1.2f;
+			p->m_fSpeedMax          = 2.5f;
+			p->m_xGravity           = { 0.0f, -3.0f, 0.0f };
+			p->m_fDrag              = 1.0f;
+			p->m_xColorStart        = { 0.95f, 0.25f, 0.20f, 1.0f };  // alarm red
+			p->m_xColorEnd          = { 0.50f, 0.10f, 0.10f, 0.0f };
+			p->m_fSizeStart         = 0.10f;
+			p->m_fSizeEnd           = 0.04f;
+			p->m_bAdditiveBlending  = true;
+			p->m_bUseGPUCompute     = false;
+			return p;
+		}
+
 		// Build all eight configs in the right slot. Caller owns
 		// deallocation via Shutdown.
 		void BuildAllConfigs()
@@ -332,6 +425,9 @@ namespace DP_Particles
 			g_apxConfigs[static_cast<int>(Kind::BogWaterSteam)]     = MakeBogWaterSteam();
 			g_apxConfigs[static_cast<int>(Kind::PriestAlert)]       = MakePriestAlert();
 			g_apxConfigs[static_cast<int>(Kind::HighScentAura)]     = MakeHighScentAura();
+			g_apxConfigs[static_cast<int>(Kind::DevoutChannel)]     = MakeDevoutChannel();
+			g_apxConfigs[static_cast<int>(Kind::BeggarStealthAura)] = MakeBeggarStealthAura();
+			g_apxConfigs[static_cast<int>(Kind::ChildToolRefusal)]  = MakeChildToolRefusal();
 
 			for (int i = 0; i < kNumKinds; ++i)
 			{
@@ -402,6 +498,54 @@ namespace DP_Particles
 			// glyph), not the world telegraph.
 			Burst(Kind::PriestAlert, xEv.m_xPosition);
 		}
+
+		void OnChildToolRefused(const DP_OnChildToolRefused& xEv)
+		{
+			Burst(Kind::ChildToolRefusal, xEv.m_xPosition);
+		}
+
+		// Shared implementation for the continuous-emission per-villager
+		// auras (HighScent / DevoutChannel / BeggarStealth). Kept
+		// distinct from Burst() because the trigger condition is
+		// per-frame state, not an event.
+		void UpdateContinuousAura(Kind eKind, Zenith_EntityID xVillager, bool bShow)
+		{
+			if (!g_bInitialized) return;
+			const int iKind = static_cast<int>(eKind);
+			if (iKind < 0 || iKind >= kNumKinds) return;
+			Zenith_EntityID xEmitterId = g_axEmitterEntities[iKind];
+			if (!xEmitterId.IsValid()) return;
+			Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xEmitterId);
+			if (pxScene == nullptr) return;
+			Zenith_Entity xEnt = pxScene->TryGetEntity(xEmitterId);
+			if (!xEnt.IsValid()) return;
+			if (!xEnt.HasComponent<Zenith_ParticleEmitterComponent>()) return;
+			Zenith_ParticleEmitterComponent& xEmitter =
+				xEnt.GetComponent<Zenith_ParticleEmitterComponent>();
+			const bool bWantEmit = bShow && xVillager.IsValid();
+			if (!bWantEmit)
+			{
+				xEmitter.SetEmitting(false);
+				return;
+			}
+			Zenith_SceneData* pxVilScene = Zenith_SceneManager::GetSceneDataForEntity(xVillager);
+			if (pxVilScene == nullptr)
+			{
+				xEmitter.SetEmitting(false);
+				return;
+			}
+			Zenith_Entity xVilEnt = pxVilScene->TryGetEntity(xVillager);
+			if (!xVilEnt.IsValid() || !xVilEnt.HasComponent<Zenith_TransformComponent>())
+			{
+				xEmitter.SetEmitting(false);
+				return;
+			}
+			Zenith_Maths::Vector3 xPos;
+			xVilEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xPos);
+			xPos.y += kKindHeightOffset[iKind];
+			xEmitter.SetEmitPosition(xPos);
+			xEmitter.SetEmitting(true);
+		}
 	}
 
 	// =====================================================================
@@ -423,6 +567,7 @@ namespace DP_Particles
 		g_xSubBellRing            = xDispatcher.Subscribe<DP_OnBellRing>(&OnBellRing);
 		g_xSubItemEvaporated      = xDispatcher.Subscribe<DP_OnItemEvaporated>(&OnItemEvaporated);
 		g_xSubPriestAlerted       = xDispatcher.Subscribe<DP_OnPriestAlerted>(&OnPriestAlerted);
+		g_xSubChildToolRefused    = xDispatcher.Subscribe<DP_OnChildToolRefused>(&OnChildToolRefused);
 
 		for (int i = 0; i < kNumKinds; ++i) g_auBurstCounts[i] = 0;
 		for (int i = 0; i < kNumKinds; ++i) g_axEmitterEntities[i] = INVALID_ENTITY_ID;
@@ -443,6 +588,7 @@ namespace DP_Particles
 		xDispatcher.Unsubscribe(g_xSubBellRing);
 		xDispatcher.Unsubscribe(g_xSubItemEvaporated);
 		xDispatcher.Unsubscribe(g_xSubPriestAlerted);
+		xDispatcher.Unsubscribe(g_xSubChildToolRefused);
 		g_xSubDoorOpened          = INVALID_EVENT_HANDLE;
 		g_xSubDoorLockRejected    = INVALID_EVENT_HANDLE;
 		g_xSubChestOpened         = INVALID_EVENT_HANDLE;
@@ -451,6 +597,7 @@ namespace DP_Particles
 		g_xSubBellRing            = INVALID_EVENT_HANDLE;
 		g_xSubItemEvaporated      = INVALID_EVENT_HANDLE;
 		g_xSubPriestAlerted       = INVALID_EVENT_HANDLE;
+		g_xSubChildToolRefused    = INVALID_EVENT_HANDLE;
 
 		ClearEmitterEntities();
 		TearDownAllConfigs();
@@ -553,49 +700,17 @@ namespace DP_Particles
 
 	void UpdateHighScentAura(Zenith_EntityID xVillager, bool bShow)
 	{
-		if (!g_bInitialized) return;
-		const int iKind = static_cast<int>(Kind::HighScentAura);
+		UpdateContinuousAura(Kind::HighScentAura, xVillager, bShow);
+	}
 
-		// Resolve the aura emitter entity. If it wasn't created (e.g. a
-		// test loads ProcLevel but the bootstrap didn't run), bail.
-		Zenith_EntityID xEmitterId = g_axEmitterEntities[iKind];
-		if (!xEmitterId.IsValid()) return;
-		Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xEmitterId);
-		if (pxScene == nullptr) return;
-		Zenith_Entity xEnt = pxScene->TryGetEntity(xEmitterId);
-		if (!xEnt.IsValid()) return;
-		if (!xEnt.HasComponent<Zenith_ParticleEmitterComponent>()) return;
-		Zenith_ParticleEmitterComponent& xEmitter =
-			xEnt.GetComponent<Zenith_ParticleEmitterComponent>();
+	void UpdateBeggarStealthAura(Zenith_EntityID xVillager, bool bShow)
+	{
+		UpdateContinuousAura(Kind::BeggarStealthAura, xVillager, bShow);
+	}
 
-		const bool bWantEmit = bShow && xVillager.IsValid();
-		if (!bWantEmit)
-		{
-			xEmitter.SetEmitting(false);
-			return;
-		}
-
-		// Reposition the emitter at the villager's world position
-		// (plus the kind's vertical offset) + flip emission on. Done
-		// every frame so the aura follows the villager around the
-		// village rather than blooming once and staying put.
-		Zenith_SceneData* pxVilScene = Zenith_SceneManager::GetSceneDataForEntity(xVillager);
-		if (pxVilScene == nullptr)
-		{
-			xEmitter.SetEmitting(false);
-			return;
-		}
-		Zenith_Entity xVilEnt = pxVilScene->TryGetEntity(xVillager);
-		if (!xVilEnt.IsValid() || !xVilEnt.HasComponent<Zenith_TransformComponent>())
-		{
-			xEmitter.SetEmitting(false);
-			return;
-		}
-		Zenith_Maths::Vector3 xPos;
-		xVilEnt.GetComponent<Zenith_TransformComponent>().GetPosition(xPos);
-		xPos.y += kKindHeightOffset[iKind];
-		xEmitter.SetEmitPosition(xPos);
-		xEmitter.SetEmitting(true);
+	void UpdateDevoutChannelAura(Zenith_EntityID xVillager, bool bShow)
+	{
+		UpdateContinuousAura(Kind::DevoutChannel, xVillager, bShow);
 	}
 
 	uint32_t GetBurstCountForTest(Kind eKind)

--- a/Games/DevilsPlayground/Source/DPParticles.h
+++ b/Games/DevilsPlayground/Source/DPParticles.h
@@ -59,6 +59,18 @@ namespace DP_Particles
 		                        //   villager. Distinct from the other kinds: NOT
 		                        //   burst-based -- continuously emits while the
 		                        //   tracked villager has scent above threshold.
+		DevoutChannel     = 9,  // continuous candlelight motes around a Devout
+		                        //   being possessed while the 0.8 s channel
+		                        //   completes. Player feedback for "the
+		                        //   possession is in progress, don't move yet."
+		BeggarStealthAura = 10, // continuous dim grey halo around any possessed
+		                        //   Beggar. Telegraphs "you are invisible to
+		                        //   Aelfric" -- otherwise the Beggar-ignored
+		                        //   rule is a silent BridgePerception filter
+		                        //   the player can't see.
+		ChildToolRefusal  = 11, // one-shot red-X burst when a Child villager
+		                        //   tries to auto-pickup a tool (Iron / Key)
+		                        //   and the proximity-pickup is rejected.
 
 		COUNT
 	};
@@ -109,6 +121,18 @@ namespace DP_Particles
 	// INVALID_ENTITY_ID for xVillager OR bShow=false stops emission.
 	// Idempotent.
 	void UpdateHighScentAura(Zenith_EntityID xVillager, bool bShow);
+
+	// 2026-05-21: archetype-aware aura updates. Same shape as
+	// UpdateHighScentAura but for the Beggar + Devout effects.
+	// Called once per frame from DPPlayerController_Behaviour to
+	// track:
+	//   * The currently-possessed Beggar (BeggarStealthAura emits).
+	//   * The current Devout channel target during a 0.8 s channel
+	//     (DevoutChannel emits).
+	// Each is a SetEmitting(true) + SetEmitPosition call when the
+	// state holds; off otherwise. Idempotent.
+	void UpdateBeggarStealthAura(Zenith_EntityID xVillager, bool bShow);
+	void UpdateDevoutChannelAura(Zenith_EntityID xVillager, bool bShow);
 
 	// ----- Test accessors (ZENITH_INPUT_SIMULATOR only) -----
 	//

--- a/Games/DevilsPlayground/Source/PublicInterfaces.h
+++ b/Games/DevilsPlayground/Source/PublicInterfaces.h
@@ -299,6 +299,20 @@ struct DP_OnPriestAlerted
 	Zenith_Maths::Vector3   m_xPosition;    // priest world pos at alert (for the "!" billboard anchor)
 };
 
+// Child-archetype tool-pickup refusal (2026-05-21). Dispatched by
+// DPItemBase when the proximity-pickup path detects the possessed
+// villager is a Child AND the item tag is a tool (Iron / Key). The
+// pickup is silently rejected gameplay-side; this event surfaces the
+// rejection to the particles + tutorialisation systems so the
+// player can see "this villager can't carry that."
+struct DP_OnChildToolRefused
+{
+	Zenith_EntityID         m_xVillager;
+	Zenith_EntityID         m_xItem;
+	DP_ItemTag              m_eTag;          // the tool tag the Child refused
+	Zenith_Maths::Vector3   m_xPosition;     // villager world pos at refusal
+};
+
 // (DP_OnItemPickedUp lives at the top of the file -- its tag field
 // was extended 2026-05-21 to carry the picked-up tag so the
 // tutorialisation system + telemetry don't have to re-resolve.)

--- a/Games/DevilsPlayground/Tests/Test_P5Archetype_Telegraphs.cpp
+++ b/Games/DevilsPlayground/Tests/Test_P5Archetype_Telegraphs.cpp
@@ -1,0 +1,180 @@
+#include "Zenith.h"
+
+#ifdef ZENITH_INPUT_SIMULATOR
+
+#include "Core/Zenith_AutomatedTest.h"
+#include "EntityComponent/Zenith_SceneManager.h"
+#include "EntityComponent/Zenith_SceneData.h"
+#include "EntityComponent/Components/Zenith_TransformComponent.h"
+#include "EntityComponent/Components/Zenith_ParticleEmitterComponent.h"
+#include "EntityComponent/Zenith_EventSystem.h"
+#include "Maths/Zenith_Maths.h"
+
+#include "Source/PublicInterfaces.h"
+#include "Source/DevilsPlayground_Tags.h"
+#include "Source/DPParticles.h"
+#include "Components/DPVillager_Behaviour.h"
+
+#include <cstdio>
+
+// ============================================================================
+// Test_P5Archetype_Telegraphs (2026-05-21)
+//
+// Pins the three archetype-specific in-world telegraphs:
+//   * ChildToolRefusal -- one-shot red-X burst dispatched by DPItemBase
+//     when a possessed Child tries to auto-pickup a tool. Verified by
+//     dispatching DP_OnChildToolRefused directly + watching the burst
+//     counter increment.
+//   * UpdateBeggarStealthAura -- emitter toggles on with valid villager,
+//     off when bShow=false / villager invalid.
+//   * UpdateDevoutChannelAura -- same shape as BeggarStealthAura.
+//
+// All three are exercised in pure-namespace mode (no full gameplay
+// scene needed). The bootstrap creates the emitter entities; we
+// dispatch events / call the update APIs and observe the result.
+// ============================================================================
+
+namespace
+{
+	enum Phase : int { kP_Start, kP_WaitScene, kP_Run, kP_Verify, kP_Done };
+
+	int                     g_iPhase = kP_Start;
+	uint32_t                g_uChildRefusalBefore = 0;
+	uint32_t                g_uChildRefusalAfter = 0;
+	bool                    g_bBeggarOn = false;
+	bool                    g_bBeggarOff = true;
+	bool                    g_bDevoutOn = false;
+	bool                    g_bDevoutOff = true;
+	int                     g_iWait = 0;
+}
+
+static bool IsAuraEmitting(DP_Particles::Kind eKind)
+{
+	const Zenith_EntityID xId = DP_Particles::GetEmitterEntityForTest(eKind);
+	if (!xId.IsValid()) return false;
+	Zenith_SceneData* pxScene = Zenith_SceneManager::GetSceneDataForEntity(xId);
+	if (pxScene == nullptr) return false;
+	Zenith_Entity xEnt = pxScene->TryGetEntity(xId);
+	if (!xEnt.IsValid() || !xEnt.HasComponent<Zenith_ParticleEmitterComponent>()) return false;
+	return xEnt.GetComponent<Zenith_ParticleEmitterComponent>().IsEmitting();
+}
+
+static void Setup_P5ArchetypeTelegraphs()
+{
+	g_iPhase = kP_Start;
+	g_uChildRefusalBefore = 0;
+	g_uChildRefusalAfter = 0;
+	g_bBeggarOn = false;
+	g_bBeggarOff = true;
+	g_bDevoutOn = false;
+	g_bDevoutOff = true;
+	g_iWait = 0;
+}
+
+static bool Step_P5ArchetypeTelegraphs(int /*iFrame*/)
+{
+	switch (g_iPhase)
+	{
+	case kP_Start:
+		Zenith_SceneManager::LoadSceneByIndex(1, SCENE_LOAD_SINGLE);
+		g_iPhase = kP_WaitScene;
+		g_iWait = 0;
+		return true;
+
+	case kP_WaitScene:
+		++g_iWait;
+		if (g_iWait < 6) return true;
+		g_iPhase = kP_Run;
+		return true;
+
+	case kP_Run:
+	{
+		DP_Particles::ResetBurstCountsForTest();
+		g_uChildRefusalBefore =
+			DP_Particles::GetBurstCountForTest(DP_Particles::Kind::ChildToolRefusal);
+
+		// Pick any villager for the entity-arg slots.
+		Zenith_EntityID xAny;
+		DP_Query::ForEachScriptInActiveScene<DPVillager_Behaviour>(
+			[&xAny](Zenith_EntityID xId, DPVillager_Behaviour&)
+			{
+				if (!xAny.IsValid()) xAny = xId;
+			});
+
+		// Dispatch ChildToolRefusal event + expect a burst.
+		Zenith_EventDispatcher::Get().Dispatch(DP_OnChildToolRefused{
+			xAny, xAny, DP_ItemTag::Iron, Zenith_Maths::Vector3(10.f, 0.f, 10.f) });
+		g_uChildRefusalAfter =
+			DP_Particles::GetBurstCountForTest(DP_Particles::Kind::ChildToolRefusal);
+
+		// BeggarStealthAura: on with valid villager, off otherwise.
+		DP_Particles::UpdateBeggarStealthAura(xAny, true);
+		g_bBeggarOn = IsAuraEmitting(DP_Particles::Kind::BeggarStealthAura);
+		DP_Particles::UpdateBeggarStealthAura(xAny, false);
+		g_bBeggarOff = IsAuraEmitting(DP_Particles::Kind::BeggarStealthAura);
+
+		// DevoutChannel: same shape.
+		DP_Particles::UpdateDevoutChannelAura(xAny, true);
+		g_bDevoutOn = IsAuraEmitting(DP_Particles::Kind::DevoutChannel);
+		DP_Particles::UpdateDevoutChannelAura(xAny, false);
+		g_bDevoutOff = IsAuraEmitting(DP_Particles::Kind::DevoutChannel);
+
+		std::printf("[P5Archetype] child_burst=%u->%u beggarOn=%d beggarOff=%d devoutOn=%d devoutOff=%d\n",
+			g_uChildRefusalBefore, g_uChildRefusalAfter,
+			(int)g_bBeggarOn, (int)g_bBeggarOff, (int)g_bDevoutOn, (int)g_bDevoutOff);
+		std::fflush(stdout);
+		g_iPhase = kP_Done;
+		return false;
+	}
+
+	case kP_Done:
+	default:
+		return false;
+	}
+}
+
+static bool Verify_P5ArchetypeTelegraphs()
+{
+	if (g_uChildRefusalAfter <= g_uChildRefusalBefore)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5Archetype: ChildToolRefusal didn't burst on DP_OnChildToolRefused dispatch");
+		return false;
+	}
+	if (!g_bBeggarOn)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5Archetype: BeggarStealthAura didn't emit when UpdateBeggarStealthAura(villager, true) called");
+		return false;
+	}
+	if (g_bBeggarOff)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5Archetype: BeggarStealthAura still emitting after UpdateBeggarStealthAura(villager, false)");
+		return false;
+	}
+	if (!g_bDevoutOn)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5Archetype: DevoutChannel didn't emit when UpdateDevoutChannelAura(villager, true) called");
+		return false;
+	}
+	if (g_bDevoutOff)
+	{
+		Zenith_Log(LOG_CATEGORY_AI,
+			"P5Archetype: DevoutChannel still emitting after UpdateDevoutChannelAura(villager, false)");
+		return false;
+	}
+	return true;
+}
+
+static const Zenith_AutomatedTest g_xP5ArchetypeTest = {
+	"Test_P5Archetype_Telegraphs",
+	&Setup_P5ArchetypeTelegraphs,
+	&Step_P5ArchetypeTelegraphs,
+	&Verify_P5ArchetypeTelegraphs,
+	120
+};
+ZENITH_AUTOMATED_TEST_REGISTER(g_xP5ArchetypeTest);
+
+#endif // ZENITH_INPUT_SIMULATOR


### PR DESCRIPTION
## Summary

**Final PR in the in-game-feedback stack. Stacked on top of PR #130 + #131 + #132 + #133.** Diff is against `dp/demon-scent-functional-2026-05-21`.

Closes the "archetype rules are silent" gap. The 4 MVP archetypes (Farmhand / Beggar / Devout / Child) had functional gameplay rules but **zero in-world feedback** -- the only sign of the differences was the HUD's archetype-name label (added in PR #131).

## Three new particle Kinds

| Kind | Mode | Visual | Trigger |
|------|------|--------|---------|
| **BeggarStealthAura** | continuous | Dim grey haze | Possessing a Beggar |
| **DevoutChannel** | continuous | Candlelight motes | `DP_Player::IsChanneling()` true |
| **ChildToolRefusal** | one-shot burst | Red-X flash | DPItemBase Child-tool rejection branch |

## Gameplay teaching beats

- **Beggar**: pre-fix the Aelfric filter (`Priest_Behaviour::BridgePerceptionToBlackboard` skips Beggar candidates) was completely invisible. Now: possessed Beggar has a subtle aura that telegraphs "you are unseen."
- **Devout**: pre-fix the 0.8 s `TryVoluntaryPossessSwitch` channel was invisible -- click, wait, snap. Now: candlelight aura around the channel target during the channel.
- **Child**: pre-fix tool rejection was a bare `return` -- player saw "I walked over an Iron, nothing happened." Now: red-X burst on the rejected pickup.

## New event

```cpp
struct DP_OnChildToolRefused
{
    Zenith_EntityID         m_xVillager;
    Zenith_EntityID         m_xItem;
    DP_ItemTag              m_eTag;
    Zenith_Maths::Vector3   m_xPosition;
};
```

Dispatched from `DPItemBase` when the Child-tool branch rejects a proximity pickup.

## Refactor

DPParticles has a shared `UpdateContinuousAura(Kind, villager, bShow)` helper now. Removes the duplication between HighScent / Beggar / DevoutChannel update paths.

## Test plan

- [x] Build green
- [x] Full DP suite: **122/122 pass** (+1 new test: `Test_P5Archetype_Telegraphs`)
- [x] All three archetype telegraph paths pinned: ChildToolRefusal burst-counter check, BeggarStealthAura emit-toggle, DevoutChannel emit-toggle.

## Stack summary

| PR | Topic | Tests added |
|---|---|---:|
| #130 | Particle telegraphs (interactions + priest "!") | +1 |
| #131 | HUD telegraphs (locked-door / awareness / scent bar / archetype line) | +1 |
| #132 | First-encounter tutorialisation | +1 |
| #133 | Demon-scent functional consumer | +1 |
| #134 (this) | Archetype in-world telegraphs | +1 |

Total: 5 new tests, **122/122** suite, every issue from the state-of-the-game review (other than missing art assets) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)