### PR TITLE
Zenithmon Docs: close out S0 (gate met, protection active, checklist ticked)

### DIFF
--- a/Games/Zenithmon/CLAUDE.md
+++ b/Games/Zenithmon/CLAUDE.md
@@ -8,8 +8,10 @@ procedurally generated and baked by tools builds.
 > S0-S12 stage plan. `Docs/AgentBriefing.md` is the session onboarding guide;
 > `Docs/Scope.md` is the binding in/out list. Game code uses the `ZM_` prefix.
 
-Current stage: **S0** (skeleton + harness + CI + Docs). The game today is the
-scaffold placeholder: one lit cube bobbing under a title.
+Current stage: **S0 COMPLETE** (merged 2026-07-10; `zm-tests` is a required
+check). Next per `Docs/Roadmap.md`: S1 (data core) in parallel with S3 (first
+overworld). The game today is the scaffold placeholder: one lit cube bobbing
+under a title.
 
 ## File structure
 

--- a/Games/Zenithmon/Docs/CIPolicy.md
+++ b/Games/Zenithmon/Docs/CIPolicy.md
@@ -13,8 +13,7 @@ AssetManifest.md (why the runner has no assets).
 **Status:** LIVING -- update whenever a gate is added/retired or branch
 protection changes.
 
-**Last updated:** 2026-07-09 (S0 -- zm-tests.yml written, first PR pending;
-required-check registration NOT yet done).
+**Last updated:** 2026-07-10 (S0 closed -- zm-tests green on PRs #143/#144 and registered as a required branch-protection check; see section 4).
 
 ---
 
@@ -93,19 +92,28 @@ protection (Settings -> Branches), not in this file; keep the table above in
 sync when gates change. `release-build` (nightly) and `scaffold-smoke`
 (burn-in) are documented as non-blocking by their own headers.
 
-## 4. Branch protection: adding `zm-tests` (MANUAL step, pending)
+## 4. Branch protection: `zm-tests` required (ACTIVE since 2026-07-10)
 
-GitHub only offers a check name in the required-checks picker after it has
-reported at least once, so the flow is:
+Master branch protection now exists and requires `zm-tests`. History + the
+exact shape (because it differs from the original plan in two ways):
 
-1. Open the first Zenithmon PR (S0 skeleton); let `zm-tests` run green.
-2. A human adds `zm-tests` to the master branch-protection required checks
-   via the GitHub web UI -- the exact click path is spelled out in
-   ManualSetupChecklist.md. **This cannot be done by an agent and is still
-   pending as of S0.**
+1. The first Zenithmon PR (#143, S0 skeleton) put a green `zm-tests` run on
+   record; the follow-up CI-fix PR (#144) made the whole gate set green.
+2. Master had **no branch protection and no rulesets at all** -- the
+   "required checks" discipline had been purely conventional. Classic branch
+   protection was CREATED (user-directed, via `gh api PUT
+   .../branches/master/protection`): required status checks `[zm-tests]`
+   with `strict=false`, `enforce_admins=false`, no required reviews.
 
-Until that box is ticked, zm-tests runs on every PR but does not BLOCK
-merges; treat it as blocking by discipline in the meantime.
+Consequences of that shape:
+- `zm-tests` BLOCKS every non-admin merge into master.
+- `enforce_admins=false` means the repo owner's direct pushes bypass the
+  check -- deliberate, matching the established direct-push workflow. Agent
+  work always lands via PRs, so agents are always gated.
+- Only `zm-tests` is machine-enforced; the other gates in section 3 remain
+  blocking BY DISCIPLINE (nothing merges red, section 5). Add them to the
+  protection contexts only deliberately -- several are path-filtered and a
+  required check that never reports deadlocks the PR.
 
 ## 5. Merge policy
 

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,41 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-016 -- Master branch protection CREATED with `zm-tests` as the sole machine-enforced required check
+
+- **Decision:** master had NO branch protection and no rulesets at all (the
+  repo's "required checks" had been purely conventional). On the user's
+  direction ("Add zm-tests yourself"), classic branch protection was created
+  via the API: required status checks `[zm-tests]`, `strict=false`,
+  `enforce_admins=false`, no required reviews.
+- **Why:** the S0 gate requires zm-tests to actually block merges;
+  `enforce_admins=false` preserves the owner's established direct-push
+  workflow (agents always land via PRs, so agents are always gated). Other
+  gates stay blocking-by-discipline because several are path-filtered and a
+  required check that never reports deadlocks a PR.
+- **Tests that lock it:** none (GitHub configuration); verified by
+  `gh api repos/tomosh22/Zenith/branches/master/protection`.
+- **Reversibility:** trivial (delete/edit the protection rule); recorded in
+  CIPolicy.md section 4 + ManualSetupChecklist.md.
+
+## 2026-07-10 -- ZM-D-015 -- Three pre-existing master-red CI gates fixed as a prerequisite PR rather than inherited red
+
+- **Decision:** engine-gate, layering-gate, and scaffold-smoke had been red on
+  master since 2026-07-07/08 (before Zenithmon existed). Rather than merging
+  S0 with inherited red checks, they were fixed in a dedicated PR (#144,
+  `0844689e`): unit baseline 1053->1068 single-sourced in
+  `Tools/run_unit_gate.ps1` (test_scaffold.ps1 reuses it), `Flux_HDR.cpp`
+  g_xEngine reaches reduced via the established local-hoist idiom (fixed, not
+  allow-listed), and regen.ps1 given a dotnet-exec fallback on the tracked
+  Sharpmake dll (+ scaffold-smoke got `lfs: true` and the standard
+  `/p:WindowsTargetPlatformVersion=10.0` build override).
+- **Why:** "nothing merges red" is only meaningful if master itself can go
+  green; every future Zenithmon stage PR needs a green baseline.
+- **Tests that lock it:** the gates themselves (all 9 checks green on #144;
+  all 10 green on the rebased #143); scaffold smoke 11/0 locally.
+- **Reversibility:** each fix is independent and small; the baseline bump is
+  a ratchet (future engine-test additions bump it again in ONE place).
+
 ## 2026-07-09 -- ZM-D-014 -- Engine name-validation narrowed to a PascalCase word boundary so 'Zenithmon' is a legal game name
 
 - **Decision:** `zenith new Zenithmon` was rejected by the blanket

--- a/Games/Zenithmon/Docs/ManualSetupChecklist.md
+++ b/Games/Zenithmon/Docs/ManualSetupChecklist.md
@@ -13,16 +13,17 @@ item is completed.
 below), CIPolicy.md (what zm-tests is and why it must become a required
 check).
 
-**Last updated:** 2026-07-09 (S0 -- nothing verified yet).
+**Last updated:** 2026-07-10 (S0 close -- ALL items verified; see notes for the
+two spots where reality differs from the original expectation).
 
 ---
 
-## A. GitHub repository configuration (web UI)
+## A. GitHub repository configuration
 
 | Done | Item | How to verify / do it | Verified by / date |
 |---|---|---|---|
-| [ ] | **GitHub Actions enabled** on the repo. The pre-existing gates (dp-tests, cb-tests, complexity-gate, layering-gate, memory-gate, engine-gate, shader-validation, doc-lint -- see CIPolicy.md section 3) should already be running on PRs, which proves this. | Repo -> Actions tab shows recent workflow runs; or Settings -> Actions -> General -> "Allow all actions" | |
-| [ ] | **Add `zm-tests` to master branch-protection required checks** -- AFTER the first green zm-tests run (GitHub only lists check names that have reported at least once; the S0 skeleton PR provides that run). UI path: Settings -> Branches -> edit the `master` rule -> "Require status checks to pass before merging" -> search for `zm-tests` in the status-check picker -> add -> Save changes. | Settings -> Branches -> master rule lists `zm-tests` under required status checks; a scratch PR with a deliberately red zm-tests shows merging blocked | |
+| [x] | **GitHub Actions enabled** on the repo. The pre-existing gates (dp-tests, cb-tests, complexity-gate, layering-gate, memory-gate, engine-gate, shader-validation, doc-lint -- see CIPolicy.md section 3) should already be running on PRs, which proves this. | Repo -> Actions tab shows recent workflow runs; or Settings -> Actions -> General -> "Allow all actions" | Claude session / 2026-07-10 (all gates ran on PRs #143/#144) |
+| [x] | **Add `zm-tests` to master branch-protection required checks** -- AFTER the first green zm-tests run. NOTE (2026-07-10): master had NO branch protection and no rulesets at all, so classic protection was CREATED via the API (user-directed): required contexts `[zm-tests]`, `strict=false`, `enforce_admins=false` (owner direct pushes bypass -- the repo's established workflow). | `gh api repos/tomosh22/Zenith/branches/master/protection` lists `zm-tests` under required_status_checks.contexts | Claude session (user-directed) / 2026-07-10 |
 
 Ordering note: item 2 is deliberately AFTER the first PR -- setting a
 required check before the check name exists deadlocks all merges.
@@ -31,17 +32,17 @@ required check before the check name exists deadlocks all merges.
 
 | Done | Item | How to verify | Verified by / date |
 |---|---|---|---|
-| [ ] | **Visual Studio 2022 toolset** installed with the "Desktop development with C++" workload (this machine uses the 18/Insiders MSBuild layout -- either works). | `vswhere.exe -products * -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath` returns a path | |
-| [ ] | **Vulkan SDK 1.3.290.0** installed (the CI-pinned version). | `$env:VULKAN_SDK` points at 1.3.290.0; `Test-Path "$env:VULKAN_SDK\Include\vulkan\vulkan.h"` is true | |
-| [ ] | **Slang 2026.1** DLL tree available. | `Test-Path Middleware\slang\bin\slang.dll` is true | |
-| [ ] | **.NET SDK 6.0+** (Sharpmake regen) and **Git 2.30+**. | `dotnet --version` >= 6.0; `git --version` >= 2.30 | |
+| [x] | **Visual Studio 2022 toolset** installed with the "Desktop development with C++" workload (this machine uses the 18/Insiders MSBuild layout -- either works). | `vswhere.exe -products * -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath` returns a path | Claude session / 2026-07-10 (all S0 builds via 18/Insiders MSBuild) |
+| [x] | **Vulkan SDK** installed. CI pins 1.3.290.0; this machine has **1.4.313.1** (newer than the pin -- fine; the pin matters only for the CI runner provisioning). | `Test-Path "$env:VULKAN_SDK\Include\vulkan\vulkan.h"` is true | Claude session / 2026-07-10 (1.4.313.1) |
+| [x] | **Slang 2026.1** DLL tree available. | `Test-Path Middleware\slang\bin\slang.dll` is true | Claude session / 2026-07-10 |
+| [x] | **.NET runtime** (for `dotnet exec` -- Sharpmake regen's fallback path; the full SDK is NOT required since regen executes the tracked prebuilt dll) and **Git 2.30+**. | `dotnet exec Sharpmake\Sharpmake.Application.dll` works (exercised by the regen fallback); `git --version` >= 2.30 | Claude session / 2026-07-10 (runtime present, SDK absent -- sufficient; git 2.46.2) |
 
 ## C. First local build + bake (per BuildEnvironment.md section 3)
 
 | Done | Item | How to verify | Verified by / date |
 |---|---|---|---|
-| [ ] | **First Vulkan_True build + run executed once locally** -- `zenith build Zenithmon` (config `Vulkan_vs2022_Debug_Win64_True`) then `zenith run Zenithmon`. The tools boot bakes `FrontEnd.zscen` (+ all generated assets, which are git-ignored and therefore absent on a fresh checkout). Without this, `_False` builds have no scene to load. | `Test-Path Games\Zenithmon\Assets\Scenes\FrontEnd.zscen` is true after the run; the exe boots to the FrontEnd title screen | |
-| [ ] | **Headless test suite green locally** -- `zenith test Zenithmon --headless` (or the pwsh form from BuildEnvironment.md section 4.1) exits 0. S0 expectation: 1 automated test passed / 0 failed, plus the boot unit tests reported at engine boot. | Runner prints the pass/fail summary and exits 0 | |
+| [x] | **First Vulkan_True build + run executed once locally** -- `zenith build Zenithmon` (config `Vulkan_vs2022_Debug_Win64_True`) then `zenith run Zenithmon`. The tools boot bakes `FrontEnd.zscen` (+ all generated assets, which are git-ignored and therefore absent on a fresh checkout). Without this, `_False` builds have no scene to load. | `Test-Path Games\Zenithmon\Assets\Scenes\FrontEnd.zscen` is true after the run; the exe boots to the FrontEnd title screen | Claude session / 2026-07-10 |
+| [x] | **Headless test suite green locally** -- `zenith test Zenithmon --headless` (or the pwsh form from BuildEnvironment.md section 4.1) exits 0. S0 expectation: 1 automated test passed / 0 failed, plus the boot unit tests reported at engine boot. | Runner prints the pass/fail summary and exits 0 | Claude session / 2026-07-10 (1/1 automated; 1070 boot units, 0 failed) |
 
 ---
 

--- a/Games/Zenithmon/Docs/Questions.md
+++ b/Games/Zenithmon/Docs/Questions.md
@@ -10,20 +10,6 @@
 
 ## Open
 
-### [OPEN] Q-2026-07-09-001 -- Branch protection for `zm-tests` requires a manual GitHub-UI step
-
-**Question:** when will `zm-tests` be registered as a REQUIRED status check on master?
-
-**Context:** `.github/workflows/zm-tests.yml` is written and runs on every PR/push from S0, but adding it to the required-checks list is a manual GitHub-UI step only the user can perform (tracked in ManualSetupChecklist.md; policy in CIPolicy.md). Until it is flipped, a red `zm-tests` run does not technically block a merge.
-
-**Best-guess action taken:** proceeding without it. The workflow still runs on every PR; agents treat a red `zm-tests` as a hard merge blocker by convention and note the CI result in the PR body. The S0 gate item stays unticked in Roadmap.md until the user flips it.
-
-**Cost if wrong:** moderate. A regression could auto-merge on a red run that an agent failed to notice; the next session would inherit a broken master. Bounded by the convention above and by every session starting with a baseline `zenith test Zenithmon --headless` run.
-
-**Status:** asked 2026-07-09. Acting on best guess.
-
----
-
 ### [OPEN] Q-2026-07-09-002 -- Terrain bake time for ~25 terrains is an unmeasured estimate
 
 **Question:** is the ~25-terrain plan (one terrain set per outdoor scene via engine change E1) affordable in bake time and file volume, or should routes share terrain sheets?
@@ -54,4 +40,13 @@
 
 ## Resolved
 
-(none yet)
+### [RESOLVED] Q-2026-07-09-001 -- Branch protection for `zm-tests`
+
+**Resolution (2026-07-10):** the user directed the agent to do it ("Add
+zm-tests yourself"). Discovery: master had NO branch protection and no
+rulesets at all -- the required-checks discipline had been purely
+conventional. Classic branch protection was created via
+`gh api PUT .../branches/master/protection` with required contexts
+`[zm-tests]`, `strict=false`, `enforce_admins=false` (owner direct pushes
+bypass; agent PRs are always gated). Full shape + consequences: CIPolicy.md
+section 4; checklist item ticked in ManualSetupChecklist.md.

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -12,7 +12,7 @@
 
 ---
 
-## S0 -- Skeleton, harness, CI, Docs (S-M) -- IN PROGRESS
+## S0 -- Skeleton, harness, CI, Docs (S-M) -- COMPLETE (2026-07-10)
 
 - [x] Scaffold via `zenith new Zenithmon` (`Zenithmon.zproj` + `Zenithmon.cpp` + game component + boot characterization test from `Build/Templates/NewGame`, then regen)
 - [x] Engine change: game-name validators (`Test-ZenithGameNameSyntax` in `Build/zenith_buildsystem.psm1` + `ZenithHub_GameScan::ValidateName`) narrowed from blanket `Zenith*`/`Sentinel*` prefixes to a PascalCase word boundary; shared pinned vectors (`Tools/ZenithCli/Tests/name_validation_cases.txt`) + buildsystem tests updated (suite 45 / 0)
@@ -22,10 +22,10 @@
 - [x] Between-tests hook + `Zenith_SaveData::Initialise("Zenithmon")` at boot (`Zenith_SaveData::ClearForTest` registered from S0)
 - [x] `.github/workflows/zm-tests.yml` (dp-tests clone: zenith-setup, regen -UseDotnet, Vulkan_True build, D3D12_False link proof, DLL copies, headless boot check, `zenith test Zenithmon --headless`, results artifact)
 - [x] `Docs/` seeded (Status / Roadmap / Questions / Shortfalls living docs + the reference docs per the plan's Docs table)
-- [ ] First PR from `zenithmon/s0-skeleton` opened and merged with `zm-tests` green
-- [ ] MANUAL (user): add `zm-tests` to required branch-protection checks (GitHub UI -- see Questions.md Q-2026-07-09-001, ManualSetupChecklist.md)
+- [x] First PR from `zenithmon/s0-skeleton` opened and merged with `zm-tests` green (PR #143, rebase-merged as `4c35f55d` + `4e57c680`, all 10 checks green; en route, PR #144 `0844689e` fixed the 3 PRE-EXISTING master-red gates: engine-gate baseline 1053->1068, layering-gate Flux_HDR hoists, scaffold-smoke regen dotnet-fallback + lfs + SDK override)
+- [x] `zm-tests` registered as a required branch-protection check (2026-07-10, user-directed via API -- master had NO protection at all, so classic protection was created: contexts `[zm-tests]`, strict=false, enforce_admins=false; see CIPolicy.md section 4)
 
-*Gate:* exe boots windowed + headless; `zenith test Zenithmon --headless` exits 0; **first PR through zm-tests green**. (Local build + headless suite already green as of 2026-07-09.)
+*Gate:* **MET 2026-07-10** -- exe boots windowed + headless; `zenith test Zenithmon --headless` exits 0; first PR through zm-tests green.
 
 ## S1 -- Data core (M) -- parallel with S3/S4
 

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,38 +1,35 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-09 -- S0 skeleton complete on branch `zenithmon/s0-skeleton`; first PR about to open.
+**Last updated:** 2026-07-10 -- **S0 COMPLETE and merged to master; gate met.**
 
 **Read this first each session.** This file is REPLACED at every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the honest gap audit.
 
 ## Build
 
-GREEN. `Vulkan_vs2022_Debug_Win64_True` builds clean via `zenith build Zenithmon` (per-game sln `Games/Zenithmon/zenithmon_win64.sln`, always `/t:Zenithmon` -- never whole-sln).
+GREEN on master. `Vulkan_vs2022_Debug_Win64_True` + `D3D12_vs2022_Debug_Win64_False` (link proof) both clean via `zenith build Zenithmon` (per-game sln, always `/t:Zenithmon` -- never whole-sln).
 
 ## Tests
 
-- Unit: **2 / 2 passed** (`Tests/ZM_Tests_Boot.cpp`, `ZENITH_TEST` boot suite).
-- Automated: **1 / 1 passed** (`ZM_Boot_Test` in `Tests/ZM_AutoTests_Boot.cpp`); `zenith test Zenithmon --headless` exits 0.
-- Runner is the unified `zenith test <Game>` harness (`Tools/ZenithCli/ZenithCli.psm1` -> `ZenithTestHarness.psm1`; flags `--filter/--headless/--results-dir/--config/--per-process/--fail-fast`; exit codes 0 OK / 1 usage / 2 validation / 3 generation / 4 build-or-test / 5 not-found). The old per-game `Tools/run_*_tests.ps1` scripts were DELETED at commit `c29e28f8` -- never reference them as current.
+- Unit: **2 / 2 ZM tests passed** inside the 1070-test boot suite (0 failed).
+- Automated: **1 / 1 passed** (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0; windowed `--filter ZM_Boot_Test` run also green.
+- CI: **zm-tests green on every run so far** and now a REQUIRED branch-protection check (CIPolicy.md section 4).
+
+## What landed (S0, merged 2026-07-10)
+
+- **PR #143** (rebase-merged as `4c35f55d` + `4e57c680`): name-validator PascalCase-word-boundary narrowing (unblocks the name "Zenithmon"); the game skeleton (ZM_ conventions, boot-authored FrontEnd.zscen at build index 0, SaveData init + between-tests hook, hello unit/automated tests); `.github/workflows/zm-tests.yml`; this 17-file Docs base incl. the full GDD.
+- **PR #144** (`0844689e`, squash): fixed the 3 PRE-EXISTING master-red gates -- engine-gate (unit baseline 1053->1068, single-sourced in `Tools/run_unit_gate.ps1`; `test_scaffold.ps1` now reuses it), layering-gate (`Flux_HDR.cpp` g_xEngine 45->~35 via local hoists), scaffold-smoke (regen.ps1 dotnet-fallback when `Sharpmake.Application.exe` is absent + `lfs: true` checkout + `/p:WindowsTargetPlatformVersion=10.0` on the smoke build -- its first green EVER).
+- **Branch protection created** (user-directed): master requires `zm-tests`; `enforce_admins=false`. ManualSetupChecklist.md is now fully ticked.
 
 ## Current task
 
-**S0 PR.** Open the first PR from `zenithmon/s0-skeleton`, watch `zm-tests` go green, merge. The S0 gate (see [Roadmap.md](Roadmap.md)) also requires the manual branch-protection step below.
-
-## Last completed (this session, 2026-07-09)
-
-1. **Scaffold:** `zenith new Zenithmon` (`Zenithmon.zproj` + `Zenithmon.cpp` `Project_*` entry points + regen; per-game sln generated).
-2. **Engine change (name validators):** the blanket `Zenith*`/`Sentinel*` reserved-prefix rule rejected the name "Zenithmon". Both validators -- PS `Test-ZenithGameNameSyntax` in `Build/zenith_buildsystem.psm1` and C++ `ZenithHub_GameScan::ValidateName` -- were narrowed to a PascalCase word boundary: reject `Zenith`/`Sentinel` alone or followed by an uppercase letter/digit; a lowercase continuation (e.g. `Zenithmon`) is a distinct word and valid. Shared pinned vectors in `Tools/ZenithCli/Tests/name_validation_cases.txt` + buildsystem tests updated; suite 45 passed / 0 failed.
-3. **ZM_ conventions applied:** `ZM_GameComponent` (registered `"ZM_Game"`, serialization order 100, S0 placeholder bobbing cube); boot-authored `FrontEnd.zscen` at build index 0 (camera + "Zenithmon" title text + game component; authored by tools builds, git-ignored).
-4. **Persistence from day one:** `Zenith_SaveData::Initialise("Zenithmon")` at boot + between-tests hook registered (`Zenith_SaveData::ClearForTest`).
-5. **Tests:** 2 boot unit tests (`ZM_Tests_Boot.cpp`) + 1 automated boot test (`ZM_AutoTests_Boot.cpp`), both green locally.
-6. **CI:** `.github/workflows/zm-tests.yml` written (clone of `dp-tests.yml`): `zenith-setup` action (Vulkan SDK 1.3.290.0, Slang 2026.1) -> `Build/regen.ps1 -UseDotnet` -> `Vulkan_vs2022_Debug_Win64_True` build -> `D3D12_vs2022_Debug_Win64_False` backend-neutrality link proof -> DLL copies -> headless boot check -> `zenith.bat test Zenithmon --headless --results-dir Build/artifacts/test_results/zenithmon` -> artifact `zm-test-results`.
-7. **Docs:** `Games/Zenithmon/Docs/` knowledge base seeded (this file + siblings).
+None in flight. **Next up per [Roadmap.md](Roadmap.md): two parallel tracks open** --
+1. **S1 data core** (pure headless C++, `Source/Data/`: ZM_Types/TypeChart/SpeciesData/MoveData/ItemData/AbilityData stubs/NatureData/StatCalc/BattleRNG + WorldSpec skeleton + DataRegistry; gate ~90 unit tests). No engine changes; safe to run fully parallel.
+2. **S3 first overworld** (starts with engine changes E1 terrain-set paths + E2 rect export, each with unit tests + RenderTest boot regression).
+S2 (battle engine) follows S1; S4 (asset generators) can run alongside.
 
 ## Notes for the next agent
 
-- **Branch:** `zenithmon/s0-skeleton`. If its PR has merged, branch fresh off master for the next stage.
-- **MANUAL STEP PENDING:** registering `zm-tests` as a required branch-protection check is a GitHub-UI step only the user can do (see Questions.md Q-2026-07-09-001 and ManualSetupChecklist.md). Until it is flipped, treat a red `zm-tests` run as a hard merge blocker by convention.
-- **Next after S0:** two parallel tracks open up -- **S1 data core** (pure headless C++, `Source/Data/`) and **S3 first overworld** (starts with engine changes E1 terrain-set paths + E2 rect export). S2 follows S1; S4 can run alongside. MSBuild dispatch is SERIAL (mspdbsrv constraint) -- parallelism is code-authoring, not builds.
-- **Hard rules (locked, see Scope.md):** game-code prefix `ZM_`; ~150 original species / original names everywhere (zero Nintendo IP -- mainline MECHANICS only); no audio (engine has none); no networking/multiplayer/trading; no Dynamax-analog; battle format singles only; game data tables are compiled C arrays, not disk assets; baked assets are git-ignored.
-- **CI/assets gotcha:** baked assets (incl. `FrontEnd.zscen`) are git-ignored, so a fresh CI checkout has NO `Assets/` -- every asset/scene-dependent automated test must exists-guard + `RequestSkip` (the CI-fix pattern from commit `94813489`).
-- **Session discipline:** replace this file at session end; tick Roadmap.md checkboxes only when the PR is merged AND CI is green; log decisions in DecisionLog.md; log blockers in Questions.md and proceed on best guess.
+- Branch fresh off master (`git pull` first; master tip after S0 = `4e57c680`).
+- **Gotchas from S0 (all verified):** bare `game.exe --exit-after-frames N` NEVER exits (per-test override only -- use `zenith test --filter` or `--list-automated-tests`); `gh run rerun` re-uses the run's ORIGINAL merge commit (rebase+push to re-evaluate a PR against new master); in sandboxed agent sessions use `pwsh -File Tools\zenith.ps1 ...` / `pwsh -File Build\regen.ps1` (the 5.1 `zenith.bat` shim hits a Get-FileHash resolution quirk there; CI + user machines unaffected).
+- **Hard rules (locked, see Scope.md):** `ZM_` prefix; ~150 original species / original names (zero Nintendo IP); no audio; no networking/trading; no Dynamax-analog; singles only; game data = compiled C arrays; baked assets git-ignored (asset-dependent tests exists-guard + RequestSkip).
+- **Session discipline:** replace this file at session end; tick Roadmap.md boxes only when the PR is merged AND CI green; DecisionLog.md is append-only; serial MSBuild dispatch (never build in parallel agents).


### PR DESCRIPTION
Docs-only follow-up completing the S0 stage-gate governance: Roadmap S0 marked COMPLETE with the final two boxes ticked, Status.md session-end replacement, CIPolicy section 4 updated to the now-ACTIVE branch protection (created via API on the user's direction -- master previously had no protection at all), ManualSetupChecklist fully verified, Q-2026-07-09-001 resolved, DecisionLog entries ZM-D-015/016 appended.

Merge on green zm-tests (now machine-enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)