### PR TITLE
feat(zm): S1 - ZM_SpeciesData structural roster (152 species) + integrity tests

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1079
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1090
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/CIPolicy.md
+++ b/Games/Zenithmon/Docs/CIPolicy.md
@@ -53,7 +53,7 @@ pattern), active from S0. Required check name: **`zm-tests`**.
 
 **Unit-test baseline ratchet:** step 8's `-Baseline` is the exact registered
 unit-test count of `zenithmon.exe` (engine units + `ZM_*` cases; currently
-**1079**, of which 1 is the quarantined `RegistryWideNodeRoundTrip` skip). Every
+**1090**, of which 1 is the quarantined `RegistryWideNodeRoundTrip` skip). Every
 PR that changes the `ZM_*` count -- and any engine PR that changes the engine
 unit count -- bumps this number in `zm-tests.yml` in the same PR. This mirrors
 engine-gate's discipline and guards against unit tests silently vanishing; the

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,34 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-020 -- ZM_SpeciesData decomposed: structural roster first (152 species), base stats + learnsets deferred
+
+- **Decision:** the ~150-species SpeciesData Roadmap box is split across
+  increments on the same box. Increment 1 (this PR): the `ZM_SpeciesData` schema
+  + supporting enums (`ZM_ARCHETYPE`/`ZM_RARITY`/`ZM_SIZE_CLASS`/`ZM_SPECIES_ID`)
+  + the full 152-species STRUCTURAL roster (id / name / type(s) / archetype /
+  evo-stage / evolves-to / family / rarity) transcribed from GDD section 5, with
+  size class + family seed as rule-derived accessors. DEFERRED to later
+  increments on this box: per-species base stats (a design pass) and learnsets
+  (need `ZM_MoveData`, box 3). The Roadmap box stays a WIP (`[~]`).
+- **Why:** 152 species with hand-designed base stats + every field in one commit
+  is a large, error-prone, hard-to-review PR; a structural-roster-first split is
+  standard practice for big data tables and is dependency-correct (learnsets
+  reference moves that do not exist yet). The roster is the foundation that
+  MoveData learnsets, WorldSpec encounters, DataRegistry, and S4 asset gen all
+  reference.
+- **Tests that lock it:** `Tests/ZM_Tests_Species.cpp` (category `ZM_Data`) -- 11
+  integrity tests: count==152 + index self-consistency, unique names, valid
+  types, evolution-graph shape (stage+1, same family/archetype/rarity, no
+  self-loop), families well-formed (linear chains, one species per stage),
+  family-size distribution (40/13/6 vs GDD), base/final/legendary counts,
+  archetype-family spread (18/6/7/4/6/7/5/6), every-type-on-two-families,
+  family-seed consistency+uniqueness, size-class monotonicity. Boot suite 1090
+  ran / 0 failed.
+- **Reversibility:** easy -- additive `Source/Data/` files; the struct grows
+  (base-stats + learnset fields) in follow-up increments; the `ZM_SPECIES_ID`
+  order is save-stable (append-only).
+
 ## 2026-07-10 -- ZM-D-019 -- Zenithmon boot unit tests are gated in CI via a run_unit_gate.ps1 boot step (ratcheted baseline)
 
 - **Decision:** `zm-tests.yml` gains a step that boots `zenithmon.exe` headless

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -30,7 +30,7 @@
 ## S1 -- Data core (M) -- parallel with S3/S4
 
 - [x] `ZM_Types.h` + `ZM_TypeChart` (18 types) -- 18-type `enum ZM_TYPE` + golden-locked 18x18 chart + dual-type product; 9 `ZM_Data` unit tests (PR #147). Also wired the boot unit suite into CI (ZM-D-019).
-- [ ] `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets)
+- [~] `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets) -- **structural roster SHIPPED** (152 species: id/name/types/archetype/evo/family/rarity + derived size/seed; 11 `ZM_Data` integrity tests; PR #148, ZM-D-020). REMAINING on this box: per-species base stats + learnsets (learnsets need `ZM_MoveData`).
 - [ ] `ZM_MoveData` (~220 moves as table rows over a ~60-kind `ZM_MOVE_EFFECT` enum)
 - [ ] `ZM_ItemData` (~80 + TMs)
 - [ ] `ZM_AbilityData` stubs (~50, fn-pointer hook structs) + `ZM_NatureData` (25)

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,33 +1,34 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 started: type chart landed; ZM_* unit tests now gate in CI.**
+**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species structural roster landed.**
 
-**Read this first each session.** Replaced at every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the honest gap audit.
+**Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
 ## Build
 
-GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon` (per-game sln, `/t:Zenithmon`). D3D12_False link proof runs in CI.
+GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon`. D3D12_False link proof runs in CI.
 
 ## Tests
 
-- Unit (T0, category `ZM_Data`): **1079 ran, 1078 passed, 0 failed, 1 skipped** at boot (the 1 skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). +9 over the S0 baseline = the new type-chart suite.
-- Automated (P1): **1 / 1 passed** (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
-- **CI now runs the unit suite** (this iteration's fix, ZM-D-019): `zm-tests.yml` boots `zenithmon.exe` via `Tools/run_unit_gate.ps1 -Baseline 1079`. Before this, BOTH `zenith test` and the zm-tests steps passed `--skip-unit-tests`, so no ZM unit test ran in CI.
+- Unit (T0, category `ZM_Data`): **1090 ran, 1089 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 11 species + 1068 engine + 2 boot.
+- Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
+- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1090** in `zm-tests.yml`.
 
-## What landed (this iteration -- PR #147)
+## What landed
 
-- **S1 first Roadmap task:** `Source/Data/ZM_Types.h` (`enum ZM_TYPE : u_int`, 18 GDD types, `ZM_TypeToString`) + `ZM_TypeChart` (const 18x18 effectiveness table + `GetEffectiveness` + `GetDualTypeEffectiveness`) + 9 `Tests/ZM_Tests_Data.cpp` cases (golden-matrix two-place lock, GDD design-intent spot checks, dual-type products, ToString). DecisionLog ZM-D-018.
-- **CI unit-test gate** wired into `zm-tests.yml` (DecisionLog ZM-D-019) so the S1/S2 unit backbone actually runs on every PR. Docs updated: CIPolicy §1/§6, TestPlan §4, Questions Q-2026-07-10-004.
+- **PR #147 (merged):** S1 type chart -- `ZM_Types` + `ZM_TypeChart` (golden-locked 18x18) + CI unit gate (ZM-D-018/019).
+- **PR #148 (this iteration):** `ZM_SpeciesData` **structural roster** -- schema + enums (`ZM_ARCHETYPE`/`ZM_RARITY`/`ZM_SIZE_CLASS`/`ZM_SPECIES_ID`) + full 152-species table (id/name/types/archetype/evo/family/rarity, transcribed from GDD 5) + derived size/seed accessors + 11 `ZM_Data` integrity tests. DecisionLog ZM-D-020.
 
 ## Current task
 
-None in flight (once PR #147 merges). **Next per [Roadmap.md](Roadmap.md): S1 second box -- `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets).** Then MoveData / ItemData / AbilityData+NatureData / StatCalc+BattleRNG / WorldSpec skeleton / DataRegistry. S3 (overworld, engine E1/E2) is the parallel track.
+None in flight (once PR #148 merges). **The `ZM_SpeciesData` Roadmap box is `[~]` WIP:** structural roster done; **REMAINING on the box = per-species base stats (a design pass) + learnsets (need `ZM_MoveData`).** So the next task is either continue that box with **base stats** (increment 2 -- add a base-stats field to `ZM_SpeciesData` + values + range/BST tests; bump baseline) or start `ZM_MoveData` (box 3). Base stats have no upstream dependency; learnsets must wait for moves.
 
 ## Notes for the next agent
 
-- **NEW: every PR that adds/removes `ZM_*` unit tests must bump `-Baseline` in `.github/workflows/zm-tests.yml`** (currently 1079). An engine PR that changes the engine unit count also bumps it. This is the ratchet that makes unit tests gate; forget it and zm-tests reddens with a count mismatch (that's the point).
-- **Verify unit tests via a boot, not `zenith test`** (which skips them): `Tools/run_unit_gate.ps1 -Exe <zenithmon.exe> -Baseline <N>` or `zenithmon.exe --list-automated-tests --headless` (no `--skip-unit-tests`). See Q-2026-07-10-004.
-- New game code lives under `Source/Data/`; Sharpmake globs the whole game tree, so `Build\regen.ps1` after adding files (done this PR).
-- Branch fresh off master (`git pull` first; master tip after this = the #147 squash).
+- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1090**. Forgetting it reddens zm-tests with a count mismatch (that is the ratchet working).
+- Verify unit tests via a boot, not `zenith test` (which skips them): `zenithmon.exe --list-automated-tests --headless` prints `Unit tests complete: N ran … M failed`, or `Tools/run_unit_gate.ps1`. See Q-2026-07-10-004.
+- **Working-dir gotcha:** the Bash and PowerShell tools SHARE a cwd here -- a `cd` in Bash moves PowerShell too. Avoid `cd`; use absolute paths / `Set-Location C:\dev\Zenith` before `regen`/`build`.
+- `Source/Data/` is globbed by Sharpmake; run `Build\regen.ps1` after adding files.
+- Branch fresh off master (`git pull` first).
 - **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored.
-- Session discipline: replace this file at session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.
+- Session discipline: replace this file each session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.

--- a/Games/Zenithmon/Source/Data/ZM_SpeciesData.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_SpeciesData.cpp
@@ -1,0 +1,293 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+
+// ============================================================================
+// ZM_SpeciesData -- the 152-species dex table (structural roster), transcribed
+// from Docs/GameDesignDocument.md section 5. Rows are in ZM_SPECIES_ID order;
+// s_axSpecies[i].m_eId == i is asserted by the tests. Base stats + learnsets
+// are added by later increments on this Roadmap box (DecisionLog ZM-D-020).
+//
+// Type columns follow the GDD: single-type species carry ZM_TYPE_NONE in the
+// second slot; "X, final +Y" families gain the second type only at the final
+// stage; a bare "X/Y" family is dual from stage 1.
+// ============================================================================
+
+namespace
+{
+	const ZM_SpeciesData s_axSpecies[ZM_SPECIES_COUNT] =
+	{
+		// -- F01 QUADRUPED, RARE (starter: grove-antlered deer) --
+		{ ZM_SPECIES_FERNFAWN,     "Fernfawn",     { ZM_TYPE_GRASS,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_THICKETBUCK, 1,  ZM_RARITY_RARE     },
+		{ ZM_SPECIES_THICKETBUCK,  "Thicketbuck",  { ZM_TYPE_GRASS,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_SYLVASTAG,   1,  ZM_RARITY_RARE     },
+		{ ZM_SPECIES_SYLVASTAG,    "Sylvastag",    { ZM_TYPE_GRASS,    ZM_TYPE_EARTH }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        1,  ZM_RARITY_RARE     },
+		// -- F02 BIPED, RARE (starter: self-firing kiln salamander) --
+		{ ZM_SPECIES_KINDLET,      "Kindlet",      { ZM_TYPE_FIRE,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            1, ZM_SPECIES_SCORCHEL,    2,  ZM_RARITY_RARE     },
+		{ ZM_SPECIES_SCORCHEL,     "Scorchel",     { ZM_TYPE_FIRE,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            2, ZM_SPECIES_PYROCLAST,   2,  ZM_RARITY_RARE     },
+		{ ZM_SPECIES_PYROCLAST,    "Pyroclast",    { ZM_TYPE_FIRE,     ZM_TYPE_STONE }, ZM_ARCHETYPE_BIPED,            3, ZM_SPECIES_NONE,        2,  ZM_RARITY_RARE     },
+		// -- F03 AQUATIC, RARE (starter: blade-billed duelist fish) --
+		{ ZM_SPECIES_FINLET,       "Finlet",       { ZM_TYPE_WATER,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_AQUATIC,          1, ZM_SPECIES_MARLANCE,    3,  ZM_RARITY_RARE     },
+		{ ZM_SPECIES_MARLANCE,     "Marlance",     { ZM_TYPE_WATER,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_AQUATIC,          2, ZM_SPECIES_TIDESABRE,   3,  ZM_RARITY_RARE     },
+		{ ZM_SPECIES_TIDESABRE,    "Tidesabre",    { ZM_TYPE_WATER,    ZM_TYPE_IRON  }, ZM_ARCHETYPE_AQUATIC,          3, ZM_SPECIES_NONE,        3,  ZM_RARITY_RARE     },
+		// -- F04 AVIAN, COMMON (everywhere-songbird) --
+		{ ZM_SPECIES_PIPWIT,       "Pipwit",       { ZM_TYPE_NORMAL,   ZM_TYPE_SKY   }, ZM_ARCHETYPE_AVIAN,            1, ZM_SPECIES_TRILLARK,    4,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_TRILLARK,     "Trillark",     { ZM_TYPE_NORMAL,   ZM_TYPE_SKY   }, ZM_ARCHETYPE_AVIAN,            2, ZM_SPECIES_STRATAVIS,   4,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_STRATAVIS,    "Stratavis",    { ZM_TYPE_NORMAL,   ZM_TYPE_SKY   }, ZM_ARCHETYPE_AVIAN,            3, ZM_SPECIES_NONE,        4,  ZM_RARITY_COMMON   },
+		// -- F05 QUADRUPED, COMMON (seed-hoarding vole) --
+		{ ZM_SPECIES_NIBBIN,       "Nibbin",       { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_HOARDEL,     5,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_HOARDEL,      "Hoardel",      { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_GRAINMAW,    5,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_GRAINMAW,     "Grainmaw",     { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        5,  ZM_RARITY_COMMON   },
+		// -- F06 INSECTOID, COMMON (early butterfly) --
+		{ ZM_SPECIES_WRIGGLET,     "Wrigglet",     { ZM_TYPE_SWARM,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_CRADLEWRAP,  6,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_CRADLEWRAP,   "Cradlewrap",   { ZM_TYPE_SWARM,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_AURELWING,   6,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_AURELWING,    "Aurelwing",    { ZM_TYPE_SWARM,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        6,  ZM_RARITY_COMMON   },
+		// -- F07 QUADRUPED, COMMON (gate-guarding hound) --
+		{ ZM_SPECIES_STRAYLING,    "Strayling",    { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_WARDHUND,    7,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_WARDHUND,     "Wardhund",     { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_NONE,        7,  ZM_RARITY_COMMON   },
+		// -- F08 FLOATER_PLANTOID, COMMON (dandelion drifter) --
+		{ ZM_SPECIES_PUFFSEED,     "Puffseed",     { ZM_TYPE_GRASS,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_FLOATER_PLANTOID, 1, ZM_SPECIES_DANDELIFT,   8,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_DANDELIFT,    "Dandelift",    { ZM_TYPE_GRASS,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_FLOATER_PLANTOID, 2, ZM_SPECIES_ZEPHYRBLOOM, 8,  ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_ZEPHYRBLOOM,  "Zephyrbloom",  { ZM_TYPE_GRASS,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_FLOATER_PLANTOID, 3, ZM_SPECIES_NONE,        8,  ZM_RARITY_COMMON   },
+		// -- F09 QUADRUPED, UNCOMMON (storm-chasing fox) --
+		{ ZM_SPECIES_SPARKIT,      "Sparkit",      { ZM_TYPE_ELECTRIC, ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_AMPTAIL,     9,  ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_AMPTAIL,      "Amptail",      { ZM_TYPE_ELECTRIC, ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_FULGURUN,    9,  ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_FULGURUN,     "Fulgurun",     { ZM_TYPE_ELECTRIC, ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        9,  ZM_RARITY_UNCOMMON },
+		// -- F10 BLOB, COMMON (walking cairn) --
+		{ ZM_SPECIES_RUBBLET,      "Rubblet",      { ZM_TYPE_STONE,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             1, ZM_SPECIES_CAIRNGO,     10, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_CAIRNGO,      "Cairngo",      { ZM_TYPE_STONE,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             2, ZM_SPECIES_MONOLODE,    10, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_MONOLODE,     "Monolode",     { ZM_TYPE_STONE,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             3, ZM_SPECIES_NONE,        10, ZM_RARITY_COMMON   },
+		// -- F11 AQUATIC, COMMON (universal river fish) --
+		{ ZM_SPECIES_MINNET,       "Minnet",       { ZM_TYPE_WATER,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_AQUATIC,          1, ZM_SPECIES_SHOALFIN,    11, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_SHOALFIN,     "Shoalfin",     { ZM_TYPE_WATER,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_AQUATIC,          2, ZM_SPECIES_TORRENTFIN,  11, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_TORRENTFIN,   "Torrentfin",   { ZM_TYPE_WATER,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_AQUATIC,          3, ZM_SPECIES_NONE,        11, ZM_RARITY_COMMON   },
+		// -- F12 QUADRUPED, UNCOMMON (toxin-sweating bog newt) --
+		{ ZM_SPECIES_MIRELET,      "Mirelet",      { ZM_TYPE_VENOM,    ZM_TYPE_WATER }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_BOGBANE,     12, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_BOGBANE,      "Bogbane",      { ZM_TYPE_VENOM,    ZM_TYPE_WATER }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_VENOMIRE,    12, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_VENOMIRE,     "Venomire",     { ZM_TYPE_VENOM,    ZM_TYPE_WATER }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        12, ZM_RARITY_UNCOMMON },
+		// -- F13 BIPED, UNCOMMON (boxing hare) --
+		{ ZM_SPECIES_SCRAPLING,    "Scrapling",    { ZM_TYPE_BRAWL,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            1, ZM_SPECIES_SPARHARE,    13, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_SPARHARE,     "Sparhare",     { ZM_TYPE_BRAWL,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            2, ZM_SPECIES_GRANDGUARD,  13, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_GRANDGUARD,   "Grandguard",   { ZM_TYPE_BRAWL,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            3, ZM_SPECIES_NONE,        13, ZM_RARITY_UNCOMMON },
+		// -- F14 FLOATER_PLANTOID, UNCOMMON (will-o'-the-wisp) --
+		{ ZM_SPECIES_WISPET,       "Wispet",       { ZM_TYPE_PHANTOM,  ZM_TYPE_NONE  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 1, ZM_SPECIES_GLIMMOURN,   14, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_GLIMMOURN,    "Glimmourn",    { ZM_TYPE_PHANTOM,  ZM_TYPE_NONE  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 2, ZM_SPECIES_MOURNLIGHT,  14, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_MOURNLIGHT,   "Mournlight",   { ZM_TYPE_PHANTOM,  ZM_TYPE_NONE  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 3, ZM_SPECIES_NONE,        14, ZM_RARITY_UNCOMMON },
+		// -- F15 BIPED, RARE (blindfolded seer) --
+		{ ZM_SPECIES_TRANCET,      "Trancet",      { ZM_TYPE_MIND,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            1, ZM_SPECIES_MESMEREL,    15, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_MESMEREL,     "Mesmerel",     { ZM_TYPE_MIND,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            2, ZM_SPECIES_ORACLYNE,    15, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_ORACLYNE,     "Oraclyne",     { ZM_TYPE_MIND,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BIPED,            3, ZM_SPECIES_NONE,        15, ZM_RARITY_RARE     },
+		// -- F16 QUADRUPED, UNCOMMON (alpine ice elk) --
+		{ ZM_SPECIES_FRISKET,      "Frisket",      { ZM_TYPE_ICE,      ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_SNOWLOPE,    16, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_SNOWLOPE,     "Snowlope",     { ZM_TYPE_ICE,      ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_GLACIELK,    16, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_GLACIELK,     "Glacielk",     { ZM_TYPE_ICE,      ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        16, ZM_RARITY_UNCOMMON },
+		// -- F17 SERPENT, RARE (pseudo-legendary climbing wyrm) --
+		{ ZM_SPECIES_WYRMLING,     "Wyrmling",     { ZM_TYPE_DRAKE,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_SERPENT,          1, ZM_SPECIES_CRAGWYRM,    17, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_CRAGWYRM,     "Cragwyrm",     { ZM_TYPE_DRAKE,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_SERPENT,          2, ZM_SPECIES_ZENITHRAX,   17, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_ZENITHRAX,    "Zenithrax",    { ZM_TYPE_DRAKE,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_SERPENT,          3, ZM_SPECIES_NONE,        17, ZM_RARITY_RARE     },
+		// -- F18 BLOB, UNCOMMON (living foundry slag) --
+		{ ZM_SPECIES_SLAGLET,      "Slaglet",      { ZM_TYPE_IRON,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             1, ZM_SPECIES_FERRALUMP,   18, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_FERRALUMP,    "Ferralump",    { ZM_TYPE_IRON,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             2, ZM_SPECIES_SMELTITAN,   18, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_SMELTITAN,    "Smeltitan",    { ZM_TYPE_IRON,     ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             3, ZM_SPECIES_NONE,        18, ZM_RARITY_UNCOMMON },
+		// -- F19 FLOATER_PLANTOID, RARE (flower-ring dancer) --
+		{ ZM_SPECIES_FAYLING,      "Fayling",      { ZM_TYPE_FEY,      ZM_TYPE_NONE  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 1, ZM_SPECIES_CHIMESPRITE, 19, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_CHIMESPRITE,  "Chimesprite",  { ZM_TYPE_FEY,      ZM_TYPE_NONE  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 2, ZM_SPECIES_SYLPHARA,    19, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_SYLPHARA,     "Sylphara",     { ZM_TYPE_FEY,      ZM_TYPE_NONE  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 3, ZM_SPECIES_NONE,        19, ZM_RARITY_RARE     },
+		// -- F20 QUADRUPED, UNCOMMON (dusk-woven moor cat) --
+		{ ZM_SPECIES_SHADELET,     "Shadelet",     { ZM_TYPE_UMBRAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_DUSKSTALK,   20, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_DUSKSTALK,    "Duskstalk",    { ZM_TYPE_UMBRAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_NIGHTREAVE,  20, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_NIGHTREAVE,   "Nightreave",   { ZM_TYPE_UMBRAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        20, ZM_RARITY_UNCOMMON },
+		// -- F21 INSECTOID, COMMON (hedge spider) --
+		{ ZM_SPECIES_LOOMITE,      "Loomite",      { ZM_TYPE_SWARM,    ZM_TYPE_VENOM }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_SILKLURK,    21, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_SILKLURK,     "Silklurk",     { ZM_TYPE_SWARM,    ZM_TYPE_VENOM }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_WEAVENOM,    21, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_WEAVENOM,     "Weavenom",     { ZM_TYPE_SWARM,    ZM_TYPE_VENOM }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        21, ZM_RARITY_COMMON   },
+		// -- F22 QUADRUPED, COMMON (route-digging mole) --
+		{ ZM_SPECIES_BURRIT,       "Burrit",       { ZM_TYPE_EARTH,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_GRAVELOW,    22, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_GRAVELOW,     "Gravelow",     { ZM_TYPE_EARTH,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_TERRADRILL,  22, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_TERRADRILL,   "Terradrill",   { ZM_TYPE_EARTH,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        22, ZM_RARITY_COMMON   },
+		// -- F23 AVIAN, RARE (thunderhead storm-petrel) --
+		{ ZM_SPECIES_SQUALLET,     "Squallet",     { ZM_TYPE_SKY,      ZM_TYPE_ELECTRIC }, ZM_ARCHETYPE_AVIAN,         1, ZM_SPECIES_GALECREST,   23, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_GALECREST,    "Galecrest",    { ZM_TYPE_SKY,      ZM_TYPE_ELECTRIC }, ZM_ARCHETYPE_AVIAN,         2, ZM_SPECIES_THUNDEROC,   23, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_THUNDEROC,    "Thunderoc",    { ZM_TYPE_SKY,      ZM_TYPE_ELECTRIC }, ZM_ARCHETYPE_AVIAN,         3, ZM_SPECIES_NONE,        23, ZM_RARITY_RARE     },
+		// -- F24 AQUATIC, UNCOMMON (ice-floe seal to aurora orca) --
+		{ ZM_SPECIES_FLOELET,      "Floelet",      { ZM_TYPE_WATER,    ZM_TYPE_ICE   }, ZM_ARCHETYPE_AQUATIC,          1, ZM_SPECIES_PINNIFLOE,   24, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_PINNIFLOE,    "Pinnifloe",    { ZM_TYPE_WATER,    ZM_TYPE_ICE   }, ZM_ARCHETYPE_AQUATIC,          2, ZM_SPECIES_AURORCA,     24, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_AURORCA,      "Aurorca",      { ZM_TYPE_WATER,    ZM_TYPE_ICE   }, ZM_ARCHETYPE_AQUATIC,          3, ZM_SPECIES_NONE,        24, ZM_RARITY_UNCOMMON },
+		// -- F25 QUADRUPED, UNCOMMON (volcanic scavenger jackal) --
+		{ ZM_SPECIES_CINDERJACK,   "Cinderjack",   { ZM_TYPE_FIRE,     ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_QUADRUPED,       1, ZM_SPECIES_ASHENHOWL,   25, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_ASHENHOWL,    "Ashenhowl",    { ZM_TYPE_FIRE,     ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_QUADRUPED,       2, ZM_SPECIES_NONE,        25, ZM_RARITY_UNCOMMON },
+		// -- F26 INSECTOID, UNCOMMON (pruning-blade mantis) --
+		{ ZM_SPECIES_BLADEBUD,     "Bladebud",     { ZM_TYPE_GRASS,    ZM_TYPE_SWARM }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_MANTISPRIG,  26, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_MANTISPRIG,   "Mantisprig",   { ZM_TYPE_GRASS,    ZM_TYPE_SWARM }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_VERDANTIS,   26, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_VERDANTIS,    "Verdantis",    { ZM_TYPE_GRASS,    ZM_TYPE_SWARM }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        26, ZM_RARITY_UNCOMMON },
+		// -- F27 QUADRUPED, RARE (boulder-mimic drake) --
+		{ ZM_SPECIES_SHARDSCALE,   "Shardscale",   { ZM_TYPE_STONE,    ZM_TYPE_DRAKE }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_BOULDRAKE,   27, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_BOULDRAKE,    "Bouldrake",    { ZM_TYPE_STONE,    ZM_TYPE_DRAKE }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_NONE,        27, ZM_RARITY_RARE     },
+		// -- F28 QUADRUPED, UNCOMMON (dream-storing sheep) --
+		{ ZM_SPECIES_FLEECEL,      "Fleecel",      { ZM_TYPE_NORMAL,   ZM_TYPE_FEY   }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_RAMBELLOW,   28, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_RAMBELLOW,    "Rambellow",    { ZM_TYPE_NORMAL,   ZM_TYPE_FEY   }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_NONE,        28, ZM_RARITY_UNCOMMON },
+		// -- F29 BIPED, RARE (haunted armor) --
+		{ ZM_SPECIES_RUSTSHADE,    "Rustshade",    { ZM_TYPE_PHANTOM,  ZM_TYPE_IRON  }, ZM_ARCHETYPE_BIPED,            1, ZM_SPECIES_HAUNTPLATE,  29, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_HAUNTPLATE,   "Hauntplate",   { ZM_TYPE_PHANTOM,  ZM_TYPE_IRON  }, ZM_ARCHETYPE_BIPED,            2, ZM_SPECIES_DREADARMET,  29, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_DREADARMET,   "Dreadarmet",   { ZM_TYPE_PHANTOM,  ZM_TYPE_IRON  }, ZM_ARCHETYPE_BIPED,            3, ZM_SPECIES_NONE,        29, ZM_RARITY_RARE     },
+		// -- F30 FLOATER_PLANTOID, COMMON (updraft jellyfish) --
+		{ ZM_SPECIES_PUFFJEL,      "Puffjel",      { ZM_TYPE_SKY,      ZM_TYPE_MIND  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 1, ZM_SPECIES_NIMBJEL,     30, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_NIMBJEL,      "Nimbjel",      { ZM_TYPE_SKY,      ZM_TYPE_MIND  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 2, ZM_SPECIES_STRATOJEL,   30, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_STRATOJEL,    "Stratojel",    { ZM_TYPE_SKY,      ZM_TYPE_MIND  }, ZM_ARCHETYPE_FLOATER_PLANTOID, 3, ZM_SPECIES_NONE,        30, ZM_RARITY_COMMON   },
+		// -- F31 AVIAN, COMMON (cave bat) --
+		{ ZM_SPECIES_ECHOLET,      "Echolet",      { ZM_TYPE_VENOM,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_AVIAN,           1, ZM_SPECIES_GLOOMWING,   31, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_GLOOMWING,    "Gloomwing",    { ZM_TYPE_VENOM,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_AVIAN,           2, ZM_SPECIES_NOCTURSONG,  31, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_NOCTURSONG,   "Noctursong",   { ZM_TYPE_VENOM,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_AVIAN,           3, ZM_SPECIES_NONE,        31, ZM_RARITY_COMMON   },
+		// -- F32 AQUATIC, UNCOMMON (lotus-throne pond turtle) --
+		{ ZM_SPECIES_PADLET,       "Padlet",       { ZM_TYPE_WATER,    ZM_TYPE_GRASS }, ZM_ARCHETYPE_AQUATIC,          1, ZM_SPECIES_LILYTURT,    32, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_LILYTURT,     "Lilyturt",     { ZM_TYPE_WATER,    ZM_TYPE_GRASS }, ZM_ARCHETYPE_AQUATIC,          2, ZM_SPECIES_LOTUSTLE,    32, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_LOTUSTLE,     "Lotustle",     { ZM_TYPE_WATER,    ZM_TYPE_GRASS }, ZM_ARCHETYPE_AQUATIC,          3, ZM_SPECIES_NONE,        32, ZM_RARITY_UNCOMMON },
+		// -- F33 INSECTOID, UNCOMMON (firefly streetlamp) --
+		{ ZM_SPECIES_GLOWMITE,     "Glowmite",     { ZM_TYPE_FIRE,     ZM_TYPE_SWARM }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_EMBERFLY,    33, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_EMBERFLY,     "Emberfly",     { ZM_TYPE_FIRE,     ZM_TYPE_SWARM }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_PYRELUME,    33, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_PYRELUME,     "Pyrelume",     { ZM_TYPE_FIRE,     ZM_TYPE_SWARM }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        33, ZM_RARITY_UNCOMMON },
+		// -- F34 QUADRUPED, UNCOMMON (fortress pangolin) --
+		{ ZM_SPECIES_SCUTLET,      "Scutlet",      { ZM_TYPE_EARTH,    ZM_TYPE_STONE }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_PANGROL,     34, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_PANGROL,      "Pangrol",      { ZM_TYPE_EARTH,    ZM_TYPE_STONE }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_FORTRESCALE, 34, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_FORTRESCALE,  "Fortrescale",  { ZM_TYPE_EARTH,    ZM_TYPE_STONE }, ZM_ARCHETYPE_QUADRUPED,        3, ZM_SPECIES_NONE,        34, ZM_RARITY_UNCOMMON },
+		// -- F35 BLOB, UNCOMMON (living dynamo) --
+		{ ZM_SPECIES_VOLTNUT,      "Voltnut",      { ZM_TYPE_ELECTRIC, ZM_TYPE_IRON  }, ZM_ARCHETYPE_BLOB,             1, ZM_SPECIES_COILCORE,    35, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_COILCORE,     "Coilcore",     { ZM_TYPE_ELECTRIC, ZM_TYPE_IRON  }, ZM_ARCHETYPE_BLOB,             2, ZM_SPECIES_NONE,        35, ZM_RARITY_UNCOMMON },
+		// -- F36 FLOATER_PLANTOID, RARE (blizzard wraith) --
+		{ ZM_SPECIES_CHILLSHADE,   "Chillshade",   { ZM_TYPE_ICE,      ZM_TYPE_PHANTOM }, ZM_ARCHETYPE_FLOATER_PLANTOID, 1, ZM_SPECIES_FROSTWRAITH, 36, ZM_RARITY_RARE   },
+		{ ZM_SPECIES_FROSTWRAITH,  "Frostwraith",  { ZM_TYPE_ICE,      ZM_TYPE_PHANTOM }, ZM_ARCHETYPE_FLOATER_PLANTOID, 2, ZM_SPECIES_PERMAFRIGHT, 36, ZM_RARITY_RARE   },
+		{ ZM_SPECIES_PERMAFRIGHT,  "Permafright",  { ZM_TYPE_ICE,      ZM_TYPE_PHANTOM }, ZM_ARCHETYPE_FLOATER_PLANTOID, 3, ZM_SPECIES_NONE,        36, ZM_RARITY_RARE   },
+		// -- F37 BIPED, UNCOMMON (quarry golem boxer) --
+		{ ZM_SPECIES_PEBBLEFIST,   "Pebblefist",   { ZM_TYPE_BRAWL,    ZM_TYPE_STONE }, ZM_ARCHETYPE_BIPED,            1, ZM_SPECIES_COBBLEBRAWN, 37, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_COBBLEBRAWN,  "Cobblebrawn",  { ZM_TYPE_BRAWL,    ZM_TYPE_STONE }, ZM_ARCHETYPE_BIPED,            2, ZM_SPECIES_MONUMENTOR,  37, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_MONUMENTOR,   "Monumentor",   { ZM_TYPE_BRAWL,    ZM_TYPE_STONE }, ZM_ARCHETYPE_BIPED,            3, ZM_SPECIES_NONE,        37, ZM_RARITY_UNCOMMON },
+		// -- F38 FLOATER_PLANTOID, COMMON (walking night mushroom) --
+		{ ZM_SPECIES_SPORELING,    "Sporeling",    { ZM_TYPE_GRASS,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_FLOATER_PLANTOID, 1, ZM_SPECIES_DUSKCAP,     38, ZM_RARITY_COMMON  },
+		{ ZM_SPECIES_DUSKCAP,      "Duskcap",      { ZM_TYPE_GRASS,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_FLOATER_PLANTOID, 2, ZM_SPECIES_FUNGROVE,    38, ZM_RARITY_COMMON  },
+		{ ZM_SPECIES_FUNGROVE,     "Fungrove",     { ZM_TYPE_GRASS,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_FLOATER_PLANTOID, 3, ZM_SPECIES_NONE,        38, ZM_RARITY_COMMON  },
+		// -- F39 AVIAN, COMMON (coastal gull) --
+		{ ZM_SPECIES_SKIMMET,      "Skimmet",      { ZM_TYPE_WATER,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_AVIAN,            1, ZM_SPECIES_PELAGAIR,    39, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_PELAGAIR,     "Pelagair",     { ZM_TYPE_WATER,    ZM_TYPE_SKY   }, ZM_ARCHETYPE_AVIAN,            2, ZM_SPECIES_NONE,        39, ZM_RARITY_COMMON   },
+		// -- F40 BLOB, COMMON (amiable ooze) --
+		{ ZM_SPECIES_GLOOPET,      "Gloopet",      { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             1, ZM_SPECIES_GLUTTONUB,   40, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_GLUTTONUB,    "Gluttonub",    { ZM_TYPE_NORMAL,   ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             2, ZM_SPECIES_NONE,        40, ZM_RARITY_COMMON   },
+		// -- F41 BLOB, COMMON (city-drain sludge) --
+		{ ZM_SPECIES_OOZEL,        "Oozel",        { ZM_TYPE_VENOM,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             1, ZM_SPECIES_MIREMASS,    41, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_MIREMASS,     "Miremass",     { ZM_TYPE_VENOM,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_BLOB,             2, ZM_SPECIES_NONE,        41, ZM_RARITY_COMMON   },
+		// -- F42 QUADRUPED, RARE (starlight foal) --
+		{ ZM_SPECIES_MOONFOAL,     "Moonfoal",     { ZM_TYPE_FEY,      ZM_TYPE_MIND  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_ASTRAMARE,   42, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_ASTRAMARE,    "Astramare",    { ZM_TYPE_FEY,      ZM_TYPE_MIND  }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_NONE,        42, ZM_RARITY_RARE     },
+		// -- F43 SERPENT, RARE (volcano serpent) --
+		{ ZM_SPECIES_CINDERASP,    "Cinderasp",    { ZM_TYPE_FIRE,     ZM_TYPE_DRAKE }, ZM_ARCHETYPE_SERPENT,          1, ZM_SPECIES_MAGMABOA,    43, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_MAGMABOA,     "Magmaboa",     { ZM_TYPE_FIRE,     ZM_TYPE_DRAKE }, ZM_ARCHETYPE_SERPENT,          2, ZM_SPECIES_PYROTHON,    43, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_PYROTHON,     "Pyrothon",     { ZM_TYPE_FIRE,     ZM_TYPE_DRAKE }, ZM_ARCHETYPE_SERPENT,          3, ZM_SPECIES_NONE,        43, ZM_RARITY_RARE     },
+		// -- F44 INSECTOID, RARE (geode-boring beetle) --
+		{ ZM_SPECIES_PRISMITE,     "Prismite",     { ZM_TYPE_SWARM,    ZM_TYPE_STONE }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_GEOBORER,    44, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_GEOBORER,     "Geoborer",     { ZM_TYPE_SWARM,    ZM_TYPE_STONE }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_CRYSTALLISK, 44, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_CRYSTALLISK,  "Crystallisk",  { ZM_TYPE_SWARM,    ZM_TYPE_STONE }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        44, ZM_RARITY_RARE     },
+		// -- F45 AVIAN, UNCOMMON (martial crane) --
+		{ ZM_SPECIES_PECKIT,       "Peckit",       { ZM_TYPE_SKY,      ZM_TYPE_BRAWL }, ZM_ARCHETYPE_AVIAN,            1, ZM_SPECIES_LONGSTRIDE,  45, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_LONGSTRIDE,   "Longstride",   { ZM_TYPE_SKY,      ZM_TYPE_BRAWL }, ZM_ARCHETYPE_AVIAN,            2, ZM_SPECIES_CRANECLASH,  45, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_CRANECLASH,   "Craneclash",   { ZM_TYPE_SKY,      ZM_TYPE_BRAWL }, ZM_ARCHETYPE_AVIAN,            3, ZM_SPECIES_NONE,        45, ZM_RARITY_UNCOMMON },
+		// -- F46 INSECTOID, UNCOMMON (badlands scorpion) --
+		{ ZM_SPECIES_STINGLET,     "Stinglet",     { ZM_TYPE_EARTH,    ZM_TYPE_VENOM }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_BARBTAIL,    46, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_BARBTAIL,     "Barbtail",     { ZM_TYPE_EARTH,    ZM_TYPE_VENOM }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_SCORPICRAG,  46, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_SCORPICRAG,   "Scorpicrag",   { ZM_TYPE_EARTH,    ZM_TYPE_VENOM }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        46, ZM_RARITY_UNCOMMON },
+		// -- F47 QUADRUPED, COMMON (flying squirrel) --
+		{ ZM_SPECIES_GLIDEKIN,     "Glidekin",     { ZM_TYPE_NORMAL,   ZM_TYPE_SKY   }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_SOAREL,      47, ZM_RARITY_COMMON   },
+		{ ZM_SPECIES_SOAREL,       "Soarel",       { ZM_TYPE_NORMAL,   ZM_TYPE_SKY   }, ZM_ARCHETYPE_QUADRUPED,        2, ZM_SPECIES_NONE,        47, ZM_RARITY_COMMON   },
+		// -- F48 SERPENT, RARE (feeble fish that isn't) --
+		{ ZM_SPECIES_FLOPFIN,      "Flopfin",      { ZM_TYPE_WATER,    ZM_TYPE_NONE  }, ZM_ARCHETYPE_SERPENT,          1, ZM_SPECIES_LEVIANTH,    48, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_LEVIANTH,     "Levianth",     { ZM_TYPE_WATER,    ZM_TYPE_DRAKE }, ZM_ARCHETYPE_SERPENT,          2, ZM_SPECIES_NONE,        48, ZM_RARITY_RARE     },
+		// -- F49 QUADRUPED, UNCOMMON (graveyard hound) --
+		{ ZM_SPECIES_GRAVEPUP,     "Gravepup",     { ZM_TYPE_PHANTOM,  ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_QUADRUPED,       1, ZM_SPECIES_DIRGEHOUND,  49, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_DIRGEHOUND,   "Dirgehound",   { ZM_TYPE_PHANTOM,  ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_QUADRUPED,       2, ZM_SPECIES_NONE,        49, ZM_RARITY_UNCOMMON },
+		// -- F50 BIPED, RARE (clockwork oracle) --
+		{ ZM_SPECIES_COGLING,      "Cogling",      { ZM_TYPE_MIND,     ZM_TYPE_IRON  }, ZM_ARCHETYPE_BIPED,            1, ZM_SPECIES_CEREBRASS,   50, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_CEREBRASS,    "Cerebrass",    { ZM_TYPE_MIND,     ZM_TYPE_IRON  }, ZM_ARCHETYPE_BIPED,            2, ZM_SPECIES_NONE,        50, ZM_RARITY_RARE     },
+		// -- F51 AVIAN, UNCOMMON (augur raven) --
+		{ ZM_SPECIES_CORVIT,       "Corvit",       { ZM_TYPE_UMBRAL,   ZM_TYPE_MIND  }, ZM_ARCHETYPE_AVIAN,            1, ZM_SPECIES_OMENROOK,    51, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_OMENROOK,     "Omenrook",     { ZM_TYPE_UMBRAL,   ZM_TYPE_MIND  }, ZM_ARCHETYPE_AVIAN,            2, ZM_SPECIES_AUGURAVAN,   51, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_AUGURAVAN,    "Auguravan",    { ZM_TYPE_UMBRAL,   ZM_TYPE_MIND  }, ZM_ARCHETYPE_AVIAN,            3, ZM_SPECIES_NONE,        51, ZM_RARITY_UNCOMMON },
+		// -- F52 INSECTOID, UNCOMMON (hive-mind) --
+		{ ZM_SPECIES_POLLENET,     "Pollenet",     { ZM_TYPE_SWARM,    ZM_TYPE_MIND  }, ZM_ARCHETYPE_INSECTOID,        1, ZM_SPECIES_COMBWING,    52, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_COMBWING,     "Combwing",     { ZM_TYPE_SWARM,    ZM_TYPE_MIND  }, ZM_ARCHETYPE_INSECTOID,        2, ZM_SPECIES_HIVEMIND,    52, ZM_RARITY_UNCOMMON },
+		{ ZM_SPECIES_HIVEMIND,     "Hivemind",     { ZM_TYPE_SWARM,    ZM_TYPE_MIND  }, ZM_ARCHETYPE_INSECTOID,        3, ZM_SPECIES_NONE,        52, ZM_RARITY_UNCOMMON },
+		// -- F53 AQUATIC, RARE (deep-lake angler) --
+		{ ZM_SPECIES_LURELET,      "Lurelet",      { ZM_TYPE_WATER,    ZM_TYPE_PHANTOM }, ZM_ARCHETYPE_AQUATIC,        1, ZM_SPECIES_DEEPGLEAM,   53, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_DEEPGLEAM,    "Deepgleam",    { ZM_TYPE_WATER,    ZM_TYPE_PHANTOM }, ZM_ARCHETYPE_AQUATIC,        2, ZM_SPECIES_ABYSSVEIL,   53, ZM_RARITY_RARE     },
+		{ ZM_SPECIES_ABYSSVEIL,    "Abyssveil",    { ZM_TYPE_WATER,    ZM_TYPE_PHANTOM }, ZM_ARCHETYPE_AQUATIC,        3, ZM_SPECIES_NONE,        53, ZM_RARITY_RARE     },
+		// -- F54 QUADRUPED, RARE (single: gold-horned antelope) --
+		{ ZM_SPECIES_AURICORN,     "Auricorn",     { ZM_TYPE_IRON,     ZM_TYPE_FEY   }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_NONE,        54, ZM_RARITY_RARE     },
+		// -- F55 QUADRUPED, RARE (single: wall-mimic chameleon) --
+		{ ZM_SPECIES_DUNELEON,     "Duneleon",     { ZM_TYPE_EARTH,    ZM_TYPE_UMBRAL }, ZM_ARCHETYPE_QUADRUPED,       1, ZM_SPECIES_NONE,        55, ZM_RARITY_RARE     },
+		// -- F56 AQUATIC, RARE (single: hot-spring koi) --
+		{ ZM_SPECIES_EMBERKOI,     "Emberkoi",     { ZM_TYPE_FIRE,     ZM_TYPE_WATER }, ZM_ARCHETYPE_AQUATIC,          1, ZM_SPECIES_NONE,        56, ZM_RARITY_RARE     },
+		// -- Legendaries (single stage) --
+		{ ZM_SPECIES_ZENARIS,      "Zenaris",      { ZM_TYPE_SKY,      ZM_TYPE_FIRE  }, ZM_ARCHETYPE_AVIAN,            1, ZM_SPECIES_NONE,        57, ZM_RARITY_LEGENDARY },
+		{ ZM_SPECIES_NADIRATH,     "Nadirath",     { ZM_TYPE_UMBRAL,   ZM_TYPE_EARTH }, ZM_ARCHETYPE_SERPENT,          1, ZM_SPECIES_NONE,        58, ZM_RARITY_LEGENDARY },
+		{ ZM_SPECIES_EQUINARA,     "Equinara",     { ZM_TYPE_FEY,      ZM_TYPE_MIND  }, ZM_ARCHETYPE_QUADRUPED,        1, ZM_SPECIES_NONE,        59, ZM_RARITY_LEGENDARY },
+	};
+}
+
+const ZM_SpeciesData& ZM_GetSpeciesData(ZM_SPECIES_ID eId)
+{
+	Zenith_Assert(eId < ZM_SPECIES_COUNT, "ZM_GetSpeciesData: species id out of range (%u)", (u_int)eId);
+	return s_axSpecies[eId];
+}
+
+u_int ZM_GetSpeciesCount()
+{
+	return ZM_SPECIES_COUNT;
+}
+
+const char* ZM_GetSpeciesName(ZM_SPECIES_ID eId)
+{
+	if (eId >= ZM_SPECIES_COUNT)
+	{
+		return "NONE";
+	}
+	return s_axSpecies[eId].m_szName;
+}
+
+ZM_SIZE_CLASS ZM_GetSpeciesSizeClass(ZM_SPECIES_ID eId)
+{
+	const ZM_SpeciesData& xData = ZM_GetSpeciesData(eId);
+
+	// Base scale from evolution stage: stage 1 SMALL, 2 MEDIUM, 3 LARGE.
+	int iSize = (int)ZM_SIZE_SMALL + ((int)xData.m_uEvoStage - 1);
+
+	// Body-plan nudges: small fliers/bugs/drifters read a step smaller, bulky
+	// serpents/blobs a step larger. Constant within a family, so size stays
+	// non-decreasing along an evolution chain.
+	switch (xData.m_eArchetype)
+	{
+	case ZM_ARCHETYPE_AVIAN:
+	case ZM_ARCHETYPE_INSECTOID:
+	case ZM_ARCHETYPE_FLOATER_PLANTOID:
+		iSize -= 1;
+		break;
+	case ZM_ARCHETYPE_SERPENT:
+	case ZM_ARCHETYPE_BLOB:
+		iSize += 1;
+		break;
+	default:
+		break;
+	}
+
+	// Legendaries loom regardless of stage.
+	if (xData.m_eRarity == ZM_RARITY_LEGENDARY)
+	{
+		iSize = (int)ZM_SIZE_HUGE;
+	}
+
+	if (iSize < (int)ZM_SIZE_TINY) { iSize = (int)ZM_SIZE_TINY; }
+	if (iSize > (int)ZM_SIZE_HUGE) { iSize = (int)ZM_SIZE_HUGE; }
+	return (ZM_SIZE_CLASS)iSize;
+}
+
+u_int ZM_GetSpeciesFamilySeed(ZM_SPECIES_ID eId)
+{
+	// Shared by all stages of a family; Knuth multiplicative hash of the family
+	// id gives a well-spread, deterministic, per-family-unique generator seed.
+	const u_int uFamilyId = ZM_GetSpeciesData(eId).m_uFamilyId;
+	return uFamilyId * 2654435761u;
+}

--- a/Games/Zenithmon/Source/Data/ZM_SpeciesData.h
+++ b/Games/Zenithmon/Source/Data/ZM_SpeciesData.h
@@ -1,0 +1,299 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_Types.h"
+
+// ============================================================================
+// ZM_SpeciesData -- the species dex table (S1 data core).
+//
+// This is the STRUCTURAL roster: id / name / type(s) / archetype / evolution /
+// family / rarity for all 152 species from Docs/GameDesignDocument.md section 5.
+// Base stats and learnsets are deferred to follow-up increments on the same
+// Roadmap box (stats are a design pass; learnsets need ZM_MoveData) -- see
+// DecisionLog ZM-D-020.
+//
+// Data is a compiled const C array (DecisionLog ZM-D-009): zero file I/O in
+// headless tests. The ZM_SPECIES_ID order is the dex order and is save-stable
+// once content ships -- APPEND before ZM_SPECIES_COUNT, never reorder.
+// ============================================================================
+
+// The 8 body plans -- each names the ZM_CreatureGen builder used for a family
+// (S4). All stages of a family share one archetype (GDD 5).
+enum ZM_ARCHETYPE : u_int
+{
+	ZM_ARCHETYPE_QUADRUPED,
+	ZM_ARCHETYPE_BIPED,
+	ZM_ARCHETYPE_AVIAN,
+	ZM_ARCHETYPE_SERPENT,
+	ZM_ARCHETYPE_AQUATIC,
+	ZM_ARCHETYPE_INSECTOID,
+	ZM_ARCHETYPE_BLOB,
+	ZM_ARCHETYPE_FLOATER_PLANTOID,
+
+	ZM_ARCHETYPE_COUNT
+};
+
+// Encounter-slot weight tier; LEGENDARY gates post-game (GDD 5).
+enum ZM_RARITY : u_int
+{
+	ZM_RARITY_COMMON,
+	ZM_RARITY_UNCOMMON,
+	ZM_RARITY_RARE,
+	ZM_RARITY_LEGENDARY,
+
+	ZM_RARITY_COUNT
+};
+
+// Rough physical scale, consumed by ZM_CreatureGen (S4) and camera framing.
+// Derived from evolution stage + archetype for now (see ZM_GetSpeciesSizeClass).
+enum ZM_SIZE_CLASS : u_int
+{
+	ZM_SIZE_TINY,
+	ZM_SIZE_SMALL,
+	ZM_SIZE_MEDIUM,
+	ZM_SIZE_LARGE,
+	ZM_SIZE_HUGE,
+
+	ZM_SIZE_COUNT
+};
+
+// Every species, in dex order: family F01..F56 (each family's stages in order),
+// then the three legendaries. IDs are contiguous 0..ZM_SPECIES_COUNT-1.
+enum ZM_SPECIES_ID : u_int
+{
+	// F01 QUADRUPED (starter -- grove-antlered deer)
+	ZM_SPECIES_FERNFAWN,
+	ZM_SPECIES_THICKETBUCK,
+	ZM_SPECIES_SYLVASTAG,
+	// F02 BIPED (starter -- self-firing kiln salamander)
+	ZM_SPECIES_KINDLET,
+	ZM_SPECIES_SCORCHEL,
+	ZM_SPECIES_PYROCLAST,
+	// F03 AQUATIC (starter -- blade-billed duelist fish)
+	ZM_SPECIES_FINLET,
+	ZM_SPECIES_MARLANCE,
+	ZM_SPECIES_TIDESABRE,
+	// F04 AVIAN (everywhere-songbird)
+	ZM_SPECIES_PIPWIT,
+	ZM_SPECIES_TRILLARK,
+	ZM_SPECIES_STRATAVIS,
+	// F05 QUADRUPED (seed-hoarding vole)
+	ZM_SPECIES_NIBBIN,
+	ZM_SPECIES_HOARDEL,
+	ZM_SPECIES_GRAINMAW,
+	// F06 INSECTOID (early butterfly)
+	ZM_SPECIES_WRIGGLET,
+	ZM_SPECIES_CRADLEWRAP,
+	ZM_SPECIES_AURELWING,
+	// F07 QUADRUPED (gate-guarding hound) -- 2 stages
+	ZM_SPECIES_STRAYLING,
+	ZM_SPECIES_WARDHUND,
+	// F08 FLOATER_PLANTOID (dandelion drifter)
+	ZM_SPECIES_PUFFSEED,
+	ZM_SPECIES_DANDELIFT,
+	ZM_SPECIES_ZEPHYRBLOOM,
+	// F09 QUADRUPED (storm-chasing fox)
+	ZM_SPECIES_SPARKIT,
+	ZM_SPECIES_AMPTAIL,
+	ZM_SPECIES_FULGURUN,
+	// F10 BLOB (walking cairn)
+	ZM_SPECIES_RUBBLET,
+	ZM_SPECIES_CAIRNGO,
+	ZM_SPECIES_MONOLODE,
+	// F11 AQUATIC (universal river fish)
+	ZM_SPECIES_MINNET,
+	ZM_SPECIES_SHOALFIN,
+	ZM_SPECIES_TORRENTFIN,
+	// F12 QUADRUPED (toxin-sweating bog newt)
+	ZM_SPECIES_MIRELET,
+	ZM_SPECIES_BOGBANE,
+	ZM_SPECIES_VENOMIRE,
+	// F13 BIPED (boxing hare)
+	ZM_SPECIES_SCRAPLING,
+	ZM_SPECIES_SPARHARE,
+	ZM_SPECIES_GRANDGUARD,
+	// F14 FLOATER_PLANTOID (will-o'-the-wisp)
+	ZM_SPECIES_WISPET,
+	ZM_SPECIES_GLIMMOURN,
+	ZM_SPECIES_MOURNLIGHT,
+	// F15 BIPED (blindfolded seer)
+	ZM_SPECIES_TRANCET,
+	ZM_SPECIES_MESMEREL,
+	ZM_SPECIES_ORACLYNE,
+	// F16 QUADRUPED (alpine ice elk)
+	ZM_SPECIES_FRISKET,
+	ZM_SPECIES_SNOWLOPE,
+	ZM_SPECIES_GLACIELK,
+	// F17 SERPENT (pseudo-legendary climbing wyrm)
+	ZM_SPECIES_WYRMLING,
+	ZM_SPECIES_CRAGWYRM,
+	ZM_SPECIES_ZENITHRAX,
+	// F18 BLOB (living foundry slag)
+	ZM_SPECIES_SLAGLET,
+	ZM_SPECIES_FERRALUMP,
+	ZM_SPECIES_SMELTITAN,
+	// F19 FLOATER_PLANTOID (flower-ring dancer)
+	ZM_SPECIES_FAYLING,
+	ZM_SPECIES_CHIMESPRITE,
+	ZM_SPECIES_SYLPHARA,
+	// F20 QUADRUPED (dusk-woven moor cat)
+	ZM_SPECIES_SHADELET,
+	ZM_SPECIES_DUSKSTALK,
+	ZM_SPECIES_NIGHTREAVE,
+	// F21 INSECTOID (hedge spider)
+	ZM_SPECIES_LOOMITE,
+	ZM_SPECIES_SILKLURK,
+	ZM_SPECIES_WEAVENOM,
+	// F22 QUADRUPED (route-digging mole)
+	ZM_SPECIES_BURRIT,
+	ZM_SPECIES_GRAVELOW,
+	ZM_SPECIES_TERRADRILL,
+	// F23 AVIAN (thunderhead storm-petrel)
+	ZM_SPECIES_SQUALLET,
+	ZM_SPECIES_GALECREST,
+	ZM_SPECIES_THUNDEROC,
+	// F24 AQUATIC (ice-floe seal to aurora orca)
+	ZM_SPECIES_FLOELET,
+	ZM_SPECIES_PINNIFLOE,
+	ZM_SPECIES_AURORCA,
+	// F25 QUADRUPED (volcanic scavenger jackal) -- 2 stages
+	ZM_SPECIES_CINDERJACK,
+	ZM_SPECIES_ASHENHOWL,
+	// F26 INSECTOID (pruning-blade mantis)
+	ZM_SPECIES_BLADEBUD,
+	ZM_SPECIES_MANTISPRIG,
+	ZM_SPECIES_VERDANTIS,
+	// F27 QUADRUPED (boulder-mimic drake) -- 2 stages
+	ZM_SPECIES_SHARDSCALE,
+	ZM_SPECIES_BOULDRAKE,
+	// F28 QUADRUPED (dream-storing sheep) -- 2 stages
+	ZM_SPECIES_FLEECEL,
+	ZM_SPECIES_RAMBELLOW,
+	// F29 BIPED (haunted armor)
+	ZM_SPECIES_RUSTSHADE,
+	ZM_SPECIES_HAUNTPLATE,
+	ZM_SPECIES_DREADARMET,
+	// F30 FLOATER_PLANTOID (updraft jellyfish)
+	ZM_SPECIES_PUFFJEL,
+	ZM_SPECIES_NIMBJEL,
+	ZM_SPECIES_STRATOJEL,
+	// F31 AVIAN (cave bat)
+	ZM_SPECIES_ECHOLET,
+	ZM_SPECIES_GLOOMWING,
+	ZM_SPECIES_NOCTURSONG,
+	// F32 AQUATIC (lotus-throne pond turtle)
+	ZM_SPECIES_PADLET,
+	ZM_SPECIES_LILYTURT,
+	ZM_SPECIES_LOTUSTLE,
+	// F33 INSECTOID (firefly streetlamp)
+	ZM_SPECIES_GLOWMITE,
+	ZM_SPECIES_EMBERFLY,
+	ZM_SPECIES_PYRELUME,
+	// F34 QUADRUPED (fortress pangolin)
+	ZM_SPECIES_SCUTLET,
+	ZM_SPECIES_PANGROL,
+	ZM_SPECIES_FORTRESCALE,
+	// F35 BLOB (living dynamo) -- 2 stages
+	ZM_SPECIES_VOLTNUT,
+	ZM_SPECIES_COILCORE,
+	// F36 FLOATER_PLANTOID (blizzard wraith)
+	ZM_SPECIES_CHILLSHADE,
+	ZM_SPECIES_FROSTWRAITH,
+	ZM_SPECIES_PERMAFRIGHT,
+	// F37 BIPED (quarry golem boxer)
+	ZM_SPECIES_PEBBLEFIST,
+	ZM_SPECIES_COBBLEBRAWN,
+	ZM_SPECIES_MONUMENTOR,
+	// F38 FLOATER_PLANTOID (walking night mushroom)
+	ZM_SPECIES_SPORELING,
+	ZM_SPECIES_DUSKCAP,
+	ZM_SPECIES_FUNGROVE,
+	// F39 AVIAN (coastal gull) -- 2 stages
+	ZM_SPECIES_SKIMMET,
+	ZM_SPECIES_PELAGAIR,
+	// F40 BLOB (amiable ooze) -- 2 stages
+	ZM_SPECIES_GLOOPET,
+	ZM_SPECIES_GLUTTONUB,
+	// F41 BLOB (city-drain sludge) -- 2 stages
+	ZM_SPECIES_OOZEL,
+	ZM_SPECIES_MIREMASS,
+	// F42 QUADRUPED (starlight foal) -- 2 stages
+	ZM_SPECIES_MOONFOAL,
+	ZM_SPECIES_ASTRAMARE,
+	// F43 SERPENT (volcano serpent)
+	ZM_SPECIES_CINDERASP,
+	ZM_SPECIES_MAGMABOA,
+	ZM_SPECIES_PYROTHON,
+	// F44 INSECTOID (geode-boring beetle)
+	ZM_SPECIES_PRISMITE,
+	ZM_SPECIES_GEOBORER,
+	ZM_SPECIES_CRYSTALLISK,
+	// F45 AVIAN (martial crane)
+	ZM_SPECIES_PECKIT,
+	ZM_SPECIES_LONGSTRIDE,
+	ZM_SPECIES_CRANECLASH,
+	// F46 INSECTOID (badlands scorpion)
+	ZM_SPECIES_STINGLET,
+	ZM_SPECIES_BARBTAIL,
+	ZM_SPECIES_SCORPICRAG,
+	// F47 QUADRUPED (flying squirrel) -- 2 stages
+	ZM_SPECIES_GLIDEKIN,
+	ZM_SPECIES_SOAREL,
+	// F48 SERPENT (feeble fish that isn't) -- 2 stages
+	ZM_SPECIES_FLOPFIN,
+	ZM_SPECIES_LEVIANTH,
+	// F49 QUADRUPED (graveyard hound) -- 2 stages
+	ZM_SPECIES_GRAVEPUP,
+	ZM_SPECIES_DIRGEHOUND,
+	// F50 BIPED (clockwork oracle) -- 2 stages
+	ZM_SPECIES_COGLING,
+	ZM_SPECIES_CEREBRASS,
+	// F51 AVIAN (augur raven)
+	ZM_SPECIES_CORVIT,
+	ZM_SPECIES_OMENROOK,
+	ZM_SPECIES_AUGURAVAN,
+	// F52 INSECTOID (hive-mind)
+	ZM_SPECIES_POLLENET,
+	ZM_SPECIES_COMBWING,
+	ZM_SPECIES_HIVEMIND,
+	// F53 AQUATIC (deep-lake angler)
+	ZM_SPECIES_LURELET,
+	ZM_SPECIES_DEEPGLEAM,
+	ZM_SPECIES_ABYSSVEIL,
+	// F54 QUADRUPED (gold-horned antelope) -- single stage
+	ZM_SPECIES_AURICORN,
+	// F55 QUADRUPED (wall-mimic chameleon) -- single stage
+	ZM_SPECIES_DUNELEON,
+	// F56 AQUATIC (hot-spring koi) -- single stage
+	ZM_SPECIES_EMBERKOI,
+	// Legendaries (single stage)
+	ZM_SPECIES_ZENARIS,   // L01 -- the Noon Crown
+	ZM_SPECIES_NADIRATH,  // L02 -- the Under-Coil
+	ZM_SPECIES_EQUINARA,  // L03 -- the Horizon-Walker
+
+	ZM_SPECIES_COUNT,
+	ZM_SPECIES_NONE = ZM_SPECIES_COUNT   // "no species" sentinel (e.g. final-stage evolves-to)
+};
+
+// One dex row. Base stats + learnsets are added by later increments on this box.
+struct ZM_SpeciesData
+{
+	ZM_SPECIES_ID	m_eId;
+	const char*		m_szName;
+	ZM_TYPE			m_aeTypes[2];		// [1] == ZM_TYPE_NONE for single-type species
+	ZM_ARCHETYPE	m_eArchetype;
+	u_int			m_uEvoStage;		// 1, 2, or 3 (1 for single-stage / legendary)
+	ZM_SPECIES_ID	m_eEvolvesTo;		// next stage, or ZM_SPECIES_NONE if final
+	u_int			m_uFamilyId;		// 1..56 for F-families; 57..59 for legendaries
+	ZM_RARITY		m_eRarity;
+};
+
+// Table accessors (bounds-asserted). GetSpeciesData indexes by ZM_SPECIES_ID.
+const ZM_SpeciesData&	ZM_GetSpeciesData(ZM_SPECIES_ID eId);
+u_int					ZM_GetSpeciesCount();				// == ZM_SPECIES_COUNT
+const char*				ZM_GetSpeciesName(ZM_SPECIES_ID eId);
+
+// Rule-derived species fields (stored per-row later if per-species tuning is
+// needed): size class from evo stage + archetype; the per-family generator seed
+// shared by all stages of a family (S4 ZM_CreatureGen input).
+ZM_SIZE_CLASS			ZM_GetSpeciesSizeClass(ZM_SPECIES_ID eId);
+u_int					ZM_GetSpeciesFamilySeed(ZM_SPECIES_ID eId);

--- a/Games/Zenithmon/Tests/ZM_Tests_Species.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_Species.cpp
@@ -1,0 +1,298 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_Species -- structural integrity of the species dex (category
+// ZM_Data). This is the schema enforcer for the 152-species roster: it pins the
+// counts from Docs/GameDesignDocument.md section 5, the evolution graph shape,
+// and per-family consistency. Base-stat / learnset tests join as those fields
+// land on the same Roadmap box.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_Types.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+
+#include <cstring>   // strcmp
+
+namespace
+{
+	constexpr u_int uEXPECTED_SPECIES = 152;
+	constexpr u_int uEXPECTED_FAMILIES = 59;   // 56 F-families + 3 legendaries
+	constexpr u_int uMAX_FAMILY_ID = 60;       // sizing headroom (ids run 1..59)
+
+	const ZM_SpeciesData& Sp(u_int uIndex)
+	{
+		return ZM_GetSpeciesData((ZM_SPECIES_ID)uIndex);
+	}
+}
+
+// The roster is exactly 152 species and the table is index-consistent.
+ZENITH_TEST(ZM_Data, Species_CountAndSelfConsistent)
+{
+	ZENITH_ASSERT_EQ(ZM_GetSpeciesCount(), uEXPECTED_SPECIES);
+	ZENITH_ASSERT_EQ((u_int)ZM_SPECIES_COUNT, uEXPECTED_SPECIES);
+
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)Sp(i).m_eId, i, "species row %u has mismatched m_eId", i);
+	}
+}
+
+// Every name is present and unique.
+ZENITH_TEST(ZM_Data, Species_NamesUniqueNonEmpty)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const char* szA = Sp(i).m_szName;
+		ZENITH_ASSERT_NOT_NULL(szA);
+		ZENITH_ASSERT_TRUE(szA[0] != '\0', "species %u has an empty name", i);
+		for (u_int j = i + 1; j < ZM_SPECIES_COUNT; ++j)
+		{
+			ZENITH_ASSERT_FALSE(strcmp(szA, Sp(j).m_szName) == 0,
+				"duplicate species name '%s' at %u and %u", szA, i, j);
+		}
+	}
+}
+
+// Types: primary is a real type; secondary is real or NONE; never doubled.
+ZENITH_TEST(ZM_Data, Species_TypesValid)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		ZENITH_ASSERT_TRUE(x.m_aeTypes[0] < ZM_TYPE_COUNT,
+			"%s primary type is not a real type", x.m_szName);
+		ZENITH_ASSERT_TRUE(x.m_aeTypes[1] < ZM_TYPE_COUNT || x.m_aeTypes[1] == ZM_TYPE_NONE,
+			"%s secondary type out of range", x.m_szName);
+		if (x.m_aeTypes[1] != ZM_TYPE_NONE)
+		{
+			ZENITH_ASSERT_NE(x.m_aeTypes[0], x.m_aeTypes[1],
+				"%s lists the same type twice", x.m_szName);
+		}
+	}
+}
+
+// Evolution stage is 1..3; the graph is well-formed: a non-final species points
+// to a real next-stage species in the SAME family (stage+1, same archetype and
+// rarity); a final species points to NONE.
+ZENITH_TEST(ZM_Data, Species_EvolutionGraphValid)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		ZENITH_ASSERT_TRUE(x.m_uEvoStage >= 1 && x.m_uEvoStage <= 3,
+			"%s has out-of-range evo stage %u", x.m_szName, x.m_uEvoStage);
+
+		if (x.m_eEvolvesTo == ZM_SPECIES_NONE)
+		{
+			continue;
+		}
+		ZENITH_ASSERT_TRUE(x.m_eEvolvesTo < ZM_SPECIES_COUNT,
+			"%s evolves to an invalid id", x.m_szName);
+		ZENITH_ASSERT_NE((u_int)x.m_eEvolvesTo, i, "%s evolves into itself", x.m_szName);
+
+		const ZM_SpeciesData& xNext = ZM_GetSpeciesData(x.m_eEvolvesTo);
+		ZENITH_ASSERT_EQ(xNext.m_uEvoStage, x.m_uEvoStage + 1,
+			"%s -> %s must be exactly one stage up", x.m_szName, xNext.m_szName);
+		ZENITH_ASSERT_EQ(xNext.m_uFamilyId, x.m_uFamilyId,
+			"%s evolves outside its family", x.m_szName);
+		ZENITH_ASSERT_EQ((u_int)xNext.m_eArchetype, (u_int)x.m_eArchetype,
+			"%s changes archetype on evolution", x.m_szName);
+		ZENITH_ASSERT_EQ((u_int)xNext.m_eRarity, (u_int)x.m_eRarity,
+			"%s changes rarity on evolution", x.m_szName);
+	}
+}
+
+// Family ids are in range; each family is a linear chain (one species per stage,
+// stages 1..maxStage with no gaps) sharing one archetype and rarity.
+ZENITH_TEST(ZM_Data, Species_FamiliesWellFormed)
+{
+	u_int auCount[uMAX_FAMILY_ID] = {};
+	u_int auMaxStage[uMAX_FAMILY_ID] = {};
+	u_int auStageBits[uMAX_FAMILY_ID] = {};   // bit s set => a stage-s member exists
+	u_int aeArch[uMAX_FAMILY_ID] = {};
+	u_int aeRar[uMAX_FAMILY_ID] = {};
+
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		ZENITH_ASSERT_TRUE(x.m_uFamilyId >= 1 && x.m_uFamilyId < uMAX_FAMILY_ID,
+			"%s has out-of-range family id %u", x.m_szName, x.m_uFamilyId);
+		const u_int f = x.m_uFamilyId;
+
+		if (auCount[f] == 0)
+		{
+			aeArch[f] = (u_int)x.m_eArchetype;
+			aeRar[f] = (u_int)x.m_eRarity;
+		}
+		else
+		{
+			ZENITH_ASSERT_EQ((u_int)x.m_eArchetype, aeArch[f],
+				"family %u mixes archetypes (at %s)", f, x.m_szName);
+			ZENITH_ASSERT_EQ((u_int)x.m_eRarity, aeRar[f],
+				"family %u mixes rarities (at %s)", f, x.m_szName);
+		}
+		auCount[f]++;
+		if (x.m_uEvoStage > auMaxStage[f]) { auMaxStage[f] = x.m_uEvoStage; }
+		const u_int uBit = 1u << x.m_uEvoStage;
+		ZENITH_ASSERT_TRUE((auStageBits[f] & uBit) == 0,
+			"family %u has two species at stage %u (at %s)", f, x.m_uEvoStage, x.m_szName);
+		auStageBits[f] |= uBit;
+	}
+
+	u_int uFamilies = 0;
+	for (u_int f = 1; f < uMAX_FAMILY_ID; ++f)
+	{
+		if (auCount[f] == 0) { continue; }
+		uFamilies++;
+		// Species count equals the max stage (linear 1..maxStage chain).
+		ZENITH_ASSERT_EQ(auCount[f], auMaxStage[f],
+			"family %u has %u members but max stage %u", f, auCount[f], auMaxStage[f]);
+		// Stages 1..maxStage all present (no gaps).
+		u_int uExpectBits = 0;
+		for (u_int s = 1; s <= auMaxStage[f]; ++s) { uExpectBits |= (1u << s); }
+		ZENITH_ASSERT_EQ(auStageBits[f], uExpectBits, "family %u has a stage gap", f);
+	}
+	ZENITH_ASSERT_EQ(uFamilies, uEXPECTED_FAMILIES);
+}
+
+// The family-size distribution matches the GDD count: 40 three-stage,
+// 13 two-stage, 6 single-stage (3 rares + 3 legendaries).
+ZENITH_TEST(ZM_Data, Species_FamilySizeDistribution)
+{
+	u_int auMaxStage[uMAX_FAMILY_ID] = {};
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		if (x.m_uEvoStage > auMaxStage[x.m_uFamilyId]) { auMaxStage[x.m_uFamilyId] = x.m_uEvoStage; }
+	}
+	u_int uThree = 0, uTwo = 0, uOne = 0;
+	for (u_int f = 1; f < uMAX_FAMILY_ID; ++f)
+	{
+		switch (auMaxStage[f])
+		{
+		case 3: uThree++; break;
+		case 2: uTwo++; break;
+		case 1: uOne++; break;
+		default: break;
+		}
+	}
+	ZENITH_ASSERT_EQ(uThree, 40u, "expected 40 three-stage families");
+	ZENITH_ASSERT_EQ(uTwo, 13u, "expected 13 two-stage families");
+	ZENITH_ASSERT_EQ(uOne, 6u, "expected 6 single-stage families (3 rares + 3 legendaries)");
+}
+
+// One base (stage-1) species and one final (evolves-to-NONE) per family, and
+// exactly three legendaries, each a single-stage species.
+ZENITH_TEST(ZM_Data, Species_BasesFinalsAndLegendaries)
+{
+	u_int uBases = 0, uFinals = 0, uLegendary = 0;
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		if (x.m_uEvoStage == 1) { uBases++; }
+		if (x.m_eEvolvesTo == ZM_SPECIES_NONE) { uFinals++; }
+		if (x.m_eRarity == ZM_RARITY_LEGENDARY)
+		{
+			uLegendary++;
+			ZENITH_ASSERT_EQ(x.m_uEvoStage, 1u, "%s (legendary) must be single-stage", x.m_szName);
+			ZENITH_ASSERT_EQ((u_int)x.m_eEvolvesTo, (u_int)ZM_SPECIES_NONE,
+				"%s (legendary) must not evolve", x.m_szName);
+		}
+	}
+	ZENITH_ASSERT_EQ(uBases, uEXPECTED_FAMILIES, "one stage-1 base per family");
+	ZENITH_ASSERT_EQ(uFinals, uEXPECTED_FAMILIES, "one final stage per family");
+	ZENITH_ASSERT_EQ(uLegendary, 3u);
+}
+
+// Archetype spread by FAMILY matches the GDD (section 5 tally, incl. legendaries).
+ZENITH_TEST(ZM_Data, Species_ArchetypeSpreadMatchesGdd)
+{
+	// bit f set in seen[arch] => family f has that archetype (families are
+	// single-archetype, verified by Species_FamiliesWellFormed).
+	u_int auFamCountByArch[ZM_ARCHETYPE_COUNT] = {};
+	bool aabSeen[ZM_ARCHETYPE_COUNT][uMAX_FAMILY_ID] = {};
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		if (!aabSeen[x.m_eArchetype][x.m_uFamilyId])
+		{
+			aabSeen[x.m_eArchetype][x.m_uFamilyId] = true;
+			auFamCountByArch[x.m_eArchetype]++;
+		}
+	}
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_QUADRUPED],        18u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_BIPED],            6u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_AVIAN],           7u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_SERPENT],         4u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_AQUATIC],         6u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_INSECTOID],       7u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_BLOB],            5u);
+	ZENITH_ASSERT_EQ(auFamCountByArch[ZM_ARCHETYPE_FLOATER_PLANTOID], 6u);
+}
+
+// All 18 types appear on at least two families (GDD 5 invariant).
+ZENITH_TEST(ZM_Data, Species_EveryTypeOnTwoFamilies)
+{
+	bool aabTypeInFamily[ZM_TYPE_COUNT][uMAX_FAMILY_ID] = {};
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		aabTypeInFamily[x.m_aeTypes[0]][x.m_uFamilyId] = true;
+		if (x.m_aeTypes[1] != ZM_TYPE_NONE)
+		{
+			aabTypeInFamily[x.m_aeTypes[1]][x.m_uFamilyId] = true;
+		}
+	}
+	for (u_int t = 0; t < ZM_TYPE_COUNT; ++t)
+	{
+		u_int uFams = 0;
+		for (u_int f = 1; f < uMAX_FAMILY_ID; ++f) { if (aabTypeInFamily[t][f]) { uFams++; } }
+		ZENITH_ASSERT_GE(uFams, 2u, "type %s appears on fewer than two families", ZM_TypeToString((ZM_TYPE)t));
+	}
+}
+
+// Derived family seed is shared within a family and unique across families.
+ZENITH_TEST(ZM_Data, Species_FamilySeedConsistentAndUnique)
+{
+	u_int auSeed[uMAX_FAMILY_ID] = {};
+	bool  abHaveSeed[uMAX_FAMILY_ID] = {};
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		const u_int uSeed = ZM_GetSpeciesFamilySeed(x.m_eId);
+		if (!abHaveSeed[x.m_uFamilyId])
+		{
+			abHaveSeed[x.m_uFamilyId] = true;
+			auSeed[x.m_uFamilyId] = uSeed;
+		}
+		else
+		{
+			ZENITH_ASSERT_EQ(uSeed, auSeed[x.m_uFamilyId],
+				"%s has a different family seed from its family", x.m_szName);
+		}
+	}
+	for (u_int a = 1; a < uMAX_FAMILY_ID; ++a)
+	{
+		if (!abHaveSeed[a]) { continue; }
+		for (u_int b = a + 1; b < uMAX_FAMILY_ID; ++b)
+		{
+			if (!abHaveSeed[b]) { continue; }
+			ZENITH_ASSERT_NE(auSeed[a], auSeed[b], "families %u and %u share a seed", a, b);
+		}
+	}
+}
+
+// Derived size class never shrinks as a species evolves.
+ZENITH_TEST(ZM_Data, Species_SizeClassNonDecreasing)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		if (x.m_eEvolvesTo == ZM_SPECIES_NONE) { continue; }
+		const ZM_SIZE_CLASS eHere = ZM_GetSpeciesSizeClass(x.m_eId);
+		const ZM_SIZE_CLASS eNext = ZM_GetSpeciesSizeClass(x.m_eEvolvesTo);
+		ZENITH_ASSERT_LE((u_int)eHere, (u_int)eNext,
+			"%s shrinks on evolution", x.m_szName);
+	}
+}


### PR DESCRIPTION
## S1 data core -- `ZM_SpeciesData` structural roster (152 species)

First increment of the SpeciesData Roadmap box. Lands the full **structural** dex; base stats and learnsets are deferred follow-ups on the same box (DecisionLog ZM-D-020 -- learnsets need `ZM_MoveData`, base stats are a design pass).

### What
- **`Source/Data/ZM_SpeciesData.h`** -- `ZM_ARCHETYPE` (8 body plans) / `ZM_RARITY` (4) / `ZM_SIZE_CLASS` enums; `ZM_SPECIES_ID` (152 species, dex order, append-only / save-stable); the `ZM_SpeciesData` struct (id / name / `types[2]` / archetype / evo-stage / evolves-to / family / rarity) + accessors.
- **`Source/Data/ZM_SpeciesData.cpp`** -- the 152-row table transcribed from **GDD section 5** (56 families F01-F56 + 3 legendaries), with single/dual/final-stage typing per the GDD; `ZM_GetSpeciesData/Count/Name` + rule-derived `ZM_GetSpeciesSizeClass` (stage+archetype) and `ZM_GetSpeciesFamilySeed` (per-family, for S4 `ZM_CreatureGen`).
- **`Tests/ZM_Tests_Species.cpp`** -- 11 `ZM_Data` integrity tests: count == 152 + index self-consistency, unique names, valid types, evolution-graph shape (stage+1, same family/archetype/rarity, no self-loop), families well-formed (linear chains, one per stage), family-size distribution (40 three-stage / 13 two-stage / 6 single vs GDD), base/final/legendary counts, **archetype-family spread 18/6/7/4/6/7/5/6** (matches GDD tally), every-type-on-two-families, family-seed consistency + uniqueness, size-class monotonicity.

### Verification (local)
- `zenith build Zenithmon` (Vulkan_True) clean.
- Boot unit suite: **1090 ran, 1089 passed, 0 failed, 1 skipped** (+11 species tests; the 1 skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`).
- Pre-build cross-check: the `ZM_SPECIES_ID` enum and the table rows are identical and identically ordered (152 == 152), no duplicate names.

### CI
Bumped the zm-tests unit-gate baseline **1079 -> 1090** (`zm-tests.yml`, CIPolicy §1) in this PR -- the ratchet that keeps the ZM unit suite honest (ZM-D-019).

### Docs (same PR)
DecisionLog ZM-D-020, Roadmap (box -> `[~]` WIP with the remaining work), CIPolicy baseline, Status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
