### PR TITLE
CI: fix the three master-red gates (engine-gate, layering-gate, scaffold-smoke)

### DIFF
--- a/.github/workflows/engine-gate.yml
+++ b/.github/workflows/engine-gate.yml
@@ -11,7 +11,8 @@
 #      Vulkan_Debug_True build also proves the engine lib transitively.
 #
 # Baseline lives in Tools/run_unit_gate.ps1 (-Baseline default); bump it there
-# AND in Tools/test_scaffold.ps1 together when adding engine unit tests.
+# when adding engine unit tests (Tools/test_scaffold.ps1 reuses the same script,
+# so there is exactly one place to bump).
 #
 # Rollout: land with workflow_dispatch; enable pull_request/push after two
 # green dispatch runs; mark required after a week of burn-in.

--- a/.github/workflows/scaffold-smoke.yml
+++ b/.github/workflows/scaffold-smoke.yml
@@ -7,8 +7,9 @@
 #
 # The gate is Tools/test_scaffold.ps1: `zenith new ScaffoldSmoke` -> per-game sln
 # exists -> builds Vulkan_vs2022_Debug_Win64_True -> boots headless with the
-# engine units baseline (1047) -> teardown removes Games/ScaffoldSmoke + regen ->
-# git status identical (scaffolding touched nothing outside Games/<Name>/).
+# engine units baseline (Tools/run_unit_gate.ps1 -Baseline default) -> teardown
+# removes Games/ScaffoldSmoke + regen -> git status identical (scaffolding
+# touched nothing outside Games/<Name>/).
 
 name: scaffold-smoke
 
@@ -55,6 +56,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The units-at-boot gate (run_unit_gate.ps1, via test_scaffold.ps1) runs
+          # the tool asset exports, which read the LFS-tracked source meshes +
+          # textures -- same requirement as engine-gate.yml.
+          lfs: true
 
       - name: Provision Zenith toolchain (MSBuild + vcpkg + Vulkan + Slang)
         uses: ./.github/actions/zenith-setup

--- a/Build/regen.ps1
+++ b/Build/regen.ps1
@@ -73,8 +73,21 @@ try {
     }
     else {
         $exe = Join-Path $repoRoot 'Sharpmake\Sharpmake.Application.exe'
-        if (-not (Test-Path $exe)) { Fail "Sharpmake.Application.exe not found at $exe." 3 }
-        cmd /c "`"$exe`" $sourcesArg"
+        if (Test-Path $exe) {
+            cmd /c "`"$exe`" $sourcesArg"
+        }
+        else {
+            # No locally built Sharpmake.Application.exe (fresh clone / CI runner).
+            # Fall back to the TRACKED Sharpmake.Application.dll via dotnet -- the
+            # same engine -UseDotnet selects explicitly. This keeps `zenith new`
+            # and regen working on runners that never build the exe
+            # (scaffold-smoke was red on every CI run without this).
+            $dll = Join-Path $repoRoot 'Sharpmake\Sharpmake.Application.dll'
+            if (-not (Test-Path $dll)) { Fail "Sharpmake.Application.exe not found at $exe and no Sharpmake.Application.dll at $dll." 3 }
+            if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) { Fail "Sharpmake.Application.exe not found at $exe and no 'dotnet' on PATH for the .dll fallback." 3 }
+            Write-Host "[regen] Sharpmake.Application.exe not found; falling back to 'dotnet exec Sharpmake.Application.dll'." -ForegroundColor DarkGray
+            cmd /c "dotnet exec `"$dll`" $sourcesArg"
+        }
     }
     $sharpmakeExit = $LASTEXITCODE
 }

--- a/Tools/run_unit_gate.ps1
+++ b/Tools/run_unit_gate.ps1
@@ -4,7 +4,7 @@
 # the single known layout-sensitive flake (GraphComponent::
 # RegistryWideNodeRoundTrip, task_726cc81d) as the SOLE failure.
 #
-# Usage:  pwsh ./Tools/run_unit_gate.ps1 -Exe <game exe> [-Baseline 1053]
+# Usage:  pwsh ./Tools/run_unit_gate.ps1 -Exe <game exe> [-Baseline 1068]
 # Exit:   0 = baseline met, 1 = anything else (missing exe, timeout, failures).
 #
 # ASCII-only body; runs under Windows PowerShell 5.1 and pwsh 7.
@@ -12,7 +12,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)][string]$Exe,
-    [int]$Baseline = 1053,
+    [int]$Baseline = 1068,
     [int]$TimeoutSec = 180,
     [string]$LogPath = ""
 )
@@ -72,7 +72,7 @@ Write-Host "[unit_gate] $($unitsLine.Trim())"
 # passed bucket to the skipped bucket, never off the ran count). Deliberate skips
 # are expected and are never a failure: RegistryWideNodeRoundTrip is quarantined
 # (task_726cc81d intermittent heap corruption), so a clean boot is
-# "1053 ran, 1052 passed, 0 failed, 1 skipped".
+# "1068 ran, 1067 passed, 0 failed, 1 skipped".
 if ($unitsLine -notmatch '(\d+)\s+ran,\s+(\d+)\s+passed,\s+(\d+)\s+failed(?:,\s+(\d+)\s+skipped)?') {
     Write-Error "[unit_gate] could not parse the tally from '$($unitsLine.Trim())' (log: $LogPath)"
     exit 1

--- a/Tools/test_scaffold.ps1
+++ b/Tools/test_scaffold.ps1
@@ -46,7 +46,11 @@ try {
     Check ($null -ne $msbuild) "msbuild resolved"
     if ($msbuild -and (Test-Path $sln)) {
         Write-Host "[scaffold] building $Name (Vulkan_vs2022_Debug_Win64_True)..." -ForegroundColor Cyan
-        & $msbuild $sln /t:$Name /p:Configuration=Vulkan_vs2022_Debug_Win64_True /p:Platform=x64 /m /nologo /v:minimal | Out-Host
+        # /p:WindowsTargetPlatformVersion=10.0 resolves to the newest installed
+        # Windows SDK -- CI runners don't carry the exact SDK the generated
+        # vcxprojs pin (MSB8036). Same override every CI msbuild invocation uses
+        # (dp-tests / zm-tests / engine-gate).
+        & $msbuild $sln /t:$Name /p:Configuration=Vulkan_vs2022_Debug_Win64_True /p:Platform=x64 /p:WindowsTargetPlatformVersion=10.0 /m /nologo /v:minimal | Out-Host
         Check ($LASTEXITCODE -eq 0) "game builds _True"
 
         $exe = Join-Path $gameDir "Build/output/win64/vulkan_vs2022_debug_win64_true/$($Name.ToLowerInvariant()).exe"

--- a/Tools/test_scaffold.ps1
+++ b/Tools/test_scaffold.ps1
@@ -56,22 +56,16 @@ try {
             Get-ChildItem (Join-Path $repoRoot 'Middleware/slang/bin/*.dll') -ErrorAction SilentlyContinue | ForEach-Object {
                 $d = Join-Path $dir $_.Name; if (-not (Test-Path $d)) { Copy-Item $_.FullName $d -Force }
             }
-            $bootOut = Join-Path $scratch "scaffold_boot_$Name.txt"
-            # Boot with unit tests ENABLED (the smoke's assertion). Bounded because
-            # games can hang at shutdown teardown (a known pre-existing behavior).
-            $p = Start-Process -FilePath $exe -ArgumentList @('--headless', '--exit-after-frames', '120', '--skip-tool-exports') `
-                -PassThru -NoNewWindow -RedirectStandardOutput $bootOut -RedirectStandardError "$bootOut.err"
-            if (-not $p.WaitForExit(180000)) { try { $p.Kill() } catch {} }
-            $txt = Get-Content $bootOut -ErrorAction SilentlyContinue
-            $unitsLine = "$(($txt | Select-String -Pattern 'Unit tests complete' | Select-Object -Last 1))"
-            $cleanPass = $unitsLine -match '1053 ran, 1053 passed, 0 failed'
-            # RegistryWideNodeRoundTrip is a known layout-sensitive pre-existing flake
-            # (task_726cc81d): the game's symbol layout can trip it. Tolerate it as
-            # the SOLE failure -- the engine still ran its full 1053-test suite.
-            $knownFlake = ($unitsLine -match '1053 ran, 1052 passed, 1 failed') -and
-                ($null -ne ($txt | Select-String -Pattern 'FAILED\s+GraphComponent::RegistryWideNodeRoundTrip'))
-            Check ($cleanPass -or $knownFlake) "units-at-boot: 1053 ran, 0 failed (or only the known RegistryWideNodeRoundTrip flake)"
-            if (-not ($cleanPass -or $knownFlake)) { Write-Host "    units line was: $unitsLine" -ForegroundColor Yellow }
+            # Boot with unit tests ENABLED (the smoke's assertion) via the canonical
+            # unit gate, so the engine baseline lives in ONE place
+            # (Tools/run_unit_gate.ps1 -Baseline default -- the same script
+            # engine-gate.yml runs). run_unit_gate deliberately keeps tool exports
+            # ON so the asset-export unit tests find their generated assets
+            # (see its header; the old inline boot here used --skip-tool-exports,
+            # which wedges on a from-scratch checkout with no generated assets).
+            & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $repoRoot 'Tools/run_unit_gate.ps1') `
+                -Exe $exe -LogPath (Join-Path $scratch "scaffold_boot_$Name.log")
+            Check ($LASTEXITCODE -eq 0) "units-at-boot baseline met (run_unit_gate.ps1)"
         }
     }
 }

--- a/Zenith/Flux/HDR/Flux_HDR.cpp
+++ b/Zenith/Flux/HDR/Flux_HDR.cpp
@@ -443,6 +443,7 @@ static void ExecuteBloomThreshold(Flux_CommandBuffer* pxCommandList, void* pUser
 	// Non-capturing graph trampoline: recover this subsystem instance, then
 	// route reach-ins through it and its injected member pointers.
 	Flux_HDRImpl& xHDR = g_xEngine.HDR();
+	Flux_GraphicsImpl& xFluxGraphics = g_xEngine.FluxGraphics();
 
 	// The pass's declared view slot selects this view's bloom chain + HDR scene
 	// target (slot 0 = main/swapchain, preview = 512² → 256² base). Texel sizes
@@ -456,12 +457,12 @@ static void ExecuteBloomThreshold(Flux_CommandBuffer* pxCommandList, void* pUser
 	xBloomConsts.m_xTexelSize = Zenith_Maths::Vector2(1.0f / xBloom0.m_xSurfaceInfo.m_uWidth, 1.0f / xBloom0.m_xSurfaceInfo.m_uHeight);
 
 	pxCommandList->SetPipeline(&xHDR.m_xBloomThresholdPipeline);
-	pxCommandList->SetVertexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetVertexBuffer());
-	pxCommandList->SetIndexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetIndexBuffer());
+	pxCommandList->SetVertexBuffer(xFluxGraphics.m_xQuadMesh.GetVertexBuffer());
+	pxCommandList->SetIndexBuffer(xFluxGraphics.m_xQuadMesh.GetIndexBuffer());
 
 	namespace BT = Flux_Generated_HDR::BloomThreshold;
 	Flux_ShaderBinder xBinder(*pxCommandList);
-	xBinder.BindSRV(BT::hg_xHDRTex, &g_xEngine.FluxGraphics().GetSceneColourForPostFX(uViewSlot).SRV(), &g_xEngine.FluxGraphics().m_xClampSampler);
+	xBinder.BindSRV(BT::hg_xHDRTex, &xFluxGraphics.GetSceneColourForPostFX(uViewSlot).SRV(), &xFluxGraphics.m_xClampSampler);
 	xBinder.BindDrawConstants(BT::hBloomConstants, &xBloomConsts, sizeof(BloomConstants));
 
 	pxCommandList->DrawIndexed(6);
@@ -474,6 +475,7 @@ static void ExecuteBloomDownsample(Flux_CommandBuffer* pxCommandList, void* pUse
 	// Non-capturing graph trampoline: recover this subsystem instance, then
 	// route reach-ins through it and its injected member pointers.
 	Flux_HDRImpl& xHDR = g_xEngine.HDR();
+	Flux_GraphicsImpl& xFluxGraphics = g_xEngine.FluxGraphics();
 
 	// UserData carries the MIP only; the view comes from the recording pass's
 	// declared slot (mirrors the HiZ per-view conversion).
@@ -489,12 +491,12 @@ static void ExecuteBloomDownsample(Flux_CommandBuffer* pxCommandList, void* pUse
 	xBloomConsts.m_xTexelSize = Zenith_Maths::Vector2(1.0f / xSource.m_xSurfaceInfo.m_uWidth, 1.0f / xSource.m_xSurfaceInfo.m_uHeight);
 
 	pxCommandList->SetPipeline(&xHDR.m_xBloomDownsamplePipeline);
-	pxCommandList->SetVertexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetVertexBuffer());
-	pxCommandList->SetIndexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetIndexBuffer());
+	pxCommandList->SetVertexBuffer(xFluxGraphics.m_xQuadMesh.GetVertexBuffer());
+	pxCommandList->SetIndexBuffer(xFluxGraphics.m_xQuadMesh.GetIndexBuffer());
 
 	namespace BD = Flux_Generated_HDR::BloomDownsample;
 	Flux_ShaderBinder xBinder(*pxCommandList);
-	xBinder.BindSRV(BD::hg_xSourceTex, &xSource.SRV(), &g_xEngine.FluxGraphics().m_xClampSampler);
+	xBinder.BindSRV(BD::hg_xSourceTex, &xSource.SRV(), &xFluxGraphics.m_xClampSampler);
 	xBinder.BindDrawConstants(BD::hBloomConstants, &xBloomConsts, sizeof(BloomConstants));
 
 	pxCommandList->DrawIndexed(6);
@@ -509,6 +511,7 @@ static void ExecuteBloomUpsample(Flux_CommandBuffer* pxCommandList, void* pUserD
 	// Non-capturing graph trampoline: recover this subsystem instance, then
 	// route reach-ins through it and its injected member pointers.
 	Flux_HDRImpl& xHDR = g_xEngine.HDR();
+	Flux_GraphicsImpl& xFluxGraphics = g_xEngine.FluxGraphics();
 
 	// UserData carries the upsample step only; the view comes from the recording
 	// pass's declared slot (mirrors the HiZ per-view conversion).
@@ -521,12 +524,12 @@ static void ExecuteBloomUpsample(Flux_CommandBuffer* pxCommandList, void* pUserD
 	xBloomConsts.m_xTexelSize = Zenith_Maths::Vector2(1.0f / xTarget.m_xSurfaceInfo.m_uWidth, 1.0f / xTarget.m_xSurfaceInfo.m_uHeight);
 
 	pxCommandList->SetPipeline(&xHDR.m_xBloomUpsamplePipeline);
-	pxCommandList->SetVertexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetVertexBuffer());
-	pxCommandList->SetIndexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetIndexBuffer());
+	pxCommandList->SetVertexBuffer(xFluxGraphics.m_xQuadMesh.GetVertexBuffer());
+	pxCommandList->SetIndexBuffer(xFluxGraphics.m_xQuadMesh.GetIndexBuffer());
 
 	namespace BU = Flux_Generated_HDR::BloomUpsample;
 	Flux_ShaderBinder xBinder(*pxCommandList);
-	xBinder.BindSRV(BU::hg_xSourceTex, &xHDR.GetBloomChainAttachment(uSourceMip, uViewSlot).SRV(), &g_xEngine.FluxGraphics().m_xClampSampler);
+	xBinder.BindSRV(BU::hg_xSourceTex, &xHDR.GetBloomChainAttachment(uSourceMip, uViewSlot).SRV(), &xFluxGraphics.m_xClampSampler);
 	xBinder.BindDrawConstants(BU::hBloomConstants, &xBloomConsts, sizeof(BloomConstants));
 
 	pxCommandList->DrawIndexed(6);
@@ -539,6 +542,7 @@ static void ExecuteToneMapping(Flux_CommandBuffer* pxCommandList, void* pUserDat
 	// Non-capturing graph trampoline: recover this subsystem instance, then
 	// route reach-ins through it and its injected member pointers.
 	Flux_HDRImpl& xHDR = g_xEngine.HDR();
+	Flux_GraphicsImpl& xFluxGraphics = g_xEngine.FluxGraphics();
 
 	ToneMappingConstants xConsts;
 	xConsts.m_fExposure = xHDR.m_fExposure;
@@ -551,14 +555,14 @@ static void ExecuteToneMapping(Flux_CommandBuffer* pxCommandList, void* pUserDat
 	xConsts.m_uPad1 = 0;
 
 	pxCommandList->SetPipeline(&xHDR.m_xToneMappingPipeline);
-	pxCommandList->SetVertexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetVertexBuffer());
-	pxCommandList->SetIndexBuffer(g_xEngine.FluxGraphics().m_xQuadMesh.GetIndexBuffer());
+	pxCommandList->SetVertexBuffer(xFluxGraphics.m_xQuadMesh.GetVertexBuffer());
+	pxCommandList->SetIndexBuffer(xFluxGraphics.m_xQuadMesh.GetIndexBuffer());
 
 	{
 		namespace TM = Flux_Generated_HDR::HDR_ToneMapping;
 		Flux_ShaderBinder xBinder(*pxCommandList);
-		xBinder.BindSRV(TM::hg_xHDRTex, &g_xEngine.FluxGraphics().GetSceneColourForPostFX().SRV());
-		xBinder.BindSRV(TM::hg_xBloomTex, &xHDR.GetBloomChainAttachment(0).SRV(), &g_xEngine.FluxGraphics().m_xClampSampler);
+		xBinder.BindSRV(TM::hg_xHDRTex, &xFluxGraphics.GetSceneColourForPostFX().SRV());
+		xBinder.BindSRV(TM::hg_xBloomTex, &xHDR.GetBloomChainAttachment(0).SRV(), &xFluxGraphics.m_xClampSampler);
 		// Slang reflection keys on the variable name (not the GLSL block
 		// name) — match the names declared in Flux_ToneMapping.slang.
 		xBinder.BindUAV_Buffer(TM::hg_auHistogram,   &xHDR.m_xHistogramBuffer.GetUAV());


### PR DESCRIPTION
## Summary

All three gates have been red on **master** since 2026-07-07/08 (verified via run history), so every open PR inherits the failures — including [#143](https://github.com/tomosh22/Zenith/pull/143), which is otherwise green (zm-tests passed first try).

- **engine-gate**: unit baseline 1053 → 1068 (recent engine commits added 15 tests, all passing; the ratchet wasn't bumped). The baseline now lives ONLY in `Tools/run_unit_gate.ps1` — `test_scaffold.ps1` reuses that script instead of its stale inline copy (which still said 1053 and used `--skip-tool-exports`, the known from-scratch-checkout wedge).
- **layering-gate**: `Flux_HDR.cpp` `g_xEngine` count crept to 45 vs the allowlisted 42. Hoisted `g_xEngine.FluxGraphics()` into the existing `xHDR`-style local in the four bloom/tonemap trampolines (fixed, not allow-listed; no behavior change).
- **scaffold-smoke**: red since its introduction — `zenith new` regens without `-UseDotnet` and CI runners have no locally built `Sharpmake.Application.exe`. `regen.ps1` now falls back to `dotnet exec` on the tracked `Sharpmake.Application.dll` when the exe is absent. Its checkout also gains `lfs: true` for the units-at-boot asset-export tests (same as engine-gate).

## Verification (all local)

- `Tools/run_unit_gate.ps1` vs Combat_True: **PASS** — `1068 ran, 1067 passed, 0 failed, 1 skipped`
- `Tools\CheckComplexity.bat --gate-group architecture,lints`: clean (no findings)
- regen with `Sharpmake.Application.exe` hidden: falls back to dotnet, exit 0
- `Tools/test_scaffold.ps1` end-to-end: **11 passed / 0 failed** (was 6/2 on CI)
- Combat_True rebuilds clean with the Flux_HDR change

🤖 Generated with [Claude Code](https://claude.com/claude-code)