### PR TITLE
fix(dp,tools): unblock P>=4 seed-matrix runner (skip unit tests)

### DIFF
--- a/Tools/dp_seed_matrix_run.ps1
+++ b/Tools/dp_seed_matrix_run.ps1
@@ -21,15 +21,19 @@
 # personality smoke test, vs2022_Debug_Win64_False):
 #   -Parallelism 1 :  182.6 s  (baseline serial)
 #   -Parallelism 2 :   57.7 s  (3.16x speedup)
-#   -Parallelism 3 :   45.9 s  (3.98x speedup -- sweet spot)
-#   -Parallelism 4 :  >5300 s  (Stealth hangs; UNSTABLE -- do not use)
+#   -Parallelism 3 :   45.9 s  (3.98x speedup)
+#   -Parallelism 4 :   27.9 s  (6.54x speedup, after --skip-unit-tests fix)
 #
-# At P>=4 the Stealth personality reliably hangs in a way that
-# Casual / Speedrunner / Zealot don't, even when running solo for
-# the last 30+ minutes after the other three finished. Root cause
-# unknown; suspected lifecycle deadlock between concurrent
-# devilsplayground.exe boots. Until that's debugged, the default
-# stays at 1 and the recommended manual setting is -Parallelism 3.
+# P>=4 history: prior to 2026-05-21, P>=4 reliably hung. The hang
+# was traced to the engine's unit-test suite, which runs on every
+# boot (before the automated-test handler kicks in) and writes
+# fixture files like test_nested_base.zpfb / TestData/round_trip_
+# test.zdata into the cwd with hardcoded paths. With 4+ concurrent
+# engine boots in the same cwd, two processes would race on a
+# fixture file and one would either assert on
+# "Reading past end of DataStream" or block on the file lock. The
+# fix is to pass --skip-unit-tests to the engine, which is safe
+# here because the dp-tests CI step runs unit tests independently.
 #
 # ASCII-only.
 
@@ -40,13 +44,13 @@ param(
     [int]$ExitAfterFrames  = 8500,
     [switch]$Headless      = $true,
     [uint64[]]$Seeds       = @(0, 12345, 99999),
-    # 2026-05-21: how many cells to run concurrently. Defaults to 1
-    # (legacy serial behaviour). On a 12-core machine 6-8 is a
-    # reasonable starting point -- each devilsplayground.exe is mostly
-    # single-threaded gameplay + thread-pool job dispatch, so
-    # over-subscription helps the job pool but starves the gameplay
-    # thread above ~N=cores/2.
-    [int]$Parallelism      = 1
+    # 2026-05-21: how many cells to run concurrently. Defaults to 4,
+    # the empirical sweet spot post-fix (6.54x speedup over serial).
+    # On a 12-core machine 6-8 is a reasonable next step to try --
+    # each devilsplayground.exe is mostly single-threaded gameplay +
+    # thread-pool job dispatch, so over-subscription helps the job
+    # pool but starves the gameplay thread above ~N=cores/2.
+    [int]$Parallelism      = 4
 )
 
 $ErrorActionPreference = "Stop"
@@ -143,7 +147,15 @@ $worker = {
         "--automated-test", $testName,
         "--exit-after-frames", "$ExitAfterFrames",
         "--fixed-dt", "0.01666",
-        "--test-results", $resultJson
+        "--test-results", $resultJson,
+        # 2026-05-21: unit tests run on every engine boot and write
+        # fixture files (test_nested_base.zpfb, TestData/round_trip_
+        # test.zdata, ~25 others) to the cwd with hardcoded paths.
+        # At P>=4, concurrent engine boots race on those fixtures
+        # and one of them asserts/hangs on a partially-written file.
+        # The dp-tests CI step runs unit tests independently, so
+        # skipping them here loses no coverage.
+        "--skip-unit-tests"
     )
     if ($Headless) { $procArgs += "--headless" }
 

--- a/Tools/dp_seed_matrix_run_debug.ps1
+++ b/Tools/dp_seed_matrix_run_debug.ps1
@@ -1,0 +1,192 @@
+# Debug variant of dp_seed_matrix_run.ps1 -- captures per-cell stdout
+# to a log file and tracks engine processes directly (no Start-Job
+# layer) so we can post-mortem hangs.
+#
+# Used 2026-05-21 to investigate the P=4 Stealth hang. Root cause:
+# unit tests run on every engine boot and write fixture files with
+# hardcoded paths into the cwd. 4 concurrent boots race on those
+# files; one process asserts on "Reading past end of DataStream"
+# or blocks reading a partially-written file. Production runner
+# passes --skip-unit-tests. To re-reproduce the race for regression
+# testing, run with -SkipUnitTests:$false.
+#
+# Usage:
+#   # Verify fix is good (should complete cleanly in ~28s):
+#   pwsh Tools/dp_seed_matrix_run_debug.ps1 -Parallelism 4
+#
+#   # Re-reproduce the bug (intermittent -- may need multiple runs):
+#   pwsh Tools/dp_seed_matrix_run_debug.ps1 -Parallelism 4 -IncludeUnitTests
+
+[CmdletBinding()]
+param(
+    [string]$ConfigName     = "Debug_False",
+    [string]$OutRoot        = "Build/dp_telemetry/seed_matrix_debug",
+    [int]$ExitAfterFrames   = 8500,
+    [switch]$Headless       = $true,
+    [uint64[]]$Seeds        = @(0),
+    [int]$Parallelism       = 4,
+    # Cap on wall-clock per cell. Cells exceeding this are killed so a
+    # hung Stealth doesn't block the whole batch for 90 minutes.
+    [int]$CellTimeoutSec    = 240,
+    # Pass -IncludeUnitTests to RE-INCLUDE unit tests on each engine
+    # boot, which reproduces the 2026-05-21 P=4 unit-test fixture
+    # race (intermittently). The production runner always passes
+    # --skip-unit-tests. Switch defaults to off, so by default this
+    # debug runner matches production and just completes cleanly.
+    [switch]$IncludeUnitTests
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$exeMap = @{
+    "Debug_True"    = "Games/DevilsPlayground/Build/output/win64/vs2022_debug_win64_true/devilsplayground.exe"
+    "Debug_False"   = "Games/DevilsPlayground/Build/output/win64/vs2022_debug_win64_false/devilsplayground.exe"
+    "Release_False" = "Games/DevilsPlayground/Build/output/win64/vs2022_release_win64_false/devilsplayground.exe"
+}
+$exe = $exeMap[$ConfigName]
+$exeAbs = (Resolve-Path $exe).Path
+$personalities = @("Casual","Stealth","Speedrunner","Zealot")
+
+New-Item -ItemType Directory -Path $OutRoot -Force | Out-Null
+
+$cells = @()
+foreach ($seed in $Seeds) {
+    foreach ($p in $personalities) {
+        $cells += @{ Seed = $seed; Personality = $p }
+    }
+}
+
+Write-Host ("DEBUG matrix: {0} cells, P={1}, CellTimeout={2}s" -f $cells.Count, $Parallelism, $CellTimeoutSec) -ForegroundColor Magenta
+Write-Host ("Output dir: {0}" -f $OutRoot) -ForegroundColor Magenta
+
+function Start-Cell {
+    param($Cell)
+    $prefix = "seed{0}_{1}" -f $Cell.Seed, $Cell.Personality
+    $logPath    = Join-Path $OutRoot ("{0}.log"     -f $prefix)
+    $errPath    = Join-Path $OutRoot ("{0}.err.log" -f $prefix)
+    $resultJson = Join-Path $OutRoot ("{0}.result.json" -f $prefix)
+    Remove-Item $logPath, $errPath, $resultJson -ErrorAction SilentlyContinue
+
+    $testName = "PersonalityPlaythrough_$($Cell.Personality)"
+    $procArgs = @(
+        "--automated-test", $testName,
+        "--exit-after-frames", "$ExitAfterFrames",
+        "--fixed-dt", "0.01666",
+        "--test-results", $resultJson
+    )
+    if ($Headless.IsPresent) { $procArgs += "--headless" }
+    if (-not $IncludeUnitTests.IsPresent) { $procArgs += "--skip-unit-tests" }
+
+    # Per-cell env vars: seed + temp prefix for parallel isolation.
+    $env:DP_PROCGEN_SEED    = "$($Cell.Seed)"
+    $env:DP_TEST_TMP_PREFIX = $prefix
+
+    $proc = Start-Process -FilePath $exeAbs -ArgumentList $procArgs `
+        -RedirectStandardOutput $logPath `
+        -RedirectStandardError  $errPath `
+        -NoNewWindow -PassThru
+
+    return [pscustomobject]@{
+        Seed        = $Cell.Seed
+        Personality = $Cell.Personality
+        Proc        = $proc
+        Pid         = $proc.Id
+        StartTime   = Get-Date
+        LogPath     = $logPath
+        ErrPath     = $errPath
+        ResultJson  = $resultJson
+        TimedOut    = $false
+    }
+}
+
+$running = @()
+$summary = @()
+$cellIndex = 0
+$batchStart = Get-Date
+
+# Prime the pool.
+while ($running.Count -lt $Parallelism -and $cellIndex -lt $cells.Count) {
+    $c = $cells[$cellIndex]; $cellIndex++
+    $entry = Start-Cell $c
+    Write-Host ("  [start] seed={0} personality={1} pid={2}" -f $entry.Seed, $entry.Personality, $entry.Pid) -ForegroundColor Cyan
+    $running += $entry
+}
+
+# Main poll loop.
+while ($running.Count -gt 0) {
+    Start-Sleep -Milliseconds 1000
+    $finished = @()
+    foreach ($entry in $running) {
+        $elapsed = (Get-Date) - $entry.StartTime
+        if ($entry.Proc.HasExited) {
+            $finished += $entry
+            continue
+        }
+        if ($elapsed.TotalSeconds -gt $CellTimeoutSec) {
+            Write-Host ("  [TIMEOUT] seed={0} personality={1} pid={2} elapsed={3:F0}s -- killing" `
+                -f $entry.Seed, $entry.Personality, $entry.Pid, $elapsed.TotalSeconds) -ForegroundColor Red
+            try {
+                # Snapshot the call stack of the process tree if Sysinternals procdump is on PATH.
+                $procdump = Get-Command procdump.exe -ErrorAction SilentlyContinue
+                if ($procdump) {
+                    $dumpPath = Join-Path $OutRoot ("seed{0}_{1}.dmp" -f $entry.Seed, $entry.Personality)
+                    Write-Host ("    procdump -> {0}" -f $dumpPath) -ForegroundColor DarkYellow
+                    & procdump.exe -accepteula -ma $entry.Pid $dumpPath 2>&1 | Out-Null
+                }
+            } catch {}
+            try { Stop-Process -Id $entry.Pid -Force -ErrorAction SilentlyContinue } catch {}
+            $entry.TimedOut = $true
+            $finished += $entry
+        }
+    }
+
+    foreach ($entry in $finished) {
+        $running = @($running | Where-Object { $_.Pid -ne $entry.Pid })
+        $elapsed = (Get-Date) - $entry.StartTime
+        $exitCode = if ($entry.Proc.HasExited) { $entry.Proc.ExitCode } else { -1 }
+        $logTail = if (Test-Path $entry.LogPath) {
+            (Get-Content $entry.LogPath -Tail 6 -ErrorAction SilentlyContinue) -join " | "
+        } else { "(no log)" }
+        $errTail = if ((Test-Path $entry.ErrPath) -and ((Get-Item $entry.ErrPath).Length -gt 0)) {
+            (Get-Content $entry.ErrPath -Tail 6 -ErrorAction SilentlyContinue) -join " | "
+        } else { "" }
+        $status = if ($entry.TimedOut) { "TIMEOUT" } elseif ($exitCode -eq 0) { "OK" } else { "EXIT=$exitCode" }
+        $color = if ($entry.TimedOut) { "Red" } elseif ($exitCode -eq 0) { "Green" } else { "Yellow" }
+        Write-Host ("  [done]  seed={0} personality={1} wall={2:F1}s status={3} pid={4}" `
+            -f $entry.Seed, $entry.Personality, $elapsed.TotalSeconds, $status, $entry.Pid) -ForegroundColor $color
+        if ($logTail.Length -gt 0) {
+            $trunc = if ($logTail.Length -gt 220) { $logTail.Substring($logTail.Length - 220) } else { $logTail }
+            Write-Host ("    out: " + $trunc) -ForegroundColor DarkGray
+        }
+        if ($errTail.Length -gt 0) {
+            $trunc = if ($errTail.Length -gt 220) { $errTail.Substring($errTail.Length - 220) } else { $errTail }
+            Write-Host ("    err: " + $trunc) -ForegroundColor DarkMagenta
+        }
+        $summary += [pscustomobject]@{
+            Seed        = $entry.Seed
+            Personality = $entry.Personality
+            WallSec     = [math]::Round($elapsed.TotalSeconds, 1)
+            Status      = $status
+            ExitCode    = $exitCode
+            LogPath     = $entry.LogPath
+        }
+    }
+
+    # Refill the pool.
+    while ($running.Count -lt $Parallelism -and $cellIndex -lt $cells.Count) {
+        $c = $cells[$cellIndex]; $cellIndex++
+        $entry = Start-Cell $c
+        Write-Host ("  [start] seed={0} personality={1} pid={2}" -f $entry.Seed, $entry.Personality, $entry.Pid) -ForegroundColor Cyan
+        $running += $entry
+    }
+}
+
+$totalElapsed = (Get-Date) - $batchStart
+Write-Host ""
+Write-Host ("Total: {0:F1}s" -f $totalElapsed.TotalSeconds) -ForegroundColor Magenta
+$summary | Format-Table -AutoSize | Out-String | Write-Host
+
+# Persist summary so caller can grep it.
+$summary | ConvertTo-Json | Set-Content -Path (Join-Path $OutRoot "summary.json")


### PR DESCRIPTION
## Summary

- **Diagnosis**: the seed-matrix runner's P=4 hang was traced to the engine running its full unit-test suite on every boot. Those tests write fixture files (`test_nested_base.zpfb`, `TestData/round_trip_test.zdata`, ~25 others) to the cwd with hardcoded relative paths. With 4 concurrent engine boots in the same cwd, two of them race on a fixture, and one either asserts on `Reading past end of DataStream` or blocks reading a partially-written file. The "Stealth-specific" symptom was a red herring -- Stealth was just the longest-running personality so it stayed alive after the other three died/finished.
- **Fix**: pass `--skip-unit-tests` to the engine. The `dp-tests` CI step runs unit tests independently, so this is safe.
- **Speedup**: P=4 now completes the 1-seed x 4-personality smoke in **27.9s**, vs 45.9s at P=3 (and the previous indefinite hang). Default `-Parallelism` bumped from 1 to 4 (6.54x speedup over serial).
- **Diagnostic tool**: also lands `Tools/dp_seed_matrix_run_debug.ps1`, a variant that captures per-cell stdout/stderr to log files and kills hung cells via per-cell timeout. Kept in-tree so the next concurrent-boot bug is half as much work to diagnose.

## Throughput numbers (1 seed x 4 personality, Debug_False)

| Parallelism | Wall    | Speedup |
|-------------|---------|---------|
| 1           | 182.6 s | 1.00x   |
| 2           |  57.7 s | 3.16x   |
| 3           |  45.9 s | 3.98x   |
| 4 (default) |  27.9 s | 6.54x   |

## Test plan

- [x] Repro the bug with debug runner -- captured the assertion + stuck file
- [x] Verify fixed P=4 completes cleanly with debug runner (27.9s, all 4 OK)
- [x] Verify fixed P=4 completes cleanly with production runner (34.7s incl. PNG visualisation, all 4 passed=True)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)