### PR TITLE
feat(zm): S1 - ZM_Types + ZM_TypeChart (18-type golden-locked chart) + CI unit gate

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -143,6 +143,21 @@ jobs:
               exit 1
           }
 
+      - name: Run boot unit tests (engine + Zenithmon ZM_* suites)
+        shell: pwsh
+        run: |
+          # The enumerate step and `zenith test` both pass --skip-unit-tests for
+          # speed, so the boot ZENITH_TEST suite -- engine units PLUS Zenithmon's
+          # ZM_* data-core cases (the S1+ gate backbone) -- is exercised here via the
+          # shared engine-gate helper. It boots headless with tool-exports ON (some
+          # engine unit tests reload generated assets), watchdog-kills the known
+          # tools-build idle after the units line is logged, and asserts the full
+          # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
+          # engine) unit-test count changes -- see Docs/CIPolicy.md.
+          $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1079
+          if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
+
       - name: Run Zenithmon tests
         shell: pwsh
         run: |

--- a/Games/Zenithmon/Docs/CIPolicy.md
+++ b/Games/Zenithmon/Docs/CIPolicy.md
@@ -13,7 +13,7 @@ AssetManifest.md (why the runner has no assets).
 **Status:** LIVING -- update whenever a gate is added/retired or branch
 protection changes.
 
-**Last updated:** 2026-07-10 (S0 closed -- zm-tests green on PRs #143/#144 and registered as a required branch-protection check; see section 4).
+**Last updated:** 2026-07-10 (S1 start -- added the boot unit-test gate step (section 1 step 8) so Zenithmon `ZM_*` unit tests actually run in CI; see DecisionLog ZM-D-019).
 
 ---
 
@@ -41,10 +41,23 @@ pattern), active from S0. Required check name: **`zm-tests`**.
      vulkan-1.dll -- see BuildEnvironment.md section 5).
   7. Headless boot check: `zenithmon.exe --list-automated-tests
      --skip-tool-exports --skip-unit-tests --headless` must exit 0.
-  8. `zenith.bat test Zenithmon --headless --results-dir
-     Build/artifacts/test_results/zenithmon`.
-  9. Upload the per-test JSON as artifact **`zm-test-results`**
+  8. **Boot unit tests** (`Tools/run_unit_gate.ps1 -Exe <zenithmon.exe>
+     -Baseline N`): boots headless with tool-exports ON, runs the ZENITH_TEST
+     suite (engine units + Zenithmon `ZM_*` cases), and fails on any failure or a
+     count != baseline. Steps 7 and 9 both pass `--skip-unit-tests`, so this is
+     the ONLY step that runs the unit suite -- the S1+ data-core gate backbone.
+  9. `zenith.bat test Zenithmon --headless --results-dir
+     Build/artifacts/test_results/zenithmon` (the automated/P1 suite).
+  10. Upload the per-test JSON as artifact **`zm-test-results`**
      (`if: always()` -- results survive red runs).
+
+**Unit-test baseline ratchet:** step 8's `-Baseline` is the exact registered
+unit-test count of `zenithmon.exe` (engine units + `ZM_*` cases; currently
+**1079**, of which 1 is the quarantined `RegistryWideNodeRoundTrip` skip). Every
+PR that changes the `ZM_*` count -- and any engine PR that changes the engine
+unit count -- bumps this number in `zm-tests.yml` in the same PR. This mirrors
+engine-gate's discipline and guards against unit tests silently vanishing; the
+coupling-vs-simplicity trade-off is Questions.md Q-2026-07-10-004.
 
 ## 2. Runner constraints -- why headless pure-logic suites are the backbone
 
@@ -129,11 +142,14 @@ Consequences of that shape:
 1. **Fix forward ON the PR.** Push fixes to the same branch; the
    concurrency group cancels the superseded run automatically. Never merge
    around a red gate, never remove the check to unblock a PR.
-2. **Reproduce locally first:** `zenith test Zenithmon --headless` mirrors
-   the CI command exactly (BuildEnvironment.md section 4). If it is green
-   locally but red in CI, suspect the two runner constraints (section 2) --
-   an asset-dependent test missing its exists-guard/RequestSkip, or a
-   graphics dependency missing its `m_bRequiresGraphics` tag.
+2. **Reproduce locally first:** `zenith test Zenithmon --headless` mirrors the
+   CI automated/P1 step (BuildEnvironment.md section 4). For a red UNIT test,
+   reproduce the boot gate instead -- `Tools/run_unit_gate.ps1 -Exe
+   <zenithmon.exe> -Baseline <N>`, or boot `zenithmon.exe --list-automated-tests
+   --headless` WITHOUT `--skip-unit-tests` -- because `zenith test` skips unit
+   tests. If green locally but red in CI, suspect the two runner constraints
+   (section 2) -- an asset-dependent test missing its exists-guard/RequestSkip,
+   or a graphics dependency missing its `m_bRequiresGraphics` tag.
 3. **Get data, don't theorize:** pull the `zm-test-results` artifact and
    the step logs (the boot-check step prints head+tail of engine output on
    failure) before forming a theory.

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,53 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-019 -- Zenithmon boot unit tests are gated in CI via a run_unit_gate.ps1 boot step (ratcheted baseline)
+
+- **Decision:** `zm-tests.yml` gains a step that boots `zenithmon.exe` headless
+  through the shared `Tools/run_unit_gate.ps1` (`-Baseline 1079`) to run the boot
+  ZENITH_TEST suite (engine units + Zenithmon `ZM_*` cases) and fail on any
+  failure. The baseline is an exact-count ratchet (like engine-gate): each PR that
+  changes the `ZM_*` unit count -- or an engine PR that changes the engine unit
+  count -- bumps the number in the same PR.
+- **Why:** discovered while landing S1 -- both `zenith test` (harness default) and
+  the two prior zm-tests steps pass `--skip-unit-tests`, so Zenithmon's unit tests
+  (the S1/S2 gate backbone, ~460 cases at end state) NEVER ran in CI. The plan
+  designates the boot unit suite as the CI backbone; DP/CB never hit this because
+  they carry almost no game-side unit tests. `run_unit_gate.ps1` is the proven
+  engine-gate pattern (tool-exports ON so asset-export units work; watchdog-kills
+  the known tools-build idle after the units line is logged).
+- **Tests that lock it:** the step itself (red on any unit failure or count !=
+  baseline); validated locally = "1079 ran, 1078 passed, 0 failed, 1 skipped" (the
+  1 skip is the pre-existing quarantined `GraphComponent::RegistryWideNodeRoundTrip`).
+- **Reversibility:** easy -- delete the step. The baseline's coupling to the
+  engine unit count is the known maintenance cost (CIPolicy.md section 1); a
+  follow-up may switch to a failures-only check if the ratchet churns
+  (Questions.md Q-2026-07-10-004).
+
+## 2026-07-10 -- ZM-D-018 -- Type system: save-stable ZM_TYPE enum + golden-locked 18x18 chart with a dual-type product API
+
+- **Decision:** the 18 types are one `enum ZM_TYPE : u_int` (`Source/Data/ZM_Types.h`)
+  in the GDD-section-6 order, which is simultaneously the dex/UI order and the
+  row/column order of the chart; the range is append-only (save-stable). The
+  effectiveness matrix is a `const` 18x18 float table (`ZM_TypeChart.cpp`) of
+  {0, 0.5, 1, 2}, mapping the standard 18-type relationships onto the original
+  names. Lookups are a stateless namespace `ZM_TypeChart`:
+  `GetEffectiveness(atk, def)` + `GetDualTypeEffectiveness(atk, def1, def2)`, where
+  `def2 == ZM_TYPE_NONE` (== `ZM_TYPE_COUNT`) collapses to the single lookup and a
+  duplicated slot is never squared.
+- **Why:** types are consumed by species/moves/damage from S1 on; a save-stable
+  enum + a compiled table keeps zero file I/O in headless tests (ZM-D-009) and
+  makes the chart diffable. The dual-type product belongs with the chart (4x /
+  0.25x / 0x matchups) and is testable before species exist.
+- **Tests that lock it:** `Tests/ZM_Tests_Data.cpp` -- `TypeChart_MatchesGolden`
+  (an independent golden 18x18 compiled into the TU: the two-place-change lock,
+  TestPlan 5.1), `TypeChart_AllCellsLegal`, `TypeChart_ImmunityCountIsEight`, the
+  GDD design-intent spot checks (`StarterTriangle`, `SecondTriangleAndGhostNormal`,
+  `DrakeChecks`, `ImmunitiesAndIronWall`), `TypeChart_DualTypeProducts`,
+  `Types_ToStringContract`.
+- **Reversibility:** easy -- additive `Source/Data/` files, no engine change;
+  reordering/renaming types is a save-migration concern only after content ships.
+
 ## 2026-07-10 -- ZM-D-017 -- Docs/ becomes a self-sufficient autonomy hub: MasterPlan committed, lifecycle-loop prompt, hard-stop visual gates, permission allowlist
 
 - **Decision (user-directed):** the Docs directory must carry the whole

--- a/Games/Zenithmon/Docs/Questions.md
+++ b/Games/Zenithmon/Docs/Questions.md
@@ -36,6 +36,32 @@
 
 **Status:** asked 2026-07-09. Verified or falsified at the S5 screenshot gate (see Roadmap.md).
 
+### [OPEN] Q-2026-07-10-004 -- Unit-test verification gap in `zenith test` + baseline-ratchet churn
+
+**Question:** `zenith test Zenithmon --headless` (the loop's verify command) passes
+`--skip-unit-tests`, so it does NOT run the `ZM_*` unit suite -- only the new CI
+boot step (ZM-D-019) and a direct exe boot do. Should the CLI grow a
+`zenith test --unit-tests` flag (or run units by default for a single game), and
+should the CI unit gate keep the exact-count baseline or switch to a failures-only
+check?
+
+**Context:** found while landing S1's first unit tests. The exact-count baseline
+(1079) couples zm-tests to the engine unit count -- an unrelated engine PR that
+changes that count reddens zm-tests until the baseline is bumped. A failures-only
+check (assert the "Unit tests complete" line shows 0 failed, ignore the count)
+avoids the coupling but no longer catches a silently-vanishing `ZM_` test.
+
+**Best-guess action taken:** kept the exact-baseline ratchet (matches engine-gate,
+strongest guarantee) and verify unit tests locally via a direct exe boot
+(`--list-automated-tests --headless` without `--skip-unit-tests`, or
+`Tools/run_unit_gate.ps1`) until a CLI flag lands. Bump rule documented in
+CIPolicy.md section 1.
+
+**Cost of getting it wrong:** low. Both are small, localized changes; the ratchet's
+only symptom is an occasional one-line baseline bump caught immediately by red CI.
+
+**Status:** asked 2026-07-10; acting on best guess.
+
 ---
 
 ## Resolved

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -29,7 +29,7 @@
 
 ## S1 -- Data core (M) -- parallel with S3/S4
 
-- [ ] `ZM_Types.h` + `ZM_TypeChart` (18 types)
+- [x] `ZM_Types.h` + `ZM_TypeChart` (18 types) -- 18-type `enum ZM_TYPE` + golden-locked 18x18 chart + dual-type product; 9 `ZM_Data` unit tests (PR #147). Also wired the boot unit suite into CI (ZM-D-019).
 - [ ] `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets)
 - [ ] `ZM_MoveData` (~220 moves as table rows over a ~60-kind `ZM_MOVE_EFFECT` enum)
 - [ ] `ZM_ItemData` (~80 + TMs)

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,42 +1,33 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S0 COMPLETE and merged to master; gate met.**
+**Last updated:** 2026-07-10 -- **S1 started: type chart landed; ZM_* unit tests now gate in CI.**
 
-**Read this first each session.** This file is REPLACED at every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the honest gap audit.
+**Read this first each session.** Replaced at every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the honest gap audit.
 
 ## Build
 
-GREEN on master. `Vulkan_vs2022_Debug_Win64_True` + `D3D12_vs2022_Debug_Win64_False` (link proof) both clean via `zenith build Zenithmon` (per-game sln, always `/t:Zenithmon` -- never whole-sln).
+GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon` (per-game sln, `/t:Zenithmon`). D3D12_False link proof runs in CI.
 
 ## Tests
 
-- Unit: **2 / 2 ZM tests passed** inside the 1070-test boot suite (0 failed).
-- Automated: **1 / 1 passed** (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0; windowed `--filter ZM_Boot_Test` run also green.
-- CI: **zm-tests green on every run so far** and now a REQUIRED branch-protection check (CIPolicy.md section 4).
+- Unit (T0, category `ZM_Data`): **1079 ran, 1078 passed, 0 failed, 1 skipped** at boot (the 1 skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). +9 over the S0 baseline = the new type-chart suite.
+- Automated (P1): **1 / 1 passed** (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
+- **CI now runs the unit suite** (this iteration's fix, ZM-D-019): `zm-tests.yml` boots `zenithmon.exe` via `Tools/run_unit_gate.ps1 -Baseline 1079`. Before this, BOTH `zenith test` and the zm-tests steps passed `--skip-unit-tests`, so no ZM unit test ran in CI.
 
-## What landed (S0, merged 2026-07-10)
+## What landed (this iteration -- PR #147)
 
-- **PR #143** (rebase-merged as `4c35f55d` + `4e57c680`): name-validator PascalCase-word-boundary narrowing (unblocks the name "Zenithmon"); the game skeleton (ZM_ conventions, boot-authored FrontEnd.zscen at build index 0, SaveData init + between-tests hook, hello unit/automated tests); `.github/workflows/zm-tests.yml`; this 17-file Docs base incl. the full GDD.
-- **PR #144** (`0844689e`, squash): fixed the 3 PRE-EXISTING master-red gates -- engine-gate (unit baseline 1053->1068, single-sourced in `Tools/run_unit_gate.ps1`; `test_scaffold.ps1` now reuses it), layering-gate (`Flux_HDR.cpp` g_xEngine 45->~35 via local hoists), scaffold-smoke (regen.ps1 dotnet-fallback when `Sharpmake.Application.exe` is absent + `lfs: true` checkout + `/p:WindowsTargetPlatformVersion=10.0` on the smoke build -- its first green EVER).
-- **Branch protection created** (user-directed): master requires `zm-tests`; `enforce_admins=false`. ManualSetupChecklist.md is now fully ticked.
+- **S1 first Roadmap task:** `Source/Data/ZM_Types.h` (`enum ZM_TYPE : u_int`, 18 GDD types, `ZM_TypeToString`) + `ZM_TypeChart` (const 18x18 effectiveness table + `GetEffectiveness` + `GetDualTypeEffectiveness`) + 9 `Tests/ZM_Tests_Data.cpp` cases (golden-matrix two-place lock, GDD design-intent spot checks, dual-type products, ToString). DecisionLog ZM-D-018.
+- **CI unit-test gate** wired into `zm-tests.yml` (DecisionLog ZM-D-019) so the S1/S2 unit backbone actually runs on every PR. Docs updated: CIPolicy §1/§6, TestPlan §4, Questions Q-2026-07-10-004.
 
 ## Current task
 
-None in flight. **Next up per [Roadmap.md](Roadmap.md): two parallel tracks open** --
-1. **S1 data core** (pure headless C++, `Source/Data/`: ZM_Types/TypeChart/SpeciesData/MoveData/ItemData/AbilityData stubs/NatureData/StatCalc/BattleRNG + WorldSpec skeleton + DataRegistry; gate ~90 unit tests). No engine changes; safe to run fully parallel.
-2. **S3 first overworld** (starts with engine changes E1 terrain-set paths + E2 rect export, each with unit tests + RenderTest boot regression).
-S2 (battle engine) follows S1; S4 (asset generators) can run alongside.
+None in flight (once PR #147 merges). **Next per [Roadmap.md](Roadmap.md): S1 second box -- `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets).** Then MoveData / ItemData / AbilityData+NatureData / StatCalc+BattleRNG / WorldSpec skeleton / DataRegistry. S3 (overworld, engine E1/E2) is the parallel track.
 
 ## Notes for the next agent
 
-- **The project now runs on the lifecycle loop:** StartPrompts.md prompt 0 is
-  one idempotent iteration (resume in-flight work or take the next Roadmap
-  task; PR -> CI -> merge -> docs; hard-stop at visual gates with a GATE-WAIT
-  marker here). MasterPlan.md is the full approved plan behind the Roadmap;
-  Tools\zenith_gh.ps1 wraps gh with self-bootstrapping auth; the checked-in
-  .claude/settings.json allowlists the routine commands. See AgentBriefing.md
-  section 9 for the verified bootstrap gotchas.
-- Branch fresh off master (`git pull` first; master tip after S0 = `4e57c680`).
-- **Gotchas from S0 (all verified):** bare `game.exe --exit-after-frames N` NEVER exits (per-test override only -- use `zenith test --filter` or `--list-automated-tests`); `gh run rerun` re-uses the run's ORIGINAL merge commit (rebase+push to re-evaluate a PR against new master); in sandboxed agent sessions use `pwsh -File Tools\zenith.ps1 ...` / `pwsh -File Build\regen.ps1` (the 5.1 `zenith.bat` shim hits a Get-FileHash resolution quirk there; CI + user machines unaffected).
-- **Hard rules (locked, see Scope.md):** `ZM_` prefix; ~150 original species / original names (zero Nintendo IP); no audio; no networking/trading; no Dynamax-analog; singles only; game data = compiled C arrays; baked assets git-ignored (asset-dependent tests exists-guard + RequestSkip).
-- **Session discipline:** replace this file at session end; tick Roadmap.md boxes only when the PR is merged AND CI green; DecisionLog.md is append-only; serial MSBuild dispatch (never build in parallel agents).
+- **NEW: every PR that adds/removes `ZM_*` unit tests must bump `-Baseline` in `.github/workflows/zm-tests.yml`** (currently 1079). An engine PR that changes the engine unit count also bumps it. This is the ratchet that makes unit tests gate; forget it and zm-tests reddens with a count mismatch (that's the point).
+- **Verify unit tests via a boot, not `zenith test`** (which skips them): `Tools/run_unit_gate.ps1 -Exe <zenithmon.exe> -Baseline <N>` or `zenithmon.exe --list-automated-tests --headless` (no `--skip-unit-tests`). See Q-2026-07-10-004.
+- New game code lives under `Source/Data/`; Sharpmake globs the whole game tree, so `Build\regen.ps1` after adding files (done this PR).
+- Branch fresh off master (`git pull` first; master tip after this = the #147 squash).
+- **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored.
+- Session discipline: replace this file at session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.

--- a/Games/Zenithmon/Docs/TestPlan.md
+++ b/Games/Zenithmon/Docs/TestPlan.md
@@ -169,9 +169,11 @@ since S0. Steps: checkout -> `zenith-setup` action (Vulkan SDK 1.3.290.0,
 Slang 2026.1) -> `Build/regen.ps1 -UseDotnet` -> build
 `Vulkan_vs2022_Debug_Win64_True` (`/t:Zenithmon`) -> build
 `D3D12_vs2022_Debug_Win64_False` (backend-neutrality link proof) -> DLL copies
--> headless boot check -> `zenith.bat test Zenithmon --headless --results-dir
-Build/artifacts/test_results/zenithmon` -> upload artifact `zm-test-results`
-(`if: always()`).
+-> headless boot check -> **boot unit-test gate** (`Tools/run_unit_gate.ps1` --
+the ONLY CI step that runs the ZENITH_TEST T0 suite, since `zenith test` and the
+boot check both pass `--skip-unit-tests`) -> `zenith.bat test Zenithmon
+--headless --results-dir Build/artifacts/test_results/zenithmon` (the P1
+automated suite) -> upload artifact `zm-test-results` (`if: always()`).
 
 The CI runner is GPU-less and asset-less (assets are git-ignored), so the CI
 backbone is exactly the T0 suites plus the headless-safe P1 tests; everything

--- a/Games/Zenithmon/Source/Data/ZM_TypeChart.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_TypeChart.cpp
@@ -1,0 +1,58 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_TypeChart.h"
+
+// ============================================================================
+// ZM_TypeChart -- 18x18 effectiveness table + lookups. See the header and
+// Docs/GameDesignDocument.md section 6. If you edit a cell here, mirror it in
+// the golden copy in Tests/ZM_Tests_Data.cpp (the test fails otherwise -- that
+// two-place discipline is deliberate).
+// ============================================================================
+
+namespace
+{
+	// Rows = ATTACKING type, columns = DEFENDING type, both in ZM_TYPE order.
+	// Cell = damage multiplier (0 immune / 0.5 resisted / 1 neutral / 2 weak).
+	//
+	// Columns:      Nor  Fir  Wat  Gra  Ele  Ice  Brw  Ven  Ear  Sky  Min  Swa  Sto  Pha  Dra  Umb  Iro  Fey
+	constexpr float s_afChart[ZM_TYPE_COUNT][ZM_TYPE_COUNT] =
+	{
+		/* NORMAL   */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, .5f, 0.f, 1.f, 1.f, .5f, 1.f },
+		/* FIRE     */ { 1.f, .5f, .5f, 2.f, 1.f, 2.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, .5f, 1.f, 2.f, 1.f },
+		/* WATER    */ { 1.f, 2.f, .5f, .5f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, 1.f, 1.f },
+		/* GRASS    */ { 1.f, .5f, 2.f, .5f, 1.f, 1.f, 1.f, .5f, 2.f, .5f, 1.f, .5f, 2.f, 1.f, .5f, 1.f, .5f, 1.f },
+		/* ELECTRIC */ { 1.f, 1.f, 2.f, .5f, .5f, 1.f, 1.f, 1.f, 0.f, 2.f, 1.f, 1.f, 1.f, 1.f, .5f, 1.f, 1.f, 1.f },
+		/* ICE      */ { 1.f, .5f, .5f, 2.f, 1.f, .5f, 1.f, 1.f, 2.f, 2.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f },
+		/* BRAWL    */ { 2.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, .5f, .5f, .5f, 2.f, 0.f, 1.f, 2.f, 2.f, .5f },
+		/* VENOM    */ { 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 1.f, .5f, .5f, 1.f, 1.f, 1.f, .5f, .5f, 1.f, 1.f, 0.f, 2.f },
+		/* EARTH    */ { 1.f, 2.f, 1.f, .5f, 2.f, 1.f, 1.f, 2.f, 1.f, 0.f, 1.f, .5f, 2.f, 1.f, 1.f, 1.f, 2.f, 1.f },
+		/* SKY      */ { 1.f, 1.f, 1.f, 2.f, .5f, 1.f, 2.f, 1.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, 1.f, 1.f, .5f, 1.f },
+		/* MIND     */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 2.f, 1.f, 1.f, .5f, 1.f, 1.f, 1.f, 1.f, 0.f, .5f, 1.f },
+		/* SWARM    */ { 1.f, .5f, 1.f, 2.f, 1.f, 1.f, .5f, .5f, 1.f, .5f, 2.f, 1.f, 1.f, .5f, 1.f, 2.f, .5f, .5f },
+		/* STONE    */ { 1.f, 2.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, .5f, 2.f, 1.f, 2.f, 1.f, 1.f, 1.f, 1.f, .5f, 1.f },
+		/* PHANTOM  */ { 0.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, 1.f },
+		/* DRAKE    */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 0.f },
+		/* UMBRAL   */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, .5f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, .5f },
+		/* IRON     */ { 1.f, .5f, .5f, 1.f, .5f, 2.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 1.f, .5f, 2.f },
+		/* FEY      */ { 1.f, .5f, 1.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 2.f, .5f, 1.f },
+	};
+}
+
+float ZM_TypeChart::GetEffectiveness(ZM_TYPE eAttack, ZM_TYPE eDefend)
+{
+	Zenith_Assert(eAttack < ZM_TYPE_COUNT && eDefend < ZM_TYPE_COUNT,
+		"ZM_TypeChart::GetEffectiveness: type index out of range (atk=%u def=%u)",
+		(u_int)eAttack, (u_int)eDefend);
+	return s_afChart[eAttack][eDefend];
+}
+
+float ZM_TypeChart::GetDualTypeEffectiveness(ZM_TYPE eAttack, ZM_TYPE eDefend1, ZM_TYPE eDefend2)
+{
+	float fResult = GetEffectiveness(eAttack, eDefend1);
+
+	// Single-typed defender (NONE), or a duplicated slot -- take the one lookup.
+	if (eDefend2 != ZM_TYPE_NONE && eDefend2 != eDefend1)
+	{
+		fResult *= GetEffectiveness(eAttack, eDefend2);
+	}
+	return fResult;
+}

--- a/Games/Zenithmon/Source/Data/ZM_TypeChart.h
+++ b/Games/Zenithmon/Source/Data/ZM_TypeChart.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_Types.h"
+
+// ============================================================================
+// ZM_TypeChart -- the 18x18 type-effectiveness matrix (S1 data core).
+//
+// Pure, stateless lookup over the compiled chart table (ZM_TypeChart.cpp). The
+// multipliers are the standard 18-type relationships under Zenithmon's original
+// names; Docs/GameDesignDocument.md section 6 fixes the design intent (starter
+// triangle, DRAKE/FEY checks, MIND/UMBRAL/BRAWL triangle, PHANTOM<->NORMAL
+// immunity, IRON wall, ELECTRIC/EARTH and EARTH/SKY immunities).
+//
+// The chart is locked by a golden-matrix unit test (Tests/ZM_Tests_Data.cpp):
+// any edit to the table is a deliberate two-place change (Docs/TestPlan.md 5.1).
+// ============================================================================
+namespace ZM_TypeChart
+{
+	// Damage multiplier of a single attacking type vs a single defending type:
+	// 0 (immune), 0.5 (resisted), 1 (neutral), or 2 (super-effective).
+	// eAttack and eDefend must be real types (< ZM_TYPE_COUNT).
+	float GetEffectiveness(ZM_TYPE eAttack, ZM_TYPE eDefend);
+
+	// Multiplier of an attacking type vs a (possibly dual-typed) defender. Pass
+	// ZM_TYPE_NONE for eDefend2 on single-type defenders; the result is then the
+	// single lookup. Otherwise it is the product of both lookups (a matching
+	// eDefend2 == eDefend1 is treated as single-typed, never squared). This is
+	// where 4x / 0.25x / 0x matchups come from.
+	float GetDualTypeEffectiveness(ZM_TYPE eAttack, ZM_TYPE eDefend1, ZM_TYPE eDefend2);
+}

--- a/Games/Zenithmon/Source/Data/ZM_Types.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_Types.cpp
@@ -1,0 +1,49 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_Types.h"
+
+// ============================================================================
+// ZM_Types -- type-name lookup. The name table is index-parallel to the ZM_TYPE
+// enum; a static_assert pins the two together so adding a type without a name
+// (or vice versa) fails to compile.
+// ============================================================================
+
+namespace
+{
+	constexpr const char* s_aszTypeNames[ZM_TYPE_COUNT] =
+	{
+		"NORMAL",
+		"FIRE",
+		"WATER",
+		"GRASS",
+		"ELECTRIC",
+		"ICE",
+		"BRAWL",
+		"VENOM",
+		"EARTH",
+		"SKY",
+		"MIND",
+		"SWARM",
+		"STONE",
+		"PHANTOM",
+		"DRAKE",
+		"UMBRAL",
+		"IRON",
+		"FEY",
+	};
+
+	static_assert(sizeof(s_aszTypeNames) / sizeof(s_aszTypeNames[0]) == ZM_TYPE_COUNT,
+		"ZM_TypeToString name table must have exactly one entry per ZM_TYPE");
+}
+
+const char* ZM_TypeToString(ZM_TYPE eType)
+{
+	if (eType == ZM_TYPE_NONE)
+	{
+		return "NONE";
+	}
+	if (eType >= ZM_TYPE_COUNT)
+	{
+		return "INVALID";
+	}
+	return s_aszTypeNames[eType];
+}

--- a/Games/Zenithmon/Source/Data/ZM_Types.h
+++ b/Games/Zenithmon/Source/Data/ZM_Types.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// ============================================================================
+// ZM_Types -- the 18 elemental types (S1 data core).
+//
+// Original names over mainline mechanics (Docs/Scope.md: zero Nintendo IP).
+// The effectiveness relationships between these types live in ZM_TypeChart;
+// see Docs/GameDesignDocument.md section 6 for the type list and design intent.
+//
+// Data tables are compiled const C arrays, not disk assets (DecisionLog
+// ZM-D-009), so this enum is the single source of truth for the type space:
+// its order is the dex/UI order AND the row/column order of the type chart.
+// ============================================================================
+
+// A monster's / move's element. The 0..ZM_TYPE_COUNT range is save-stable once
+// content ships -- APPEND new types before ZM_TYPE_COUNT, never reorder, or old
+// saves and baked data reinterpret their types.
+enum ZM_TYPE : u_int
+{
+	ZM_TYPE_NORMAL,
+	ZM_TYPE_FIRE,
+	ZM_TYPE_WATER,
+	ZM_TYPE_GRASS,
+	ZM_TYPE_ELECTRIC,
+	ZM_TYPE_ICE,
+	ZM_TYPE_BRAWL,
+	ZM_TYPE_VENOM,
+	ZM_TYPE_EARTH,
+	ZM_TYPE_SKY,
+	ZM_TYPE_MIND,
+	ZM_TYPE_SWARM,
+	ZM_TYPE_STONE,
+	ZM_TYPE_PHANTOM,
+	ZM_TYPE_DRAKE,
+	ZM_TYPE_UMBRAL,
+	ZM_TYPE_IRON,
+	ZM_TYPE_FEY,
+
+	ZM_TYPE_COUNT,                 // 18 real types; use as the array-size sentinel
+
+	ZM_TYPE_NONE = ZM_TYPE_COUNT   // empty second-type slot; never a chart index
+};
+
+// Human-readable name (uppercase, matching the enum). Returns "NONE" for the
+// empty slot and "INVALID" out of range -- for logs, tooltips, and dex text.
+const char* ZM_TypeToString(ZM_TYPE eType);

--- a/Games/Zenithmon/Tests/ZM_Tests_Data.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_Data.cpp
@@ -1,0 +1,207 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_Data -- S1 data-core unit tests (category ZM_Data). This first slice
+// covers ZM_Types + ZM_TypeChart; species/moves/registry/worldspec suites join
+// this category as their tasks land (Docs/TestPlan.md 5.1).
+//
+// The chart test carries an INDEPENDENT golden copy of the 18x18 matrix: a
+// chart edit must touch ZM_TypeChart.cpp AND this golden, or the test fails.
+// That two-place discipline is the point. The design-intent tests below are the
+// semantic guard -- they assert the GDD's stated relationships directly, so a
+// value mistranscribed into BOTH tables is still caught where it matters.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_Types.h"
+#include "Zenithmon/Source/Data/ZM_TypeChart.h"
+
+#include <cstring>   // strcmp (type-name distinctness check)
+
+namespace
+{
+	// Independent golden matrix (rows = attacker, cols = defender, ZM_TYPE order;
+	// 0 / 0.5 / 1 / 2). Kept deliberately separate from ZM_TypeChart.cpp.
+	//
+	// Columns:      Nor  Fir  Wat  Gra  Ele  Ice  Brw  Ven  Ear  Sky  Min  Swa  Sto  Pha  Dra  Umb  Iro  Fey
+	constexpr float s_afGolden[ZM_TYPE_COUNT][ZM_TYPE_COUNT] =
+	{
+		/* NORMAL   */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, .5f, 0.f, 1.f, 1.f, .5f, 1.f },
+		/* FIRE     */ { 1.f, .5f, .5f, 2.f, 1.f, 2.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, .5f, 1.f, 2.f, 1.f },
+		/* WATER    */ { 1.f, 2.f, .5f, .5f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, 1.f, 1.f },
+		/* GRASS    */ { 1.f, .5f, 2.f, .5f, 1.f, 1.f, 1.f, .5f, 2.f, .5f, 1.f, .5f, 2.f, 1.f, .5f, 1.f, .5f, 1.f },
+		/* ELECTRIC */ { 1.f, 1.f, 2.f, .5f, .5f, 1.f, 1.f, 1.f, 0.f, 2.f, 1.f, 1.f, 1.f, 1.f, .5f, 1.f, 1.f, 1.f },
+		/* ICE      */ { 1.f, .5f, .5f, 2.f, 1.f, .5f, 1.f, 1.f, 2.f, 2.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f },
+		/* BRAWL    */ { 2.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, .5f, .5f, .5f, 2.f, 0.f, 1.f, 2.f, 2.f, .5f },
+		/* VENOM    */ { 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 1.f, .5f, .5f, 1.f, 1.f, 1.f, .5f, .5f, 1.f, 1.f, 0.f, 2.f },
+		/* EARTH    */ { 1.f, 2.f, 1.f, .5f, 2.f, 1.f, 1.f, 2.f, 1.f, 0.f, 1.f, .5f, 2.f, 1.f, 1.f, 1.f, 2.f, 1.f },
+		/* SKY      */ { 1.f, 1.f, 1.f, 2.f, .5f, 1.f, 2.f, 1.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, 1.f, 1.f, .5f, 1.f },
+		/* MIND     */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 2.f, 1.f, 1.f, .5f, 1.f, 1.f, 1.f, 1.f, 0.f, .5f, 1.f },
+		/* SWARM    */ { 1.f, .5f, 1.f, 2.f, 1.f, 1.f, .5f, .5f, 1.f, .5f, 2.f, 1.f, 1.f, .5f, 1.f, 2.f, .5f, .5f },
+		/* STONE    */ { 1.f, 2.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, .5f, 2.f, 1.f, 2.f, 1.f, 1.f, 1.f, 1.f, .5f, 1.f },
+		/* PHANTOM  */ { 0.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, 1.f },
+		/* DRAKE    */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, .5f, 0.f },
+		/* UMBRAL   */ { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, .5f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 2.f, 1.f, .5f, 1.f, .5f },
+		/* IRON     */ { 1.f, .5f, .5f, 1.f, .5f, 2.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 1.f, 1.f, 1.f, .5f, 2.f },
+		/* FEY      */ { 1.f, .5f, 1.f, 1.f, 1.f, 1.f, 2.f, .5f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 2.f, 2.f, .5f, 1.f },
+	};
+
+	// A legal effectiveness multiplier is exactly one of {0, 0.5, 1, 2}. These
+	// are exact in binary so an exact float compare is intentional here.
+	bool IsLegalMultiplier(float f)
+	{
+		return f == 0.f || f == .5f || f == 1.f || f == 2.f;
+	}
+}
+
+// The runtime chart equals the independent golden, cell for cell.
+ZENITH_TEST(ZM_Data, TypeChart_MatchesGolden)
+{
+	for (u_int uAtk = 0; uAtk < ZM_TYPE_COUNT; ++uAtk)
+	{
+		for (u_int uDef = 0; uDef < ZM_TYPE_COUNT; ++uDef)
+		{
+			const float fActual = ZM_TypeChart::GetEffectiveness((ZM_TYPE)uAtk, (ZM_TYPE)uDef);
+			ZENITH_ASSERT_EQ_FLOAT(fActual, s_afGolden[uAtk][uDef], 0.0001f,
+				"type chart mismatch at [%s attacking %s]",
+				ZM_TypeToString((ZM_TYPE)uAtk), ZM_TypeToString((ZM_TYPE)uDef));
+		}
+	}
+}
+
+// Every cell is one of the four legal multipliers -- no stray values.
+ZENITH_TEST(ZM_Data, TypeChart_AllCellsLegal)
+{
+	for (u_int uAtk = 0; uAtk < ZM_TYPE_COUNT; ++uAtk)
+	{
+		for (u_int uDef = 0; uDef < ZM_TYPE_COUNT; ++uDef)
+		{
+			const float f = ZM_TypeChart::GetEffectiveness((ZM_TYPE)uAtk, (ZM_TYPE)uDef);
+			ZENITH_ASSERT_TRUE(IsLegalMultiplier(f),
+				"illegal multiplier %.3f at [%s attacking %s]", f,
+				ZM_TypeToString((ZM_TYPE)uAtk), ZM_TypeToString((ZM_TYPE)uDef));
+		}
+	}
+}
+
+// Exactly eight immunities (0x cells) -- the well-known 18-type total. An
+// independent count that catches a stray 0 or a dropped immunity.
+ZENITH_TEST(ZM_Data, TypeChart_ImmunityCountIsEight)
+{
+	u_int uImmunities = 0;
+	for (u_int uAtk = 0; uAtk < ZM_TYPE_COUNT; ++uAtk)
+	{
+		for (u_int uDef = 0; uDef < ZM_TYPE_COUNT; ++uDef)
+		{
+			if (ZM_TypeChart::GetEffectiveness((ZM_TYPE)uAtk, (ZM_TYPE)uDef) == 0.f)
+			{
+				++uImmunities;
+			}
+		}
+	}
+	ZENITH_ASSERT_EQ(uImmunities, 8u, "expected 8 type immunities in the chart");
+}
+
+// GDD 6: the starter triangle GRASS > WATER > FIRE > GRASS.
+ZENITH_TEST(ZM_Data, TypeChart_StarterTriangle)
+{
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_GRASS, ZM_TYPE_WATER), 2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_WATER, ZM_TYPE_FIRE),  2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_FIRE,  ZM_TYPE_GRASS), 2.f, 0.0001f);
+	// ...and each is resisted the other way round.
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_WATER, ZM_TYPE_GRASS), .5f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_FIRE,  ZM_TYPE_WATER), .5f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_GRASS, ZM_TYPE_FIRE),  .5f, 0.0001f);
+}
+
+// GDD 6: MIND > BRAWL > UMBRAL > MIND, and PHANTOM<->NORMAL mutual immunity.
+ZENITH_TEST(ZM_Data, TypeChart_SecondTriangleAndGhostNormal)
+{
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_MIND,   ZM_TYPE_BRAWL),  2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_BRAWL,  ZM_TYPE_UMBRAL), 2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_UMBRAL, ZM_TYPE_MIND),   2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_PHANTOM, ZM_TYPE_NORMAL),  0.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_NORMAL,  ZM_TYPE_PHANTOM), 0.f, 0.0001f);
+	// BRAWL is also walled by PHANTOM (classic 0x).
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_BRAWL, ZM_TYPE_PHANTOM), 0.f, 0.0001f);
+}
+
+// GDD 6: DRAKE resists the elemental trio (+ELECTRIC) and is answered by ICE and
+// FEY; DRAKE cannot touch FEY at all.
+ZENITH_TEST(ZM_Data, TypeChart_DrakeChecks)
+{
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_FIRE,     ZM_TYPE_DRAKE), .5f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_WATER,    ZM_TYPE_DRAKE), .5f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_GRASS,    ZM_TYPE_DRAKE), .5f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_ELECTRIC, ZM_TYPE_DRAKE), .5f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_ICE, ZM_TYPE_DRAKE), 2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_FEY, ZM_TYPE_DRAKE), 2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_DRAKE, ZM_TYPE_FEY), 0.f, 0.0001f);
+}
+
+// GDD 6: the named immunities + IRON as the broad defensive wall.
+ZENITH_TEST(ZM_Data, TypeChart_ImmunitiesAndIronWall)
+{
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_ELECTRIC, ZM_TYPE_EARTH),  0.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_EARTH,    ZM_TYPE_SKY),    0.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_VENOM,    ZM_TYPE_IRON),   0.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_MIND,     ZM_TYPE_UMBRAL), 0.f, 0.0001f);
+
+	// IRON weak only to FIRE / BRAWL / EARTH...
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_FIRE,  ZM_TYPE_IRON), 2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_BRAWL, ZM_TYPE_IRON), 2.f, 0.0001f);
+	ZENITH_ASSERT_EQ_FLOAT(ZM_TypeChart::GetEffectiveness(ZM_TYPE_EARTH, ZM_TYPE_IRON), 2.f, 0.0001f);
+
+	// ...and resists a broad set (count the <1x columns for defender IRON).
+	u_int uIronResists = 0;
+	for (u_int uAtk = 0; uAtk < ZM_TYPE_COUNT; ++uAtk)
+	{
+		if (ZM_TypeChart::GetEffectiveness((ZM_TYPE)uAtk, ZM_TYPE_IRON) < 1.f)
+		{
+			++uIronResists;
+		}
+	}
+	ZENITH_ASSERT_GE(uIronResists, 8u, "IRON is meant to be the broad defensive wall");
+}
+
+// Dual-type effectiveness = product of the attacking type vs each defending
+// type; NONE and duplicate slots collapse to the single lookup.
+ZENITH_TEST(ZM_Data, TypeChart_DualTypeProducts)
+{
+	// 4x: STONE vs a SKY/SWARM defender (Rock hits Flying and Bug 2x each).
+	ZENITH_ASSERT_EQ_FLOAT(
+		ZM_TypeChart::GetDualTypeEffectiveness(ZM_TYPE_STONE, ZM_TYPE_SKY, ZM_TYPE_SWARM), 4.f, 0.0001f);
+	// 0.25x: GRASS vs a FIRE/DRAKE defender (0.5 * 0.5).
+	ZENITH_ASSERT_EQ_FLOAT(
+		ZM_TypeChart::GetDualTypeEffectiveness(ZM_TYPE_GRASS, ZM_TYPE_FIRE, ZM_TYPE_DRAKE), 0.25f, 0.0001f);
+	// 0x: any component immunity zeroes the product (EARTH cannot hit SKY).
+	ZENITH_ASSERT_EQ_FLOAT(
+		ZM_TypeChart::GetDualTypeEffectiveness(ZM_TYPE_EARTH, ZM_TYPE_SKY, ZM_TYPE_IRON), 0.f, 0.0001f);
+	// Single-typed defender via NONE == the single lookup.
+	ZENITH_ASSERT_EQ_FLOAT(
+		ZM_TypeChart::GetDualTypeEffectiveness(ZM_TYPE_FIRE, ZM_TYPE_GRASS, ZM_TYPE_NONE), 2.f, 0.0001f);
+	// Duplicated slot is treated as single-typed, never squared.
+	ZENITH_ASSERT_EQ_FLOAT(
+		ZM_TypeChart::GetDualTypeEffectiveness(ZM_TYPE_FIRE, ZM_TYPE_GRASS, ZM_TYPE_GRASS), 2.f, 0.0001f);
+}
+
+// Type names are present, distinct, and the sentinels resolve as documented.
+ZENITH_TEST(ZM_Data, Types_ToStringContract)
+{
+	ZENITH_ASSERT_STREQ(ZM_TypeToString(ZM_TYPE_NORMAL), "NORMAL");
+	ZENITH_ASSERT_STREQ(ZM_TypeToString(ZM_TYPE_FIRE),   "FIRE");
+	ZENITH_ASSERT_STREQ(ZM_TypeToString(ZM_TYPE_FEY),    "FEY");
+	ZENITH_ASSERT_STREQ(ZM_TypeToString(ZM_TYPE_NONE),   "NONE");
+
+	for (u_int uA = 0; uA < ZM_TYPE_COUNT; ++uA)
+	{
+		const char* szA = ZM_TypeToString((ZM_TYPE)uA);
+		ZENITH_ASSERT_NOT_NULL(szA);
+		ZENITH_ASSERT_TRUE(szA[0] != '\0', "type name %u is empty", uA);
+		for (u_int uB = uA + 1; uB < ZM_TYPE_COUNT; ++uB)
+		{
+			ZENITH_ASSERT_FALSE(strcmp(szA, ZM_TypeToString((ZM_TYPE)uB)) == 0,
+				"duplicate type name '%s' at %u and %u", szA, uA, uB);
+		}
+	}
+}


### PR DESCRIPTION
## S1 data core -- first task: the 18 types + the effectiveness chart

Implements the first unchecked S1 Roadmap box (`ZM_Types.h` + `ZM_TypeChart`).

### What
- **`Source/Data/ZM_Types.h`** -- `enum ZM_TYPE : u_int` for the 18 GDD-section-6 types (NORMAL..FEY), append-only / save-stable order, a `ZM_TYPE_NONE` second-type sentinel, and `ZM_TypeToString`.
- **`Source/Data/ZM_TypeChart.{h,cpp}`** -- a `const` 18x18 float table (0 / 0.5 / 1 / 2) mapping the standard 18-type relationships onto original names; `GetEffectiveness(atk, def)` + `GetDualTypeEffectiveness(atk, def1, def2)` (NONE / duplicated slot collapse to a single lookup -> the 4x / 0.25x / 0x matchups).
- **`Tests/ZM_Tests_Data.cpp`** -- 9 `ZM_Data` unit tests: an independent golden 18x18 (the two-place-change lock, TestPlan 5.1), all-cells-legal, immunity-count == 8, the GDD design-intent spot checks (starter & second triangles, ghost/normal immunity, DRAKE checks, IRON wall, named immunities), dual-type products, and the ToString contract.

### CI: the boot unit suite now actually runs
While landing this I found that **both `zenith test` (harness default) and the two zm-tests steps pass `--skip-unit-tests`**, so no Zenithmon unit test had ever run in CI -- the S1/S2 unit backbone would have been a hollow gate. Added a `Tools/run_unit_gate.ps1` boot step to `zm-tests.yml` (baseline **1079** = engine units + `ZM_*`) so the suite gates on every PR. The baseline is an exact ratchet (bumped per unit-test PR); see DecisionLog ZM-D-019 and Questions Q-2026-07-10-004.

### Verification (local)
- `zenith build Zenithmon` (Vulkan_True) clean.
- Boot unit suite: **1079 ran, 1078 passed, 0 failed, 1 skipped** (the 1 skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`).
- `run_unit_gate.ps1 -Baseline 1079` -> exit 0.
- `zenith test Zenithmon --headless` -> 1/1 automated passed.

### Docs (same PR)
Roadmap tick, DecisionLog ZM-D-018 (type system) + ZM-D-019 (CI unit gate), CIPolicy S1/S6, TestPlan S4, Questions Q-2026-07-10-004, Status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
