### PR TITLE
feat(zm): S1 - ZM_SpeciesData base stats (systematically derived)

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1090
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1095
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/CIPolicy.md
+++ b/Games/Zenithmon/Docs/CIPolicy.md
@@ -53,7 +53,7 @@ pattern), active from S0. Required check name: **`zm-tests`**.
 
 **Unit-test baseline ratchet:** step 8's `-Baseline` is the exact registered
 unit-test count of `zenithmon.exe` (engine units + `ZM_*` cases; currently
-**1090**, of which 1 is the quarantined `RegistryWideNodeRoundTrip` skip). Every
+**1095**, of which 1 is the quarantined `RegistryWideNodeRoundTrip` skip). Every
 PR that changes the `ZM_*` count -- and any engine PR that changes the engine
 unit count -- bumps this number in `zm-tests.yml` in the same PR. This mirrors
 engine-gate's discipline and guards against unit tests silently vanishing; the

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,29 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-021 -- Species base stats are systematically DERIVED (placeholder), not hand-tuned
+
+- **Decision:** `ZM_GetSpeciesBaseStats(id)` computes the six base stats from a
+  per-archetype stat profile (8 body-plan rows summing ~300) scaled by an
+  evolution-stage factor (single-stage finals read as fully evolved) and a rarity
+  factor, then a deterministic per-family emphasis/dock drawn from the family seed
+  (bump one stat, dock another). Stats are NOT stored per-row and are NOT
+  balance-tuned. Added the `ZM_STAT` enum + `ZM_BaseStats` struct.
+- **Why:** hand-authoring 152 x 6 balanced stats in one commit is huge and
+  error-prone, and balance is explicitly an S11 concern (headless AI-vs-AI). A
+  systematic, deterministic derivation unblocks S2 (scripted battles need fixed
+  base stats) and differentiates species by archetype AND family. It is trivially
+  superseded by a stored per-species table in a later balance pass -- the accessor
+  signature is the stable seam.
+- **Tests that lock it:** `Tests/ZM_Tests_Species.cpp` `BaseStats_*` (5) --
+  in-range [1,255]; totals banded by evolution role (stage-1 base 250-360,
+  single-stage >=480, legendary >=560, global 250-700); every stat non-decreasing
+  + BST strictly increasing along an evolution chain; archetype shapes (AVIAN
+  faster than BLOB, BLOB bulkier than AVIAN, BIPED hits harder than FLOATER);
+  family variety (>=60 distinct stat blocks). Boot suite 1095 ran / 0 failed.
+- **Reversibility:** easy -- replace the accessor body with a stored table; no
+  caller sees a difference.
+
 ## 2026-07-10 -- ZM-D-020 -- ZM_SpeciesData decomposed: structural roster first (152 species), base stats + learnsets deferred
 
 - **Decision:** the ~150-species SpeciesData Roadmap box is split across

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -30,7 +30,7 @@
 ## S1 -- Data core (M) -- parallel with S3/S4
 
 - [x] `ZM_Types.h` + `ZM_TypeChart` (18 types) -- 18-type `enum ZM_TYPE` + golden-locked 18x18 chart + dual-type product; 9 `ZM_Data` unit tests (PR #147). Also wired the boot unit suite into CI (ZM-D-019).
-- [~] `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets) -- **structural roster SHIPPED** (152 species: id/name/types/archetype/evo/family/rarity + derived size/seed; 11 `ZM_Data` integrity tests; PR #148, ZM-D-020). REMAINING on this box: per-species base stats + learnsets (learnsets need `ZM_MoveData`).
+- [~] `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets) -- **structural roster + base stats SHIPPED** (152 species: id/name/types/archetype/evo/family/rarity + derived size/seed + derived base stats; 16 `ZM_Data` tests; PRs #148 ZM-D-020, #149 ZM-D-021). REMAINING: **learnsets ONLY**, which are blocked on `ZM_MoveData` -- do that box first, then return here to add learnsets.
 - [ ] `ZM_MoveData` (~220 moves as table rows over a ~60-kind `ZM_MOVE_EFFECT` enum)
 - [ ] `ZM_ItemData` (~80 + TMs)
 - [ ] `ZM_AbilityData` stubs (~50, fn-pointer hook structs) + `ZM_NatureData` (25)

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,6 +1,6 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species structural roster landed.**
+**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species roster + species base stats landed.**
 
 **Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
@@ -10,25 +10,27 @@ GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon`. D3D1
 
 ## Tests
 
-- Unit (T0, category `ZM_Data`): **1090 ran, 1089 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 11 species + 1068 engine + 2 boot.
+- Unit (T0, category `ZM_Data`): **1095 ran, 1094 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 16 species (11 structural + 5 base-stat) + 1068 engine + 2 boot.
 - Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
-- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1090** in `zm-tests.yml`.
+- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1095** in `zm-tests.yml`.
 
 ## What landed
 
-- **PR #147 (merged):** S1 type chart -- `ZM_Types` + `ZM_TypeChart` (golden-locked 18x18) + CI unit gate (ZM-D-018/019).
-- **PR #148 (this iteration):** `ZM_SpeciesData` **structural roster** -- schema + enums (`ZM_ARCHETYPE`/`ZM_RARITY`/`ZM_SIZE_CLASS`/`ZM_SPECIES_ID`) + full 152-species table (id/name/types/archetype/evo/family/rarity, transcribed from GDD 5) + derived size/seed accessors + 11 `ZM_Data` integrity tests. DecisionLog ZM-D-020.
+- **PR #147:** type chart (`ZM_Types` + `ZM_TypeChart`) + CI unit gate (ZM-D-018/019).
+- **PR #148:** `ZM_SpeciesData` structural roster (152 species) + 11 integrity tests (ZM-D-020).
+- **PR #149 (this iteration):** `ZM_SpeciesData` **base stats** -- `ZM_STAT` enum + `ZM_BaseStats` + `ZM_GetSpeciesBaseStats/BaseStatTotal`, systematically derived (per-archetype profile x stage/rarity x per-family emphasis; ZM-D-021) + 5 `BaseStats_*` tests.
 
 ## Current task
 
-None in flight (once PR #148 merges). **The `ZM_SpeciesData` Roadmap box is `[~]` WIP:** structural roster done; **REMAINING on the box = per-species base stats (a design pass) + learnsets (need `ZM_MoveData`).** So the next task is either continue that box with **base stats** (increment 2 -- add a base-stats field to `ZM_SpeciesData` + values + range/BST tests; bump baseline) or start `ZM_MoveData` (box 3). Base stats have no upstream dependency; learnsets must wait for moves.
+None in flight (once PR #149 merges). **The `ZM_SpeciesData` box (`[~]`) now has only LEARNSETS remaining, and learnsets are BLOCKED on `ZM_MoveData`.** So the next task is **`ZM_MoveData` (Roadmap box 3)** -- ~220 moves as table rows over a ~60-kind `ZM_MOVE_EFFECT` enum (GDD section 7 has the effect list / formula spec). After MoveData lands, return to `ZM_SpeciesData` to add per-species learnsets (referencing `ZM_MOVE_ID`), then the box can be ticked `[x]`.
 
 ## Notes for the next agent
 
-- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1090**. Forgetting it reddens zm-tests with a count mismatch (that is the ratchet working).
+- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1095**. Forgetting it reddens zm-tests with a count mismatch.
 - Verify unit tests via a boot, not `zenith test` (which skips them): `zenithmon.exe --list-automated-tests --headless` prints `Unit tests complete: N ran … M failed`, or `Tools/run_unit_gate.ps1`. See Q-2026-07-10-004.
-- **Working-dir gotcha:** the Bash and PowerShell tools SHARE a cwd here -- a `cd` in Bash moves PowerShell too. Avoid `cd`; use absolute paths / `Set-Location C:\dev\Zenith` before `regen`/`build`.
-- `Source/Data/` is globbed by Sharpmake; run `Build\regen.ps1` after adding files.
+- **Base stats are DERIVED, not stored** (ZM-D-021) -- a placeholder for S11 balance. If you add real per-species base-stat tuning, replace the `ZM_GetSpeciesBaseStats` body with a stored table; the signature stays.
+- **Working-dir gotcha:** the Bash and PowerShell tools SHARE a cwd here -- a `cd` in Bash moves PowerShell too. Avoid `cd`; use `git -C` / absolute paths / `Set-Location C:\dev\Zenith` before `regen`/`build`.
+- Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`).
 - Branch fresh off master (`git pull` first).
 - **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored.
 - Session discipline: replace this file each session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.

--- a/Games/Zenithmon/Source/Data/ZM_SpeciesData.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_SpeciesData.cpp
@@ -291,3 +291,87 @@ u_int ZM_GetSpeciesFamilySeed(ZM_SPECIES_ID eId)
 	const u_int uFamilyId = ZM_GetSpeciesData(eId).m_uFamilyId;
 	return uFamilyId * 2654435761u;
 }
+
+namespace
+{
+	// Per-archetype base-stat profile (a stage-1 baseline, each row sums ~300):
+	// HP, ATK, DEF, SPATK, SPDEF, SPEED. Encodes each body plan's identity --
+	// AVIAN/INSECTOID fast+frail, BLOB bulky+slow, BIPED bruiser, FLOATER special.
+	const u_int s_aauArchetypeProfile[ZM_ARCHETYPE_COUNT][ZM_STAT_COUNT] =
+	{
+		/* QUADRUPED        */ { 55, 55, 50, 45, 45, 50 },
+		/* BIPED            */ { 55, 65, 60, 40, 45, 35 },
+		/* AVIAN            */ { 45, 50, 40, 45, 40, 80 },
+		/* SERPENT          */ { 60, 65, 50, 50, 45, 30 },
+		/* AQUATIC          */ { 60, 45, 50, 55, 55, 35 },
+		/* INSECTOID        */ { 45, 55, 40, 45, 40, 75 },
+		/* BLOB             */ { 70, 45, 70, 40, 55, 20 },
+		/* FLOATER_PLANTOID */ { 50, 35, 45, 65, 60, 45 },
+	};
+
+	// Growth from evolution stage. A single-stage species (base that is also its
+	// own final) reads as fully-evolved, so standalone rares/legendaries are
+	// strong rather than stage-1 weak.
+	float StageFactor(const ZM_SpeciesData& x)
+	{
+		const bool bSingleStage = (x.m_uEvoStage == 1 && x.m_eEvolvesTo == ZM_SPECIES_NONE);
+		if (bSingleStage)
+		{
+			return (x.m_eRarity == ZM_RARITY_LEGENDARY) ? 1.85f : 1.70f;
+		}
+		switch (x.m_uEvoStage)
+		{
+		case 1:  return 1.00f;
+		case 2:  return 1.35f;
+		default: return 1.70f;
+		}
+	}
+
+	float RarityFactor(ZM_RARITY eRarity)
+	{
+		switch (eRarity)
+		{
+		case ZM_RARITY_COMMON:    return 0.92f;
+		case ZM_RARITY_RARE:      return 1.10f;
+		case ZM_RARITY_LEGENDARY: return 1.10f;   // legendaries also get the single-stage StageFactor
+		default:                  return 1.00f;   // UNCOMMON
+		}
+	}
+}
+
+ZM_BaseStats ZM_GetSpeciesBaseStats(ZM_SPECIES_ID eId)
+{
+	const ZM_SpeciesData& xData = ZM_GetSpeciesData(eId);
+	const float fScale = StageFactor(xData) * RarityFactor(xData.m_eRarity);
+
+	// Per-family emphasis: bump one stat, dock another, chosen deterministically
+	// from the family seed and shared by all stages of the family. Because these
+	// multipliers are constant within a family, every stat still scales purely
+	// with the stage factor -- so no stat ever shrinks on evolution.
+	const u_int uSeed = ZM_GetSpeciesFamilySeed(eId);
+	const u_int uEmphasis = uSeed % ZM_STAT_COUNT;
+	u_int uDock = (uSeed / ZM_STAT_COUNT) % ZM_STAT_COUNT;
+	if (uDock == uEmphasis) { uDock = (uDock + 1) % ZM_STAT_COUNT; }
+
+	ZM_BaseStats xOut = {};
+	for (u_int i = 0; i < ZM_STAT_COUNT; ++i)
+	{
+		float fFamily = 1.0f;
+		if (i == uEmphasis)  { fFamily = 1.15f; }
+		else if (i == uDock) { fFamily = 0.85f; }
+
+		int iVal = (int)((float)s_aauArchetypeProfile[xData.m_eArchetype][i] * fScale * fFamily + 0.5f);
+		if (iVal < 1)   { iVal = 1; }
+		if (iVal > 255) { iVal = 255; }
+		xOut.m_au[i] = (u_int)iVal;
+	}
+	return xOut;
+}
+
+u_int ZM_GetSpeciesBaseStatTotal(ZM_SPECIES_ID eId)
+{
+	const ZM_BaseStats xStats = ZM_GetSpeciesBaseStats(eId);
+	u_int uSum = 0;
+	for (u_int i = 0; i < ZM_STAT_COUNT; ++i) { uSum += xStats.m_au[i]; }
+	return uSum;
+}

--- a/Games/Zenithmon/Source/Data/ZM_SpeciesData.h
+++ b/Games/Zenithmon/Source/Data/ZM_SpeciesData.h
@@ -274,7 +274,29 @@ enum ZM_SPECIES_ID : u_int
 	ZM_SPECIES_NONE = ZM_SPECIES_COUNT   // "no species" sentinel (e.g. final-stage evolves-to)
 };
 
-// One dex row. Base stats + learnsets are added by later increments on this box.
+// The six battle stats, in canonical order (index into ZM_BaseStats::m_au).
+enum ZM_STAT : u_int
+{
+	ZM_STAT_HP,
+	ZM_STAT_ATTACK,
+	ZM_STAT_DEFENSE,
+	ZM_STAT_SPATTACK,
+	ZM_STAT_SPDEFENSE,
+	ZM_STAT_SPEED,
+
+	ZM_STAT_COUNT
+};
+
+// A species' six base stats -- the per-species constants the Gen-III stat
+// formula scales by level / IV / EV / nature (that formula lands with
+// ZM_StatCalc). Values are systematically derived (ZM-D-021), not hand-tuned.
+struct ZM_BaseStats
+{
+	u_int m_au[ZM_STAT_COUNT];
+};
+
+// One dex row. Learnsets are added by a later increment on this box (they need
+// ZM_MoveData); base stats are provided by ZM_GetSpeciesBaseStats below.
 struct ZM_SpeciesData
 {
 	ZM_SPECIES_ID	m_eId;
@@ -297,3 +319,11 @@ const char*				ZM_GetSpeciesName(ZM_SPECIES_ID eId);
 // shared by all stages of a family (S4 ZM_CreatureGen input).
 ZM_SIZE_CLASS			ZM_GetSpeciesSizeClass(ZM_SPECIES_ID eId);
 u_int					ZM_GetSpeciesFamilySeed(ZM_SPECIES_ID eId);
+
+// Systematically-derived base stats (ZM-D-021): a per-archetype stat profile
+// scaled by evolution stage + rarity, with a deterministic per-family emphasis
+// from the family seed. Deterministic, and every stat is non-decreasing along an
+// evolution chain; intended to be superseded by hand-tuned per-species values in
+// a later balance pass.
+ZM_BaseStats			ZM_GetSpeciesBaseStats(ZM_SPECIES_ID eId);
+u_int					ZM_GetSpeciesBaseStatTotal(ZM_SPECIES_ID eId);   // sum of the six

--- a/Games/Zenithmon/Tests/ZM_Tests_Species.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_Species.cpp
@@ -296,3 +296,116 @@ ZENITH_TEST(ZM_Data, Species_SizeClassNonDecreasing)
 			"%s shrinks on evolution", x.m_szName);
 	}
 }
+
+// -- Derived base stats (ZM-D-021) --
+
+// Every base stat is a sane positive value.
+ZENITH_TEST(ZM_Data, BaseStats_InRange)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_BaseStats x = ZM_GetSpeciesBaseStats((ZM_SPECIES_ID)i);
+		for (u_int s = 0; s < ZM_STAT_COUNT; ++s)
+		{
+			ZENITH_ASSERT_TRUE(x.m_au[s] >= 1 && x.m_au[s] <= 255,
+				"%s stat %u out of range (%u)", Sp(i).m_szName, s, x.m_au[s]);
+		}
+	}
+}
+
+// Base-stat totals land in the expected bands for their evolution role.
+ZENITH_TEST(ZM_Data, BaseStats_TotalsInBand)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		const u_int uBst = ZM_GetSpeciesBaseStatTotal(x.m_eId);
+		ZENITH_ASSERT_TRUE(uBst >= 250 && uBst <= 700,
+			"%s BST %u outside the global band", x.m_szName, uBst);
+
+		const bool bSingleStage = (x.m_uEvoStage == 1 && x.m_eEvolvesTo == ZM_SPECIES_NONE);
+		if (x.m_eRarity == ZM_RARITY_LEGENDARY)
+		{
+			ZENITH_ASSERT_TRUE(uBst >= 560, "%s (legendary) BST %u too low", x.m_szName, uBst);
+		}
+		else if (bSingleStage)
+		{
+			ZENITH_ASSERT_TRUE(uBst >= 480, "%s (single-stage) BST %u too low", x.m_szName, uBst);
+		}
+		else if (x.m_uEvoStage == 1)
+		{
+			ZENITH_ASSERT_TRUE(uBst >= 250 && uBst <= 360,
+				"%s (stage-1 base) BST %u outside the base band", x.m_szName, uBst);
+		}
+	}
+}
+
+// No stat shrinks on evolution and the total strictly grows.
+ZENITH_TEST(ZM_Data, BaseStats_MonotonicAlongEvolution)
+{
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		if (x.m_eEvolvesTo == ZM_SPECIES_NONE) { continue; }
+		const ZM_BaseStats xHere = ZM_GetSpeciesBaseStats(x.m_eId);
+		const ZM_BaseStats xNext = ZM_GetSpeciesBaseStats(x.m_eEvolvesTo);
+		for (u_int s = 0; s < ZM_STAT_COUNT; ++s)
+		{
+			ZENITH_ASSERT_GE(xNext.m_au[s], xHere.m_au[s],
+				"%s stat %u shrinks on evolution", x.m_szName, s);
+		}
+		ZENITH_ASSERT_GT(ZM_GetSpeciesBaseStatTotal(x.m_eEvolvesTo),
+			ZM_GetSpeciesBaseStatTotal(x.m_eId),
+			"%s BST does not grow on evolution", x.m_szName);
+	}
+}
+
+// Archetype identity shows through in the averages (fast fliers, bulky blobs,
+// hard-hitting bipeds).
+ZENITH_TEST(ZM_Data, BaseStats_ArchetypeShapes)
+{
+	u_int auSpeedSum[ZM_ARCHETYPE_COUNT] = {};
+	u_int auHpDefSum[ZM_ARCHETYPE_COUNT] = {};
+	u_int auAtkSum[ZM_ARCHETYPE_COUNT] = {};
+	u_int auN[ZM_ARCHETYPE_COUNT] = {};
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_SpeciesData& x = Sp(i);
+		const ZM_BaseStats b = ZM_GetSpeciesBaseStats(x.m_eId);
+		auSpeedSum[x.m_eArchetype] += b.m_au[ZM_STAT_SPEED];
+		auHpDefSum[x.m_eArchetype] += b.m_au[ZM_STAT_HP] + b.m_au[ZM_STAT_DEFENSE];
+		auAtkSum[x.m_eArchetype]   += b.m_au[ZM_STAT_ATTACK];
+		auN[x.m_eArchetype]++;
+	}
+	// Averages (guard: each archetype has members, verified by structural tests).
+	const u_int uAvgSpeedAvian = auSpeedSum[ZM_ARCHETYPE_AVIAN] / auN[ZM_ARCHETYPE_AVIAN];
+	const u_int uAvgSpeedBlob  = auSpeedSum[ZM_ARCHETYPE_BLOB]  / auN[ZM_ARCHETYPE_BLOB];
+	const u_int uAvgBulkBlob   = auHpDefSum[ZM_ARCHETYPE_BLOB]  / auN[ZM_ARCHETYPE_BLOB];
+	const u_int uAvgBulkAvian  = auHpDefSum[ZM_ARCHETYPE_AVIAN] / auN[ZM_ARCHETYPE_AVIAN];
+	const u_int uAvgAtkBiped   = auAtkSum[ZM_ARCHETYPE_BIPED]   / auN[ZM_ARCHETYPE_BIPED];
+	const u_int uAvgAtkFloater = auAtkSum[ZM_ARCHETYPE_FLOATER_PLANTOID] / auN[ZM_ARCHETYPE_FLOATER_PLANTOID];
+
+	ZENITH_ASSERT_GT(uAvgSpeedAvian, uAvgSpeedBlob, "AVIAN should be faster than BLOB");
+	ZENITH_ASSERT_GT(uAvgBulkBlob, uAvgBulkAvian, "BLOB should be bulkier than AVIAN");
+	ZENITH_ASSERT_GT(uAvgAtkBiped, uAvgAtkFloater, "BIPED should hit harder than FLOATER");
+}
+
+// The per-family emphasis produces genuine variety, not one stat block repeated.
+ZENITH_TEST(ZM_Data, BaseStats_FamilyVariety)
+{
+	u_int uDistinct = 0;
+	for (u_int i = 0; i < ZM_SPECIES_COUNT; ++i)
+	{
+		const ZM_BaseStats bi = ZM_GetSpeciesBaseStats((ZM_SPECIES_ID)i);
+		bool bSeen = false;
+		for (u_int j = 0; j < i && !bSeen; ++j)
+		{
+			const ZM_BaseStats bj = ZM_GetSpeciesBaseStats((ZM_SPECIES_ID)j);
+			bool bEqual = true;
+			for (u_int s = 0; s < ZM_STAT_COUNT; ++s) { if (bi.m_au[s] != bj.m_au[s]) { bEqual = false; break; } }
+			if (bEqual) { bSeen = true; }
+		}
+		if (!bSeen) { uDistinct++; }
+	}
+	ZENITH_ASSERT_GE(uDistinct, 60u, "base-stat derivation collapses too many species (%u distinct)", uDistinct);
+}


### PR DESCRIPTION
## S1 data core -- `ZM_SpeciesData` base stats (second increment)

Continues the SpeciesData Roadmap box: per-species **base stats**. After this, only **learnsets** remain on the box (blocked on `ZM_MoveData`).

### What
- **`ZM_SpeciesData.h`** -- `ZM_STAT` enum (HP/ATK/DEF/SpA/SpD/SPE) + `ZM_BaseStats` struct + `ZM_GetSpeciesBaseStats` / `ZM_GetSpeciesBaseStatTotal`.
- **`ZM_SpeciesData.cpp`** -- base stats are **systematically derived** (ZM-D-021): a per-archetype stat profile (8 body plans, each ~300 BST) scaled by an evolution-stage factor (single-stage finals read as fully evolved) and a rarity factor, then a deterministic per-family emphasis/dock from the family seed. Deterministic, monotonic along evolution, and differentiated by both archetype and family. This is a **placeholder for the S11 balance pass** -- the accessor is the stable seam for a future stored/hand-tuned table.
- **`ZM_Tests_Species.cpp`** -- +5 `BaseStats_*` tests: in-range [1,255]; totals banded by evolution role (stage-1 base 250-360, single-stage >=480, legendary >=560, global 250-700); every stat non-decreasing + BST strictly increasing along an evolution chain; archetype shapes (AVIAN faster than BLOB, BLOB bulkier than AVIAN, BIPED hits harder than FLOATER); family variety (>=60 distinct stat blocks).

### Verification (local)
- `zenith build Zenithmon` (Vulkan_True) clean.
- Boot unit suite: **1095 ran, 1094 passed, 0 failed, 1 skipped** (+5 base-stat tests; the 1 skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`).

### CI
Bumped the zm-tests unit-gate baseline **1090 -> 1095** (`zm-tests.yml`, CIPolicy §1).

### Docs (same PR)
DecisionLog ZM-D-021, Roadmap (box annotation -- learnsets remaining, blocked on MoveData), CIPolicy baseline, Status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
