### PR TITLE
feat(zm): S1 - ZM_Learnsets derived per-species level-up learnsets (completes ZM_SpeciesData box)

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1111
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1119
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,34 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-023 -- Species learnsets are systematically DERIVED (placeholder), completing the ZM_SpeciesData box
+
+- **Decision:** per-species level-up learnsets are computed by
+  `ZM_GetSpeciesLearnset(id)` (`Source/Data/ZM_Learnsets.{h,cpp}`), not stored:
+  it partitions the move table into the species' STAB / secondary-type / universal
+  NORMAL damaging buckets + a shared status bucket, sorts the damaging buckets by
+  effective power (fixed-damage moves read as high power so they land late),
+  teaches a same-type damaging move at level 1, then round-robins damaging moves
+  with a capped minority of status moves, spreading levels 1..~50 and sizing the
+  list by evolution stage (12 / 14 / 16; single-stage finals 16). Returned by
+  value as a fixed-capacity `ZM_Learnset` (max 16). This ticks the `ZM_SpeciesData`
+  Roadmap box `[x]` (roster ZM-D-020 + base stats ZM-D-021 + learnsets here).
+- **Why:** identical reasoning to base stats (ZM-D-021) -- real movepools are an
+  S11 balance concern, and hand-authoring ~150 arbitrary placeholder movepools in
+  one commit buys nothing over a deterministic, type-appropriate,
+  referentially-valid derivation that unblocks S2 (which builds a monster's
+  moveset from species + level). The accessor signature is the stable seam for a
+  stored table later. TM/tutor compatibility is deferred to `ZM_ItemData`.
+- **Tests that lock it:** `Tests/ZM_Tests_Learnsets.cpp` (category `ZM_Data`, 8
+  cases) -- count bounded [4,16] + every entry a real move, level-ordered +
+  in-range + something learnable by L5, type-appropriate (own type(s) or NORMAL),
+  has a STAB move + an early damaging move, no duplicate moves, status a minority,
+  deterministic, and learnset size non-decreasing along an evolution chain. The
+  derivation was pre-validated across all 152 species offline before building.
+  Boot suite 1119 ran / 0 failed; zm-tests baseline bumped 1111 -> 1119.
+- **Reversibility:** easy -- replace the accessor body with a stored per-species
+  table; no caller sees a difference. Additive `Source/Data/` files.
+
 ## 2026-07-10 -- ZM-D-022 -- ZM_MoveData ships as data + schema only (218 moves over a 57-kind effect enum); the executor is S2
 
 - **Decision:** the ~220-move Roadmap box lands as a compiled `const ZM_MoveData`

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -30,7 +30,7 @@
 ## S1 -- Data core (M) -- parallel with S3/S4
 
 - [x] `ZM_Types.h` + `ZM_TypeChart` (18 types) -- 18-type `enum ZM_TYPE` + golden-locked 18x18 chart + dual-type product; 9 `ZM_Data` unit tests (PR #147). Also wired the boot unit suite into CI (ZM-D-019).
-- [~] `ZM_SpeciesData` (~150 species: archetype + evo stage + size class + family seed + stats/learnsets) -- **structural roster + base stats SHIPPED** (152 species: id/name/types/archetype/evo/family/rarity + derived size/seed + derived base stats; 16 `ZM_Data` tests; PRs #148 ZM-D-020, #149 ZM-D-021). REMAINING: **learnsets ONLY**, which are blocked on `ZM_MoveData` -- do that box first, then return here to add learnsets.
+- [x] `ZM_SpeciesData` (152 species: archetype + evo stage + size class + family seed + stats + learnsets) -- structural roster (id/name/types/archetype/evo/family/rarity + derived size/seed; PR #148 ZM-D-020) + derived base stats (PR #149 ZM-D-021) + derived level-up learnsets (`ZM_Learnsets.h`, `ZM_GetSpeciesLearnset`; PR #151 ZM-D-023). 24 `ZM_Data` tests (16 species + 8 learnset). Base stats + learnsets are systematic placeholders for the S11 balance pass; TM/tutor learnsets come with `ZM_ItemData`.
 - [x] `ZM_MoveData` (218 moves as table rows over a 57-kind `ZM_MOVE_EFFECT` enum) -- data + schema only (`ZM_MOVE_ID`/`ZM_MOVE_CATEGORY`/`ZM_MOVE_TARGET`/`ZM_MOVE_EFFECT` + per-row power/acc/PP/priority/crit/contact/effect+chance+magnitude); 16 `ZM_Data` tests incl. every-effect-kind-used coverage lock (PR #150, ZM-D-022). The `ZM_MoveExecutor` that interprets the effect enum is S2.
 - [ ] `ZM_ItemData` (~80 + TMs)
 - [ ] `ZM_AbilityData` stubs (~50, fn-pointer hook structs) + `ZM_NatureData` (25)

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,6 +1,6 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species (roster + base stats) + full move table landed.**
+**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species (roster + stats + learnsets, box DONE) + move table landed.**
 
 **Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
@@ -10,27 +10,28 @@ GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon`. D3D1
 
 ## Tests
 
-- Unit (T0, category `ZM_Data`): **1111 ran, 1110 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 16 species + **16 move** + 1068 engine + 2 boot.
+- Unit (T0, category `ZM_Data`): **1119 ran, 1118 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 24 species (16 dex + 8 learnset) + 16 move + 1068 engine + 2 boot.
 - Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
-- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1111** in `zm-tests.yml`.
+- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1119** in `zm-tests.yml`.
 
 ## What landed
 
-- **PR #147:** type chart (`ZM_Types` + `ZM_TypeChart`) + CI unit gate (ZM-D-018/019).
+- **PR #147:** type chart + CI unit gate (ZM-D-018/019).
 - **PR #148 / #149:** `ZM_SpeciesData` structural roster (152) + derived base stats (ZM-D-020/021).
-- **PR #150 (this iteration):** `ZM_MoveData` -- 218-move compiled table over a 57-kind `ZM_MOVE_EFFECT` enum + `ZM_MOVE_ID`/`ZM_MOVE_CATEGORY`/`ZM_MOVE_TARGET` schema + accessors + `ZM_MoveCategory/TargetToString`; 16 `ZM_Data` integrity tests (ZM-D-022). **Data + schema only -- the `ZM_MoveExecutor` that interprets the effect enum is S2.**
+- **PR #150:** `ZM_MoveData` -- 218-move table over a 57-kind `ZM_MOVE_EFFECT` enum (data + schema only; executor is S2; ZM-D-022).
+- **PR #151 (this iteration):** `ZM_Learnsets` -- derived per-species level-up learnsets (`ZM_GetSpeciesLearnset`; ZM-D-023) + 8 `ZM_Data` tests. **Completes the `ZM_SpeciesData` box (now `[x]`).**
 
 ## Current task
 
-None in flight (once PR #150 merges). **Next Roadmap task: return to the `ZM_SpeciesData` box (`[~]`) to add per-species LEARNSETS** -- now UNBLOCKED (they reference `ZM_MOVE_ID`, which exists). Add a learnset table (level-up moves per species; TMs later with `ZM_ItemData`), a registry-integrity test that every learnset entry resolves to a real move, then tick the species box `[x]`. After that the first unchecked S1 box is **`ZM_ItemData` (~80 + TMs)** (Roadmap box 4).
+None in flight (once PR #151 merges). **Next Roadmap task: `ZM_ItemData` (~80 items + TMs)** -- Roadmap S1 box 4. Model item categories (balls, medicine, held items, TMs, key items, berries-analog), a `ZM_ITEM_ID` + `ZM_ItemData` table (compiled C array), and TMs as items that map to a `ZM_MOVE_ID` (this is where TM/tutor learnset compatibility can be introduced). Then `ZM_AbilityData` + `ZM_NatureData` (box 5), `ZM_StatCalc` + `ZM_BattleRNG` (box 6), `ZM_WorldSpec` (box 7), `ZM_DataRegistry` (box 8).
 
 ## Notes for the next agent
 
-- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1111**. Forgetting it reddens zm-tests with a count mismatch.
+- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1119**. Forgetting it reddens zm-tests with a count mismatch.
 - Verify unit tests via a boot, not `zenith test` (which skips them): `Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N` prints `Unit tests complete: N ran ... M failed`. See Q-2026-07-10-004.
-- **Move data is INERT** (ZM-D-022): rows name an effect kind + magnitude + chance; nothing interprets them until S2's `ZM_MoveExecutor` switch. Every `ZM_MOVE_EFFECT` value is used by >=1 row (locked by `Moves_EveryEffectKindUsed`) so S2 per-effect scenarios all have a subject. `m_uAccuracy==0` means never-miss; `m_uPower==0` means status or fixed-damage; `m_uEffectChance==0` iff effect is NONE.
-- **Big-table authoring tip:** the 218 rows were generated + validated offline by a scratchpad Python script (enum body + table body emitted in lockstep, all invariants checked before building) -- NOT committed; the C++ table is the source of truth thereafter (ZM-D-009). Hand-edit the `.cpp` for future tuning.
-- **Base stats are DERIVED, not stored** (ZM-D-021) -- a placeholder for S11 balance.
+- **Base stats AND learnsets are DERIVED placeholders** (ZM-D-021 / ZM-D-023): `ZM_GetSpeciesBaseStats` and `ZM_GetSpeciesLearnset` compute from the tables; replace the accessor bodies with stored tables in the S11 balance pass (signatures are the stable seam). Learnsets draw only from the species' type(s) + NORMAL, teach a STAB move at L1, are damaging-dominant, and grow with evo stage.
+- **Move data is INERT** (ZM-D-022): the `ZM_MoveExecutor` that interprets `ZM_MOVE_EFFECT` is S2. Every effect kind is used by >=1 move (locked). TMs (`ZM_ItemData`) will reference `ZM_MOVE_ID`.
+- **Big-table / derivation authoring tip:** move rows + the learnset derivation were both prototyped + fully validated offline in a scratchpad Python script (parsing the committed `.cpp` tables) BEFORE building -- catches design/coverage bugs in seconds, not build cycles. Not committed; the C++ is the source of truth (ZM-D-009).
 - **Working-dir gotcha:** the Bash and PowerShell tools SHARE a cwd here -- a `cd` in Bash moves PowerShell too. Avoid `cd`; use `git -C` / absolute paths / `Set-Location C:\dev\Zenith` before `regen`/`build`.
 - Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`).
 - Branch fresh off master (`git pull` first).

--- a/Games/Zenithmon/Source/Data/ZM_Learnsets.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_Learnsets.cpp
@@ -1,0 +1,163 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_Learnsets.h"
+
+// ============================================================================
+// ZM_Learnsets -- the systematically-derived level-up learnset (ZM-D-023). Pure
+// function of the compiled species + move tables; see the header for the design
+// rationale. Every invariant is locked by Tests/ZM_Tests_Learnsets.cpp.
+//
+// Derivation, per species:
+//   1. Partition the move table into four buckets by the species' types:
+//        STAB   = damaging moves of the primary type
+//        SEC    = damaging moves of the secondary type (dual-types only)
+//        NORM   = damaging NORMAL moves (only when the species is not NORMAL-typed)
+//        STATUS = status moves of any of {primary, secondary, NORMAL}
+//   2. Sort the three damaging buckets by EFFECTIVE power ascending -- so weak
+//      moves are taught first, strong moves last. Fixed-damage moves (power 0:
+//      OHKO / fixed-level / halve-HP) read as high power so they land late.
+//   3. Teach a level-1 STAB move, then round-robin STAB / (SEC|NORM) / an
+//      occasional STATUS move (capped at a few), damaging-dominant.
+//   4. Cap the count by evolution role; spread the levels 1..~50.
+// ============================================================================
+
+namespace
+{
+	const u_int uZM_LEARNSET_MAX_STATUS = 4u;   // keep a learnset damaging-dominant
+	const u_int uZM_FIXED_DAMAGE_EFFPOW = 130u;  // power-0 fixed-damage moves sort late
+
+	u_int EffectivePower(const ZM_MoveData& xMove)
+	{
+		return xMove.m_uPower > 0u ? xMove.m_uPower : uZM_FIXED_DAMAGE_EFFPOW;
+	}
+
+	// Stable insertion sort of move-index buffer by effective power ascending.
+	// The input is index-ascending, so equal-power ties keep table order.
+	void SortByEffectivePower(u_int* auIndices, u_int uCount)
+	{
+		for (u_int i = 1u; i < uCount; ++i)
+		{
+			const u_int uCur = auIndices[i];
+			const u_int uKey = EffectivePower(ZM_GetMoveData((ZM_MOVE_ID)uCur));
+			int j = (int)i - 1;
+			while (j >= 0 && EffectivePower(ZM_GetMoveData((ZM_MOVE_ID)auIndices[j])) > uKey)
+			{
+				auIndices[j + 1] = auIndices[j];
+				--j;
+			}
+			auIndices[j + 1] = uCur;
+		}
+	}
+}
+
+ZM_Learnset ZM_GetSpeciesLearnset(ZM_SPECIES_ID eId)
+{
+	const ZM_SpeciesData& xSpecies = ZM_GetSpeciesData(eId);
+	const ZM_TYPE eT1 = xSpecies.m_aeTypes[0];
+	const ZM_TYPE eT2 = xSpecies.m_aeTypes[1];
+	const bool bDual = (eT2 != ZM_TYPE_NONE);
+
+	// Buffers are index lists into the move table; 218 moves fit comfortably.
+	u_int auStab[256];   u_int uStab = 0u;
+	u_int auSec[256];    u_int uSec = 0u;
+	u_int auNorm[256];   u_int uNorm = 0u;
+	u_int auStatus[256]; u_int uStatus = 0u;
+
+	const u_int uMoveCount = ZM_GetMoveCount();
+	for (u_int i = 0u; i < uMoveCount; ++i)
+	{
+		const ZM_MoveData& xMove = ZM_GetMoveData((ZM_MOVE_ID)i);
+		if (xMove.m_eCategory == ZM_MOVE_CATEGORY_STATUS)
+		{
+			if (xMove.m_eType == eT1 || (bDual && xMove.m_eType == eT2) || xMove.m_eType == ZM_TYPE_NORMAL)
+			{
+				auStatus[uStatus++] = i;
+			}
+		}
+		else if (xMove.m_eType == eT1)
+		{
+			auStab[uStab++] = i;
+		}
+		else if (bDual && xMove.m_eType == eT2)
+		{
+			auSec[uSec++] = i;
+		}
+		else if (xMove.m_eType == ZM_TYPE_NORMAL && eT1 != ZM_TYPE_NORMAL && eT2 != ZM_TYPE_NORMAL)
+		{
+			auNorm[uNorm++] = i;
+		}
+	}
+	SortByEffectivePower(auStab, uStab);
+	SortByEffectivePower(auSec, uSec);
+	SortByEffectivePower(auNorm, uNorm);
+	// auStatus stays in table order.
+
+	// Movepool size grows with evolution stage; a single-stage final (standalone
+	// rare / legendary) reads as fully evolved.
+	const bool bSingleStageFinal = (xSpecies.m_uEvoStage == 1u && xSpecies.m_eEvolvesTo == ZM_SPECIES_NONE);
+	u_int uCap = bSingleStageFinal ? uZM_MAX_LEARNSET_SIZE : (10u + xSpecies.m_uEvoStage * 2u);
+	if (uCap > uZM_MAX_LEARNSET_SIZE)
+	{
+		uCap = uZM_MAX_LEARNSET_SIZE;
+	}
+
+	u_int auPicks[uZM_MAX_LEARNSET_SIZE];
+	u_int uPicks = 0u;
+	u_int uSi = 0u, uSei = 0u, uNi = 0u, uTi = 0u, uStatusUsed = 0u, uRound = 0u;
+
+	// Guarantee a damaging same-type move at level 1.
+	if (uStab > 0u)
+	{
+		auPicks[uPicks++] = auStab[uSi++];
+	}
+
+	while (uPicks < uCap)
+	{
+		const bool bDamagingLeft = (uSi < uStab) || (uSei < uSec) || (uNi < uNorm);
+		const bool bStatusLeft = (uStatusUsed < uZM_LEARNSET_MAX_STATUS) && (uTi < uStatus);
+		if (!bDamagingLeft && !bStatusLeft)
+		{
+			break;
+		}
+
+		if (uSi < uStab)
+		{
+			auPicks[uPicks++] = auStab[uSi++];
+		}
+		if (uPicks >= uCap) { break; }
+
+		if (uSei < uSec)
+		{
+			auPicks[uPicks++] = auSec[uSei++];
+		}
+		else if (uNi < uNorm)
+		{
+			auPicks[uPicks++] = auNorm[uNi++];
+		}
+		if (uPicks >= uCap) { break; }
+
+		if ((uRound % 2u) == 1u && uStatusUsed < uZM_LEARNSET_MAX_STATUS && uTi < uStatus)
+		{
+			auPicks[uPicks++] = auStatus[uTi++];
+			++uStatusUsed;
+		}
+		++uRound;
+	}
+
+	// Fill any remaining slots with leftover damaging moves (strongest last).
+	while (uPicks < uCap && ((uSi < uStab) || (uSei < uSec) || (uNi < uNorm)))
+	{
+		if (uSi < uStab)		{ auPicks[uPicks++] = auStab[uSi++]; }
+		else if (uSei < uSec)	{ auPicks[uPicks++] = auSec[uSei++]; }
+		else if (uNi < uNorm)	{ auPicks[uPicks++] = auNorm[uNi++]; }
+	}
+
+	ZM_Learnset xOut;
+	xOut.m_uCount = uPicks;
+	for (u_int k = 0u; k < uPicks; ++k)
+	{
+		const u_int uLevel = (uPicks > 1u) ? (1u + (k * 49u) / (uPicks - 1u)) : 1u;
+		xOut.m_axMoves[k].m_uLevel = uLevel;
+		xOut.m_axMoves[k].m_eMove = (ZM_MOVE_ID)auPicks[k];
+	}
+	return xOut;
+}

--- a/Games/Zenithmon/Source/Data/ZM_Learnsets.h
+++ b/Games/Zenithmon/Source/Data/ZM_Learnsets.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+#include "Zenithmon/Source/Data/ZM_MoveData.h"
+
+// ============================================================================
+// ZM_Learnsets -- per-species level-up learnsets (S1 data core). Completes the
+// ZM_SpeciesData Roadmap box (roster + base stats + learnsets); see DecisionLog
+// ZM-D-023.
+//
+// Learnsets are systematically DERIVED, not hand-authored -- the same
+// placeholder strategy as base stats (ZM-D-021), and for the same reason: real
+// per-species movepools are an S11 balance concern (headless AI-vs-AI), and
+// hand-authoring ~150 movepools of arbitrary placeholder quality in one commit
+// buys nothing over a deterministic, type-appropriate, referentially-valid
+// derivation that unblocks S2. The derivation (see the .cpp):
+//   * draws only from the species' own type(s) + universal NORMAL moves,
+//   * teaches a damaging same-type move at level 1 and the strongest moves last,
+//   * is damaging-dominant (at most a few status moves),
+//   * scales its size with evolution stage,
+//   * is fully deterministic (pure function of the species + move tables).
+// It is trivially superseded by a stored per-species table later -- the accessor
+// signature is the stable seam.
+// ============================================================================
+
+// Upper bound on a single species' level-up list (sizes the return struct).
+static const u_int uZM_MAX_LEARNSET_SIZE = 16u;
+
+// One level-up entry: the move is learned on reaching m_uLevel.
+struct ZM_LevelUpMove
+{
+	u_int		m_uLevel;
+	ZM_MOVE_ID	m_eMove;
+};
+
+// A species' full level-up learnset, ordered by non-decreasing level.
+struct ZM_Learnset
+{
+	u_int			m_uCount;
+	ZM_LevelUpMove	m_axMoves[uZM_MAX_LEARNSET_SIZE];
+};
+
+// Derived level-up learnset for a species (bounds-asserted via ZM_GetSpeciesData).
+// Deterministic; every referenced move is a real ZM_MOVE_ID.
+ZM_Learnset ZM_GetSpeciesLearnset(ZM_SPECIES_ID eId);

--- a/Games/Zenithmon/Source/Data/ZM_SpeciesData.h
+++ b/Games/Zenithmon/Source/Data/ZM_SpeciesData.h
@@ -7,9 +7,9 @@
 //
 // This is the STRUCTURAL roster: id / name / type(s) / archetype / evolution /
 // family / rarity for all 152 species from Docs/GameDesignDocument.md section 5.
-// Base stats and learnsets are deferred to follow-up increments on the same
-// Roadmap box (stats are a design pass; learnsets need ZM_MoveData) -- see
-// DecisionLog ZM-D-020.
+// Base stats come from ZM_GetSpeciesBaseStats (ZM-D-021, derived); level-up
+// learnsets from ZM_GetSpeciesLearnset in ZM_Learnsets.h (ZM-D-023, derived).
+// See DecisionLog ZM-D-020 for the roster-first decomposition of this box.
 //
 // Data is a compiled const C array (DecisionLog ZM-D-009): zero file I/O in
 // headless tests. The ZM_SPECIES_ID order is the dex order and is save-stable
@@ -295,8 +295,8 @@ struct ZM_BaseStats
 	u_int m_au[ZM_STAT_COUNT];
 };
 
-// One dex row. Learnsets are added by a later increment on this box (they need
-// ZM_MoveData); base stats are provided by ZM_GetSpeciesBaseStats below.
+// One dex row. Base stats come from ZM_GetSpeciesBaseStats below; level-up
+// learnsets from ZM_GetSpeciesLearnset (ZM_Learnsets.h).
 struct ZM_SpeciesData
 {
 	ZM_SPECIES_ID	m_eId;

--- a/Games/Zenithmon/Tests/ZM_Tests_Learnsets.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_Learnsets.cpp
@@ -1,0 +1,178 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_Learnsets -- integrity of the derived per-species level-up learnsets
+// (category ZM_Data). The learnset is a placeholder derivation (ZM-D-023), so
+// this suite locks its CONTRACT rather than exact contents: every entry resolves
+// to a real move, the list is level-ordered and bounded, moves are
+// type-appropriate, a same-type damaging move is learnable early, status moves
+// stay a minority, and the derivation is deterministic. These are the properties
+// S2 relies on when it builds a monster's moveset from species + level.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_Types.h"
+#include "Zenithmon/Source/Data/ZM_MoveData.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+#include "Zenithmon/Source/Data/ZM_Learnsets.h"
+
+namespace
+{
+	bool MoveTypeAllowed(ZM_TYPE eMoveType, const ZM_SpeciesData& xSp)
+	{
+		return eMoveType == xSp.m_aeTypes[0]
+			|| eMoveType == xSp.m_aeTypes[1]
+			|| eMoveType == ZM_TYPE_NORMAL;
+	}
+}
+
+// Count is within bounds and every referenced move is a real ZM_MOVE_ID.
+ZENITH_TEST(ZM_Data, Learnset_CountBoundedAndResolves)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset((ZM_SPECIES_ID)s);
+		ZENITH_ASSERT_GE(xLs.m_uCount, 4u, "%s has too small a learnset", ZM_GetSpeciesName((ZM_SPECIES_ID)s));
+		ZENITH_ASSERT_LE(xLs.m_uCount, uZM_MAX_LEARNSET_SIZE, "%s learnset overflows", ZM_GetSpeciesName((ZM_SPECIES_ID)s));
+		for (u_int k = 0; k < xLs.m_uCount; ++k)
+		{
+			ZENITH_ASSERT_TRUE(xLs.m_axMoves[k].m_eMove < ZM_MOVE_COUNT,
+				"%s learnset entry %u is not a real move", ZM_GetSpeciesName((ZM_SPECIES_ID)s), k);
+		}
+	}
+}
+
+// Levels are non-decreasing, in [1,60], and the first move is learned early.
+ZENITH_TEST(ZM_Data, Learnset_SortedByLevel)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SPECIES_ID eId = (ZM_SPECIES_ID)s;
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset(eId);
+		u_int uPrev = 0;
+		for (u_int k = 0; k < xLs.m_uCount; ++k)
+		{
+			const u_int uLevel = xLs.m_axMoves[k].m_uLevel;
+			ZENITH_ASSERT_GE(uLevel, 1u, "%s entry %u level < 1", ZM_GetSpeciesName(eId), k);
+			ZENITH_ASSERT_LE(uLevel, 60u, "%s entry %u level > 60", ZM_GetSpeciesName(eId), k);
+			ZENITH_ASSERT_GE(uLevel, uPrev, "%s learnset is not level-ordered", ZM_GetSpeciesName(eId));
+			uPrev = uLevel;
+		}
+		ZENITH_ASSERT_LE(xLs.m_axMoves[0].m_uLevel, 5u, "%s learns nothing by level 5", ZM_GetSpeciesName(eId));
+	}
+}
+
+// Every move in a learnset is of the species' type(s) or NORMAL.
+ZENITH_TEST(ZM_Data, Learnset_TypeAppropriate)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SPECIES_ID eId = (ZM_SPECIES_ID)s;
+		const ZM_SpeciesData& xSp = ZM_GetSpeciesData(eId);
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset(eId);
+		for (u_int k = 0; k < xLs.m_uCount; ++k)
+		{
+			const ZM_MoveData& xMove = ZM_GetMoveData(xLs.m_axMoves[k].m_eMove);
+			ZENITH_ASSERT_TRUE(MoveTypeAllowed(xMove.m_eType, xSp),
+				"%s learns off-type move %s (%s)", ZM_GetSpeciesName(eId), xMove.m_szName,
+				ZM_TypeToString(xMove.m_eType));
+		}
+	}
+}
+
+// Every species knows at least one same-type (STAB) move and at least one
+// damaging move by level 5 (so a low-level wild can actually battle).
+ZENITH_TEST(ZM_Data, Learnset_HasStabAndEarlyDamage)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SPECIES_ID eId = (ZM_SPECIES_ID)s;
+		const ZM_SpeciesData& xSp = ZM_GetSpeciesData(eId);
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset(eId);
+		bool bStab = false;
+		bool bEarlyDamage = false;
+		for (u_int k = 0; k < xLs.m_uCount; ++k)
+		{
+			const ZM_MoveData& xMove = ZM_GetMoveData(xLs.m_axMoves[k].m_eMove);
+			if (xMove.m_eType == xSp.m_aeTypes[0]) { bStab = true; }
+			if (xMove.m_eCategory != ZM_MOVE_CATEGORY_STATUS && xLs.m_axMoves[k].m_uLevel <= 5u)
+			{
+				bEarlyDamage = true;
+			}
+		}
+		ZENITH_ASSERT_TRUE(bStab, "%s has no same-type move", ZM_GetSpeciesName(eId));
+		ZENITH_ASSERT_TRUE(bEarlyDamage, "%s has no early damaging move", ZM_GetSpeciesName(eId));
+	}
+}
+
+// No move appears twice in a species' learnset.
+ZENITH_TEST(ZM_Data, Learnset_NoDuplicateMoves)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SPECIES_ID eId = (ZM_SPECIES_ID)s;
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset(eId);
+		for (u_int a = 0; a < xLs.m_uCount; ++a)
+		{
+			for (u_int b = a + 1; b < xLs.m_uCount; ++b)
+			{
+				ZENITH_ASSERT_NE((u_int)xLs.m_axMoves[a].m_eMove, (u_int)xLs.m_axMoves[b].m_eMove,
+					"%s learns move %s twice", ZM_GetSpeciesName(eId),
+					ZM_GetMoveName(xLs.m_axMoves[a].m_eMove));
+			}
+		}
+	}
+}
+
+// Status moves are a minority of every learnset (movesets are damaging-dominant).
+ZENITH_TEST(ZM_Data, Learnset_StatusMinority)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SPECIES_ID eId = (ZM_SPECIES_ID)s;
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset(eId);
+		u_int uStatus = 0;
+		for (u_int k = 0; k < xLs.m_uCount; ++k)
+		{
+			if (ZM_GetMoveData(xLs.m_axMoves[k].m_eMove).m_eCategory == ZM_MOVE_CATEGORY_STATUS)
+			{
+				++uStatus;
+			}
+		}
+		ZENITH_ASSERT_LE(uStatus, xLs.m_uCount / 2u, "%s learnset is status-heavy", ZM_GetSpeciesName(eId));
+	}
+}
+
+// The derivation is a pure function: two calls return identical learnsets.
+ZENITH_TEST(ZM_Data, Learnset_Deterministic)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SPECIES_ID eId = (ZM_SPECIES_ID)s;
+		const ZM_Learnset xA = ZM_GetSpeciesLearnset(eId);
+		const ZM_Learnset xB = ZM_GetSpeciesLearnset(eId);
+		ZENITH_ASSERT_EQ(xA.m_uCount, xB.m_uCount, "%s learnset count not stable", ZM_GetSpeciesName(eId));
+		for (u_int k = 0; k < xA.m_uCount; ++k)
+		{
+			ZENITH_ASSERT_EQ(xA.m_axMoves[k].m_uLevel, xB.m_axMoves[k].m_uLevel);
+			ZENITH_ASSERT_EQ((u_int)xA.m_axMoves[k].m_eMove, (u_int)xB.m_axMoves[k].m_eMove);
+		}
+	}
+}
+
+// Evolved forms know at least as many moves as their pre-evolution (movepool
+// grows, never shrinks, along a chain).
+ZENITH_TEST(ZM_Data, Learnset_CountNonDecreasingOnEvolution)
+{
+	for (u_int s = 0; s < ZM_SPECIES_COUNT; ++s)
+	{
+		const ZM_SpeciesData& xSp = ZM_GetSpeciesData((ZM_SPECIES_ID)s);
+		if (xSp.m_eEvolvesTo == ZM_SPECIES_NONE)
+		{
+			continue;
+		}
+		const u_int uThis = ZM_GetSpeciesLearnset(xSp.m_eId).m_uCount;
+		const u_int uNext = ZM_GetSpeciesLearnset(xSp.m_eEvolvesTo).m_uCount;
+		ZENITH_ASSERT_GE(uNext, uThis, "%s learns fewer moves than its pre-evolution", ZM_GetSpeciesName(xSp.m_eEvolvesTo));
+	}
+}


### PR DESCRIPTION
## S1 data core -- `ZM_Learnsets` (completes the `ZM_SpeciesData` box)

Roadmap S1 box 2, final increment. Adds per-species level-up learnsets, now unblocked by `ZM_MoveData` (#150). With this the species box is roster (#148) + base stats (#149) + learnsets, so it ticks `[x]`.

### What landed
- `Source/Data/ZM_Learnsets.h/.cpp` -- `ZM_GetSpeciesLearnset(id)` returning a fixed-capacity `ZM_Learnset` (max 16 `{level, move}` entries). **Systematically derived** (not stored), same placeholder strategy as base stats (ZM-D-021):
  - draws only from the species' own type(s) + universal `NORMAL` moves,
  - teaches a same-type damaging move at **level 1**, strongest moves last (fixed-damage moves like OHKO/night-shade read as high power so they land late),
  - **damaging-dominant** (status moves capped to a minority),
  - movepool size scales with evolution stage (12 / 14 / 16; single-stage finals 16),
  - fully deterministic (pure function of the compiled species + move tables).
- `Tests/ZM_Tests_Learnsets.cpp` -- **8 `ZM_Data` cases**: count bounded `[4,16]` + every entry a real move, level-ordered + in-range + something by L5, type-appropriate, has a STAB move + an early damaging move, no duplicates, status a minority, deterministic, and **learnset size non-decreasing along an evolution chain**.
- `ZM_SpeciesData.h` comments updated (base stats + learnsets now exist, not "deferred").

### Why derived
Real movepools are an S11 balance concern (headless AI-vs-AI); hand-authoring ~150 arbitrary placeholder movepools in one commit buys nothing over a deterministic, type-appropriate, referentially-valid derivation that unblocks S2 (which builds a monster's moveset from species + level). The accessor signature is the stable seam for a stored table later. TM/tutor compatibility is deferred to `ZM_ItemData`. The derivation was pre-validated across all 152 species offline before building.

### Gate
- `zenith build Zenithmon` (Vulkan_Debug_True) green; D3D12_False link proof builds in CI.
- Boot unit gate: **1119 ran / 1118 passed / 0 failed / 1 skipped** (pre-existing quarantined engine test). `zm-tests` baseline bumped **1111 -> 1119** in the same PR.
- `zenith test Zenithmon --headless`: `ZM_Boot_Test` 1 passed / 0 failed, exit 0.
- Docs: Roadmap species box ticked `[x]`, DecisionLog **ZM-D-023**, Status refreshed.

Next: `ZM_ItemData` (~80 items + TMs), Roadmap S1 box 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
