### PR TITLE
feat(zm): S1 - ZM_ItemData table (90 items) + 34-kind effect enum + integrity tests

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1119
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1130
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,35 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-024 -- ZM_ItemData ships as data + schema only (90 items over a 34-kind effect enum); the bag/battle logic is S2/S5
+
+- **Decision:** the ~80-item Roadmap box lands as a compiled `const ZM_ItemData`
+  table (90 items) plus its schema -- `ZM_ITEM_ID` (90, save-stable), a 9-value
+  `ZM_ITEM_CATEGORY` (ball / medicine / battle / held / berry / evo / TM / key /
+  field), and a 34-kind `ZM_ITEM_EFFECT` executor tag. Each row carries category,
+  buy + sell price, effect kind + a kind-specific param, a consumable flag, and
+  (for TMs) a taught `ZM_MOVE_ID`. Rows are INERT: the bag/use/held-hook/catch
+  logic that interprets `ZM_ITEM_EFFECT` is S2 (held items, catch math) / S5 (bag
+  UI), mirroring the MoveData boundary (ZM-D-022). The 25 TMs each reference a
+  real move; **this is the TM/tutor learnset seam** the learnset box deferred
+  (ZM-D-023). Original names; no Nintendo IP.
+- **Why:** items are battle-core scope (Scope.md); catching (S2/S5), the mart
+  (S6), held items in battle (S2), and TM teaching all reference this table, so it
+  must exist before them. Splitting data from the ~34-arm item executor keeps this
+  a reviewable data drop. The effect enum is sized so each future per-effect
+  handler has a data subject (a tested coverage invariant).
+- **Tests that lock it:** `Tests/ZM_Tests_Items.cpp` (category `ZM_Data`, 11
+  cases) -- index self-consistency (count == 90), unique names, valid
+  category/effect enums, price sanity (sell <= buy) + key-item contract
+  (priceless + effectless), consumable-flag-matches-category, TM-teaches-a-real-
+  move (and only TMs teach), ball-only CATCH with multiplier >= 1.0x, stat/type
+  param ranges, every effect kind used, every category populated, accessor +
+  ToString contracts. The roster was validated offline before building. Boot suite
+  1130 ran / 0 failed; zm-tests baseline bumped 1119 -> 1130.
+- **Reversibility:** easy -- additive `Source/Data/` files; `ZM_ITEM_ID` order is
+  append-only (save-stable). Per-item tuning (prices, effect params) is
+  git-history, not decisions.
+
 ## 2026-07-10 -- ZM-D-023 -- Species learnsets are systematically DERIVED (placeholder), completing the ZM_SpeciesData box
 
 - **Decision:** per-species level-up learnsets are computed by

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -32,7 +32,7 @@
 - [x] `ZM_Types.h` + `ZM_TypeChart` (18 types) -- 18-type `enum ZM_TYPE` + golden-locked 18x18 chart + dual-type product; 9 `ZM_Data` unit tests (PR #147). Also wired the boot unit suite into CI (ZM-D-019).
 - [x] `ZM_SpeciesData` (152 species: archetype + evo stage + size class + family seed + stats + learnsets) -- structural roster (id/name/types/archetype/evo/family/rarity + derived size/seed; PR #148 ZM-D-020) + derived base stats (PR #149 ZM-D-021) + derived level-up learnsets (`ZM_Learnsets.h`, `ZM_GetSpeciesLearnset`; PR #151 ZM-D-023). 24 `ZM_Data` tests (16 species + 8 learnset). Base stats + learnsets are systematic placeholders for the S11 balance pass; TM/tutor learnsets come with `ZM_ItemData`.
 - [x] `ZM_MoveData` (218 moves as table rows over a 57-kind `ZM_MOVE_EFFECT` enum) -- data + schema only (`ZM_MOVE_ID`/`ZM_MOVE_CATEGORY`/`ZM_MOVE_TARGET`/`ZM_MOVE_EFFECT` + per-row power/acc/PP/priority/crit/contact/effect+chance+magnitude); 16 `ZM_Data` tests incl. every-effect-kind-used coverage lock (PR #150, ZM-D-022). The `ZM_MoveExecutor` that interprets the effect enum is S2.
-- [ ] `ZM_ItemData` (~80 + TMs)
+- [x] `ZM_ItemData` (90 items + 25 TMs) -- compiled `ZM_ItemData` table over a 9-value `ZM_ITEM_CATEGORY` (ball/medicine/battle/held/berry/evo/TM/key/field) + 34-kind `ZM_ITEM_EFFECT`; per-row buy/sell/effect+param/consumable/taught-move; TMs reference real `ZM_MOVE_ID`s. Data + schema only (bag/battle executor is S2/S5). 11 `ZM_Data` tests incl. every-effect-kind coverage (PR #152, ZM-D-024).
 - [ ] `ZM_AbilityData` stubs (~50, fn-pointer hook structs) + `ZM_NatureData` (25)
 - [ ] `ZM_StatCalc` (pure formulas) + `ZM_BattleRNG` (PCG32)
 - [ ] `ZM_WorldSpec` skeleton (the keystone declarative world table)

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,6 +1,6 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species (roster + stats + learnsets, box DONE) + move table landed.**
+**Last updated:** 2026-07-10 -- **S1 in progress: type chart + species (done) + moves + items landed. Boxes 1-4 of 8 done.**
 
 **Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
@@ -10,30 +10,29 @@ GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon`. D3D1
 
 ## Tests
 
-- Unit (T0, category `ZM_Data`): **1119 ran, 1118 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 24 species (16 dex + 8 learnset) + 16 move + 1068 engine + 2 boot.
+- Unit (T0, category `ZM_Data`): **1130 ran, 1129 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 9 type-chart + 24 species + 16 move + 11 item + 1068 engine + 2 boot.
 - Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
-- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1119** in `zm-tests.yml`.
+- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1130** in `zm-tests.yml`.
 
-## What landed
+## What landed (S1 data core so far)
 
 - **PR #147:** type chart + CI unit gate (ZM-D-018/019).
-- **PR #148 / #149:** `ZM_SpeciesData` structural roster (152) + derived base stats (ZM-D-020/021).
-- **PR #150:** `ZM_MoveData` -- 218-move table over a 57-kind `ZM_MOVE_EFFECT` enum (data + schema only; executor is S2; ZM-D-022).
-- **PR #151 (this iteration):** `ZM_Learnsets` -- derived per-species level-up learnsets (`ZM_GetSpeciesLearnset`; ZM-D-023) + 8 `ZM_Data` tests. **Completes the `ZM_SpeciesData` box (now `[x]`).**
+- **PR #148/#149/#151:** `ZM_SpeciesData` -- roster (152) + derived base stats + derived learnsets (box DONE; ZM-D-020/021/023).
+- **PR #150:** `ZM_MoveData` -- 218 moves / 57-kind effect enum (data+schema; ZM-D-022).
+- **PR #152 (this iteration):** `ZM_ItemData` -- 90 items / 34-kind effect enum / 9 categories, 25 TMs -> `ZM_MOVE_ID`; 11 `ZM_Data` tests (ZM-D-024). Data + schema only; bag/battle executor is S2/S5.
 
 ## Current task
 
-None in flight (once PR #151 merges). **Next Roadmap task: `ZM_ItemData` (~80 items + TMs)** -- Roadmap S1 box 4. Model item categories (balls, medicine, held items, TMs, key items, berries-analog), a `ZM_ITEM_ID` + `ZM_ItemData` table (compiled C array), and TMs as items that map to a `ZM_MOVE_ID` (this is where TM/tutor learnset compatibility can be introduced). Then `ZM_AbilityData` + `ZM_NatureData` (box 5), `ZM_StatCalc` + `ZM_BattleRNG` (box 6), `ZM_WorldSpec` (box 7), `ZM_DataRegistry` (box 8).
+None in flight (once PR #152 merges). **Next Roadmap task: `ZM_AbilityData` stubs + `ZM_NatureData`** -- Roadmap S1 box 5. Abilities: ~50 as fn-pointer hook structs (OnSwitchIn/OnModifyStat/OnModifyDamage/OnStatusTry/OnContact/OnTurnEnd/OnFaint/OnAccuracy...) -- for S1, define the `ZM_ABILITY_ID` enum + `ZM_AbilityData` metadata table (id/name/description) + the hook-struct SHAPE (stub fn-pointers, null-defaulted); the real hook bodies are wired in S2. Natures: 25 `ZM_NATURE` with the +10%/-10% stat pair (neutral natures raise==lower). Then box 6 `ZM_StatCalc` + `ZM_BattleRNG` (PCG32), box 7 `ZM_WorldSpec`, box 8 `ZM_DataRegistry`.
 
 ## Notes for the next agent
 
-- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1119**. Forgetting it reddens zm-tests with a count mismatch.
-- Verify unit tests via a boot, not `zenith test` (which skips them): `Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N` prints `Unit tests complete: N ran ... M failed`. See Q-2026-07-10-004.
-- **Base stats AND learnsets are DERIVED placeholders** (ZM-D-021 / ZM-D-023): `ZM_GetSpeciesBaseStats` and `ZM_GetSpeciesLearnset` compute from the tables; replace the accessor bodies with stored tables in the S11 balance pass (signatures are the stable seam). Learnsets draw only from the species' type(s) + NORMAL, teach a STAB move at L1, are damaging-dominant, and grow with evo stage.
-- **Move data is INERT** (ZM-D-022): the `ZM_MoveExecutor` that interprets `ZM_MOVE_EFFECT` is S2. Every effect kind is used by >=1 move (locked). TMs (`ZM_ItemData`) will reference `ZM_MOVE_ID`.
-- **Big-table / derivation authoring tip:** move rows + the learnset derivation were both prototyped + fully validated offline in a scratchpad Python script (parsing the committed `.cpp` tables) BEFORE building -- catches design/coverage bugs in seconds, not build cycles. Not committed; the C++ is the source of truth (ZM-D-009).
-- **Working-dir gotcha:** the Bash and PowerShell tools SHARE a cwd here -- a `cd` in Bash moves PowerShell too. Avoid `cd`; use `git -C` / absolute paths / `Set-Location C:\dev\Zenith` before `regen`/`build`.
-- Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`).
-- Branch fresh off master (`git pull` first).
-- **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored.
+- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1130**.
+- Verify unit tests via a boot, not `zenith test` (which skips them): `Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N`. See Q-2026-07-10-004.
+- **Data tables are INERT + executor comes later** is the established S1 pattern: MoveData effect enum -> S2 `ZM_MoveExecutor`; ItemData effect enum -> S2/S5 bag/battle logic. Every effect kind is coverage-locked to >=1 row. Follow this for abilities (hook structs stubbed in S1, bodies in S2).
+- **Derived placeholders** (base stats ZM-D-021, learnsets ZM-D-023): computed accessors, replaced by stored tables in the S11 balance pass. Natures likely a small real table (25 rows); abilities metadata real + hooks stubbed.
+- **Big-table authoring:** move + item rows were authored + fully validated in a scratchpad Python generator (coverage, cross-rules, TM->move resolution) BEFORE building; committed C++ is the source of truth (ZM-D-009). Reuse the pattern for large tables.
+- **Working-dir gotcha:** Bash and PowerShell SHARE a cwd here -- a `cd` in Bash moves PowerShell too. Use `Set-Location C:\dev\Zenith` before regen/build; avoid `cd`.
+- Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`). Branch fresh off master (`git pull` first).
+- **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored. Scope changes need a user DecisionLog entry FIRST.
 - Session discipline: replace this file each session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.

--- a/Games/Zenithmon/Source/Data/ZM_ItemData.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_ItemData.cpp
@@ -1,0 +1,158 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_ItemData.h"
+
+// ============================================================================
+// ZM_ItemData -- the ~90-item table (DecisionLog ZM-D-024). Rows are in
+// ZM_ITEM_ID order; s_axItems[i].m_eId == i is asserted by the tests. See the
+// header for the per-field contract. Column legend:
+//   id, "name", category, buy, sell, effect, effectParam, consumable, taughtMove
+// (Balls carry CATCH; TMs carry TEACH_MOVE + a real m_eTaughtMove; key items are
+//  priceless + effectless. All invariants are locked by ZM_Tests_Items.)
+// ============================================================================
+
+namespace
+{
+	const ZM_ItemData s_axItems[ZM_ITEM_COUNT] =
+	{
+		// Balls -- capture devices (effect CATCH, param = catch multiplier x10)
+		{ ZM_ITEM_CATCHORB,        "Catch Orb",       ZM_ITEM_CATEGORY_BALL,      200,  100, ZM_ITEM_EFFECT_CATCH,              10, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_GREATORB,        "Great Orb",       ZM_ITEM_CATEGORY_BALL,      600,  300, ZM_ITEM_EFFECT_CATCH,              15, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_ULTRAORB,        "Ultra Orb",       ZM_ITEM_CATEGORY_BALL,     1200,  600, ZM_ITEM_EFFECT_CATCH,              20, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_HEALORB,         "Heal Orb",        ZM_ITEM_CATEGORY_BALL,      300,  150, ZM_ITEM_EFFECT_CATCH,              10, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_NETORB,          "Net Orb",         ZM_ITEM_CATEGORY_BALL,     1000,  500, ZM_ITEM_EFFECT_CATCH,              10, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_DUSKORB,         "Dusk Orb",        ZM_ITEM_CATEGORY_BALL,     1000,  500, ZM_ITEM_EFFECT_CATCH,              10, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_QUICKORB,        "Quick Orb",       ZM_ITEM_CATEGORY_BALL,     1000,  500, ZM_ITEM_EFFECT_CATCH,              10, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_PRIMEORB,        "Prime Orb",       ZM_ITEM_CATEGORY_BALL,        0,    0, ZM_ITEM_EFFECT_CATCH,             255, true , ZM_MOVE_NONE },
+		// Medicine -- HP restore (param = HP healed; FULL variants ignore it)
+		{ ZM_ITEM_SALVE,           "Salve",           ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_HEAL_HP,            20, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_TONIC,           "Tonic",           ZM_ITEM_CATEGORY_MEDICINE,  300,  150, ZM_ITEM_EFFECT_HEAL_HP,            60, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_DRAUGHT,         "Elixir Draught",  ZM_ITEM_CATEGORY_MEDICINE,  700,  350, ZM_ITEM_EFFECT_HEAL_HP,           120, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_GRANDRESTORE,    "Grand Restore",   ZM_ITEM_CATEGORY_MEDICINE, 1200,  600, ZM_ITEM_EFFECT_HEAL_HP,           200, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_RENEWAL,         "Renewal",         ZM_ITEM_CATEGORY_MEDICINE, 2000, 1000, ZM_ITEM_EFFECT_HEAL_HP_FULL,        0, true , ZM_MOVE_NONE },
+		// Medicine -- revive
+		{ ZM_ITEM_REVIVE,          "Revive",          ZM_ITEM_CATEGORY_MEDICINE, 1500,  750, ZM_ITEM_EFFECT_REVIVE_HALF,         0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_MAXREVIVE,       "Max Revive",      ZM_ITEM_CATEGORY_MEDICINE, 4000, 2000, ZM_ITEM_EFFECT_REVIVE_FULL,         0, true , ZM_MOVE_NONE },
+		// Medicine -- status cures
+		{ ZM_ITEM_ANTITOXIN,       "Antitoxin",       ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_CURE_POISON,         0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_BURNBALM,        "Burn Balm",       ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_CURE_BURN,           0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_THAWSPRAY,       "Thaw Spray",      ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_CURE_FREEZE,         0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_ROUSEBELL,       "Rouse Bell",      ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_CURE_SLEEP,          0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_NUMBCURE,        "Numbcure",        ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_CURE_PARALYSIS,      0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_CLEARMIND,       "Clearmind",       ZM_ITEM_CATEGORY_MEDICINE,  100,   50, ZM_ITEM_EFFECT_CURE_CONFUSE,        0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_PANACEA,         "Panacea",         ZM_ITEM_CATEGORY_MEDICINE,  500,  250, ZM_ITEM_EFFECT_CURE_ALL_STATUS,     0, true , ZM_MOVE_NONE },
+		// Medicine -- PP
+		{ ZM_ITEM_ETHER,           "Ether",           ZM_ITEM_CATEGORY_MEDICINE, 1200,  600, ZM_ITEM_EFFECT_RESTORE_PP,         10, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_ELIXIR,          "Elixir",          ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_RESTORE_PP_ALL,      0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_PPBOOST,         "PP Boost",        ZM_ITEM_CATEGORY_MEDICINE,    0,    0, ZM_ITEM_EFFECT_PP_UP,               0, true , ZM_MOVE_NONE },
+		// Vitamins -- permanent EV boost (param = stat index) + rare candy
+		{ ZM_ITEM_VIGORROOT,       "Vigor Root",      ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_EV_BOOST,            0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_POWERDRAUGHT,    "Power Draught",   ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_EV_BOOST,            1, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_GUARDDRAUGHT,    "Guard Draught",   ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_EV_BOOST,            2, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_FOCUSDRAUGHT,    "Focus Draught",   ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_EV_BOOST,            3, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_WARDDRAUGHT,     "Ward Draught",    ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_EV_BOOST,            4, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_SWIFTDRAUGHT,    "Swift Draught",   ZM_ITEM_CATEGORY_MEDICINE, 3000, 1500, ZM_ITEM_EFFECT_EV_BOOST,            5, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_RARESWEET,       "Rare Sweet",      ZM_ITEM_CATEGORY_MEDICINE,    0,    0, ZM_ITEM_EFFECT_LEVEL_UP,            0, true , ZM_MOVE_NONE },
+		// Battle items -- temporary in-battle stat boost (param = stat index)
+		{ ZM_ITEM_XPOWER,          "X Power",         ZM_ITEM_CATEGORY_BATTLE,    500,  250, ZM_ITEM_EFFECT_BATTLE_STAT_BOOST,   1, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_XGUARD,          "X Guard",         ZM_ITEM_CATEGORY_BATTLE,    500,  250, ZM_ITEM_EFFECT_BATTLE_STAT_BOOST,   2, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_XSWIFT,          "X Swift",         ZM_ITEM_CATEGORY_BATTLE,    500,  250, ZM_ITEM_EFFECT_BATTLE_STAT_BOOST,   5, true , ZM_MOVE_NONE },
+		// Held items -- passive battle effects (not consumed)
+		{ ZM_ITEM_AFTERGROWTH,     "Aftergrowth",     ZM_ITEM_CATEGORY_HELD,     2000, 1000, ZM_ITEM_EFFECT_HELD_LEFTOVERS,      0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_FLAMECHARM,      "Flame Charm",     ZM_ITEM_CATEGORY_HELD,     1500,  750, ZM_ITEM_EFFECT_HELD_TYPE_BOOST,     1, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_AQUACHARM,       "Aqua Charm",      ZM_ITEM_CATEGORY_HELD,     1500,  750, ZM_ITEM_EFFECT_HELD_TYPE_BOOST,     2, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_LEAFCHARM,       "Leaf Charm",      ZM_ITEM_CATEGORY_HELD,     1500,  750, ZM_ITEM_EFFECT_HELD_TYPE_BOOST,     3, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_CHOICEFANG,      "Choice Fang",     ZM_ITEM_CATEGORY_HELD,     3000, 1500, ZM_ITEM_EFFECT_HELD_CHOICE,         1, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_CHOICELENS,      "Choice Lens",     ZM_ITEM_CATEGORY_HELD,     3000, 1500, ZM_ITEM_EFFECT_HELD_CHOICE,         3, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_CHOICEBOOTS,     "Choice Boots",    ZM_ITEM_CATEGORY_HELD,     3000, 1500, ZM_ITEM_EFFECT_HELD_CHOICE,         5, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_ENDURECHARM,     "Endure Charm",    ZM_ITEM_CATEGORY_HELD,     2000, 1000, ZM_ITEM_EFFECT_HELD_FOCUS_SASH,     0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_POWERORB,        "Power Orb",       ZM_ITEM_CATEGORY_HELD,     2000, 1000, ZM_ITEM_EFFECT_HELD_LIFE_ORB,       0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_JOLTBELL,        "Jolt Bell",       ZM_ITEM_CATEGORY_HELD,     2000, 1000, ZM_ITEM_EFFECT_HELD_FLINCH,         0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_HEIRLOOMKNOT,    "Heirloom Knot",   ZM_ITEM_CATEGORY_HELD,        0,    0, ZM_ITEM_EFFECT_HELD_BREED_IV,       0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_STASISSTONE,     "Stasis Stone",    ZM_ITEM_CATEGORY_HELD,        0,    0, ZM_ITEM_EFFECT_HELD_NATURE_LOCK,    0, false, ZM_MOVE_NONE },
+		// Berries -- held consumables
+		{ ZM_ITEM_ROSEWELLBERRY,   "Rosewell Berry",  ZM_ITEM_CATEGORY_BERRY,      20,   10, ZM_ITEM_EFFECT_BERRY_HEAL,         30, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_CLEANSEBERRY,    "Cleanse Berry",   ZM_ITEM_CATEGORY_BERRY,      40,   20, ZM_ITEM_EFFECT_BERRY_CURE_STATUS,   0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_EMBERPIPBERRY,   "Emberpip Berry",  ZM_ITEM_CATEGORY_BERRY,      80,   40, ZM_ITEM_EFFECT_BERRY_PINCH_BOOST,   1, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_FROSTPIPBERRY,   "Frostpip Berry",  ZM_ITEM_CATEGORY_BERRY,      80,   40, ZM_ITEM_EFFECT_BERRY_PINCH_BOOST,   3, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_BUFFERFLAME,     "Flamebuff Berry", ZM_ITEM_CATEGORY_BERRY,      80,   40, ZM_ITEM_EFFECT_BERRY_TYPE_RESIST,   1, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_BUFFERTIDE,      "Tidebuff Berry",  ZM_ITEM_CATEGORY_BERRY,      80,   40, ZM_ITEM_EFFECT_BERRY_TYPE_RESIST,   2, true , ZM_MOVE_NONE },
+		// Evolution stones (param = stone variant)
+		{ ZM_ITEM_FLARESTONE,      "Flarestone",      ZM_ITEM_CATEGORY_EVO,      3000, 1500, ZM_ITEM_EFFECT_EVOLVE,              0, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_TIDESTONE,       "Tidestone",       ZM_ITEM_CATEGORY_EVO,      3000, 1500, ZM_ITEM_EFFECT_EVOLVE,              1, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_VOLTSTONE,       "Voltstone",       ZM_ITEM_CATEGORY_EVO,      3000, 1500, ZM_ITEM_EFFECT_EVOLVE,              2, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_MOONSTONE,       "Moonstone",       ZM_ITEM_CATEGORY_EVO,      3000, 1500, ZM_ITEM_EFFECT_EVOLVE,              3, true , ZM_MOVE_NONE },
+		{ ZM_ITEM_DUSKSTONE,       "Duskstone",       ZM_ITEM_CATEGORY_EVO,      3000, 1500, ZM_ITEM_EFFECT_EVOLVE,              4, true , ZM_MOVE_NONE },
+		// Field items
+		{ ZM_ITEM_WARDSCENT,       "Ward Scent",      ZM_ITEM_CATEGORY_FIELD,     350,  175, ZM_ITEM_EFFECT_REPEL,               0, true , ZM_MOVE_NONE },
+		// TMs -- teach a move (effect TEACH_MOVE, m_eTaughtMove set); reusable
+		{ ZM_ITEM_TM_TITANBEAM,    "TM Titan Beam",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_TITANBEAM },
+		{ ZM_ITEM_TM_CLOSEBOUT,    "TM Close Bout",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_CLOSEBOUT },
+		{ ZM_ITEM_TM_TOXICLANCE,   "TM Toxic Lance",  ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_TOXICLANCE },
+		{ ZM_ITEM_TM_FAULTLINE,    "TM Faultline",    ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_FAULTLINE },
+		{ ZM_ITEM_TM_DELUGEBEAM,   "TM Deluge Beam",  ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_DELUGEBEAM },
+		{ ZM_ITEM_TM_SUNLANCE,     "TM Sunlance",     ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_SUNLANCE },
+		{ ZM_ITEM_TM_THUNDERPEAL,  "TM Thunder Peal", ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_THUNDERPEAL },
+		{ ZM_ITEM_TM_HAILSPEAR,    "TM Hail Spear",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_HAILSPEAR },
+		{ ZM_ITEM_TM_MAGMAFALL,    "TM Magmafall",    ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_MAGMAFALL },
+		{ ZM_ITEM_TM_CYCLONEPEAL,  "TM Cyclone Peal", ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_CYCLONEPEAL },
+		{ ZM_ITEM_TM_PSYSPIRAL,    "TM Psy Spiral",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_PSYSPIRAL },
+		{ ZM_ITEM_TM_BUZZDRONE,    "TM Buzz Drone",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_BUZZDRONE },
+		{ ZM_ITEM_TM_MONOLITHFALL, "TM Monolith Fall",ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_MONOLITHFALL },
+		{ ZM_ITEM_TM_WRAITHLASH,   "TM Wraithlash",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_WRAITHLASH },
+		{ ZM_ITEM_TM_SKYSUNDER,    "TM Sky Sunder",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_SKYSUNDER },
+		{ ZM_ITEM_TM_FOULPLOY,     "TM Foul Ploy",    ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_FOULPLOY },
+		{ ZM_ITEM_TM_HEAVYPRESS,   "TM Heavy Press",  ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_HEAVYPRESS },
+		{ ZM_ITEM_TM_PRISMBEAM,    "TM Prism Beam",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_PRISMBEAM },
+		{ ZM_ITEM_TM_STATICSNARE,  "TM Static Snare", ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_STATICSNARE },
+		{ ZM_ITEM_TM_BLIGHTDOSE,   "TM Blightdose",   ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_BLIGHTDOSE },
+		{ ZM_ITEM_TM_HEXFLAME,     "TM Hexflame",     ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_HEXFLAME },
+		{ ZM_ITEM_TM_RAINCALL,     "TM Raincall",     ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_RAINCALL },
+		{ ZM_ITEM_TM_SUNFLARE,     "TM Sunflare",     ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_SUNFLARE },
+		{ ZM_ITEM_TM_SANDSTIR,     "TM Sandstir",     ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_SANDSTIR },
+		{ ZM_ITEM_TM_BULWARK,      "TM Bulwark",      ZM_ITEM_CATEGORY_TM,       1000,  500, ZM_ITEM_EFFECT_TEACH_MOVE,          0, false, ZM_MOVE_BULWARK },
+		// Key items -- gameplay gating, no bag/battle effect
+		{ ZM_ITEM_ANGLEROD,        "Angle Rod",       ZM_ITEM_CATEGORY_KEY,         0,    0, ZM_ITEM_EFFECT_NONE,                0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_TRAILBIKE,       "Trail Bike",      ZM_ITEM_CATEGORY_KEY,         0,    0, ZM_ITEM_EFFECT_NONE,                0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_REGIONMAP,       "Region Map",      ZM_ITEM_CATEGORY_KEY,         0,    0, ZM_ITEM_EFFECT_NONE,                0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_SEEKSCOPE,       "Seek Scope",      ZM_ITEM_CATEGORY_KEY,         0,    0, ZM_ITEM_EFFECT_NONE,                0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_BADGECASE,       "Badge Case",      ZM_ITEM_CATEGORY_KEY,         0,    0, ZM_ITEM_EFFECT_NONE,                0, false, ZM_MOVE_NONE },
+		{ ZM_ITEM_EGGVOUCHER,      "Egg Voucher",     ZM_ITEM_CATEGORY_KEY,         0,    0, ZM_ITEM_EFFECT_NONE,                0, false, ZM_MOVE_NONE },
+	};
+}
+
+const ZM_ItemData& ZM_GetItemData(ZM_ITEM_ID eId)
+{
+	Zenith_Assert(eId < ZM_ITEM_COUNT, "ZM_GetItemData: item id out of range (%u)", (u_int)eId);
+	return s_axItems[eId];
+}
+
+u_int ZM_GetItemCount()
+{
+	return ZM_ITEM_COUNT;
+}
+
+const char* ZM_GetItemName(ZM_ITEM_ID eId)
+{
+	if (eId >= ZM_ITEM_COUNT)
+	{
+		return "NONE";
+	}
+	return s_axItems[eId].m_szName;
+}
+
+const char* ZM_ItemCategoryToString(ZM_ITEM_CATEGORY eCategory)
+{
+	switch (eCategory)
+	{
+	case ZM_ITEM_CATEGORY_BALL:     return "BALL";
+	case ZM_ITEM_CATEGORY_MEDICINE: return "MEDICINE";
+	case ZM_ITEM_CATEGORY_BATTLE:   return "BATTLE";
+	case ZM_ITEM_CATEGORY_HELD:     return "HELD";
+	case ZM_ITEM_CATEGORY_BERRY:    return "BERRY";
+	case ZM_ITEM_CATEGORY_EVO:      return "EVO";
+	case ZM_ITEM_CATEGORY_TM:       return "TM";
+	case ZM_ITEM_CATEGORY_KEY:      return "KEY";
+	case ZM_ITEM_CATEGORY_FIELD:    return "FIELD";
+	default:                        return "INVALID";
+	}
+}

--- a/Games/Zenithmon/Source/Data/ZM_ItemData.h
+++ b/Games/Zenithmon/Source/Data/ZM_ItemData.h
@@ -1,0 +1,229 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_MoveData.h"
+
+// ============================================================================
+// ZM_ItemData -- the item table (S1 data core), ~90 items across balls,
+// medicine, held items, berries, evolution stones, TMs, and key items. Spec:
+// Docs/GameDesignDocument.md section 7 (items, ~25 TMs) + Scope.md (items are
+// battle core); decomposition rationale in DecisionLog ZM-D-024.
+//
+// DATA + schema only. The bag/battle logic that INTERPRETS ZM_ITEM_EFFECT
+// (using an item, held-item hooks, catch math) is S2/S5 -- a row here is inert:
+// it names an effect kind, a magnitude, and (for TMs) a taught ZM_MOVE_ID. Every
+// effect kind is used by at least one item (a tested invariant).
+//
+// Data is a compiled const C array (ZM-D-009). The ZM_ITEM_ID order is
+// save-stable once content ships -- APPEND before ZM_ITEM_COUNT, never reorder.
+// Names are original (Scope.md: zero Nintendo IP).
+// ============================================================================
+
+// Bag pocket / behaviour class.
+enum ZM_ITEM_CATEGORY : u_int
+{
+	ZM_ITEM_CATEGORY_BALL,       // capture devices
+	ZM_ITEM_CATEGORY_MEDICINE,   // HP / status / PP heals, vitamins, rare candy
+	ZM_ITEM_CATEGORY_BATTLE,     // in-battle temporary boosters
+	ZM_ITEM_CATEGORY_HELD,       // passive held items
+	ZM_ITEM_CATEGORY_BERRY,      // held consumables
+	ZM_ITEM_CATEGORY_EVO,        // evolution stones
+	ZM_ITEM_CATEGORY_TM,         // move teachers
+	ZM_ITEM_CATEGORY_KEY,        // key items (gameplay gating, no bag/battle effect)
+	ZM_ITEM_CATEGORY_FIELD,      // field items (repel-analog, ...)
+
+	ZM_ITEM_CATEGORY_COUNT
+};
+
+// The executor tag: what an item DOES when used or held. Interpreted by the
+// S2/S5 item logic. Save-stable: APPEND before ZM_ITEM_EFFECT_COUNT.
+enum ZM_ITEM_EFFECT : u_int
+{
+	ZM_ITEM_EFFECT_NONE,
+
+	// HP restore / revive (param = HP for HEAL_HP)
+	ZM_ITEM_EFFECT_HEAL_HP,
+	ZM_ITEM_EFFECT_HEAL_HP_FULL,
+	ZM_ITEM_EFFECT_REVIVE_HALF,
+	ZM_ITEM_EFFECT_REVIVE_FULL,
+
+	// Status cures
+	ZM_ITEM_EFFECT_CURE_POISON,
+	ZM_ITEM_EFFECT_CURE_BURN,
+	ZM_ITEM_EFFECT_CURE_FREEZE,
+	ZM_ITEM_EFFECT_CURE_SLEEP,
+	ZM_ITEM_EFFECT_CURE_PARALYSIS,
+	ZM_ITEM_EFFECT_CURE_CONFUSE,
+	ZM_ITEM_EFFECT_CURE_ALL_STATUS,
+
+	// PP restore
+	ZM_ITEM_EFFECT_RESTORE_PP,
+	ZM_ITEM_EFFECT_RESTORE_PP_ALL,
+	ZM_ITEM_EFFECT_PP_UP,
+
+	// Capture / progression
+	ZM_ITEM_EFFECT_CATCH,
+	ZM_ITEM_EFFECT_EV_BOOST,
+	ZM_ITEM_EFFECT_LEVEL_UP,
+	ZM_ITEM_EFFECT_TEACH_MOVE,
+	ZM_ITEM_EFFECT_EVOLVE,
+
+	// In-battle consumable (param = stat index)
+	ZM_ITEM_EFFECT_BATTLE_STAT_BOOST,
+
+	// Held (passive)
+	ZM_ITEM_EFFECT_HELD_LEFTOVERS,
+	ZM_ITEM_EFFECT_HELD_TYPE_BOOST,
+	ZM_ITEM_EFFECT_HELD_CHOICE,
+	ZM_ITEM_EFFECT_HELD_FOCUS_SASH,
+	ZM_ITEM_EFFECT_HELD_LIFE_ORB,
+	ZM_ITEM_EFFECT_HELD_FLINCH,
+	ZM_ITEM_EFFECT_HELD_BREED_IV,
+	ZM_ITEM_EFFECT_HELD_NATURE_LOCK,
+
+	// Berries (held consumable)
+	ZM_ITEM_EFFECT_BERRY_HEAL,
+	ZM_ITEM_EFFECT_BERRY_CURE_STATUS,
+	ZM_ITEM_EFFECT_BERRY_PINCH_BOOST,
+	ZM_ITEM_EFFECT_BERRY_TYPE_RESIST,
+
+	// Field
+	ZM_ITEM_EFFECT_REPEL,
+
+	ZM_ITEM_EFFECT_COUNT
+};
+
+// Every item, in bag/data order. IDs are contiguous 0..ZM_ITEM_COUNT-1 and the
+// row index equals the id (asserted by ZM_Tests_Items).
+enum ZM_ITEM_ID : u_int
+{
+	// Balls -- capture devices (effect CATCH, param = catch multiplier x10)
+	ZM_ITEM_CATCHORB,
+	ZM_ITEM_GREATORB,
+	ZM_ITEM_ULTRAORB,
+	ZM_ITEM_HEALORB,
+	ZM_ITEM_NETORB,
+	ZM_ITEM_DUSKORB,
+	ZM_ITEM_QUICKORB,
+	ZM_ITEM_PRIMEORB,
+	// Medicine -- HP restore (param = HP healed; FULL variants ignore it)
+	ZM_ITEM_SALVE,
+	ZM_ITEM_TONIC,
+	ZM_ITEM_DRAUGHT,
+	ZM_ITEM_GRANDRESTORE,
+	ZM_ITEM_RENEWAL,
+	// Medicine -- revive
+	ZM_ITEM_REVIVE,
+	ZM_ITEM_MAXREVIVE,
+	// Medicine -- status cures
+	ZM_ITEM_ANTITOXIN,
+	ZM_ITEM_BURNBALM,
+	ZM_ITEM_THAWSPRAY,
+	ZM_ITEM_ROUSEBELL,
+	ZM_ITEM_NUMBCURE,
+	ZM_ITEM_CLEARMIND,
+	ZM_ITEM_PANACEA,
+	// Medicine -- PP
+	ZM_ITEM_ETHER,
+	ZM_ITEM_ELIXIR,
+	ZM_ITEM_PPBOOST,
+	// Vitamins -- permanent EV boost (param = stat index) + rare candy
+	ZM_ITEM_VIGORROOT,
+	ZM_ITEM_POWERDRAUGHT,
+	ZM_ITEM_GUARDDRAUGHT,
+	ZM_ITEM_FOCUSDRAUGHT,
+	ZM_ITEM_WARDDRAUGHT,
+	ZM_ITEM_SWIFTDRAUGHT,
+	ZM_ITEM_RARESWEET,
+	// Battle items -- temporary in-battle stat boost (param = stat index)
+	ZM_ITEM_XPOWER,
+	ZM_ITEM_XGUARD,
+	ZM_ITEM_XSWIFT,
+	// Held items -- passive battle effects (not consumed)
+	ZM_ITEM_AFTERGROWTH,
+	ZM_ITEM_FLAMECHARM,
+	ZM_ITEM_AQUACHARM,
+	ZM_ITEM_LEAFCHARM,
+	ZM_ITEM_CHOICEFANG,
+	ZM_ITEM_CHOICELENS,
+	ZM_ITEM_CHOICEBOOTS,
+	ZM_ITEM_ENDURECHARM,
+	ZM_ITEM_POWERORB,
+	ZM_ITEM_JOLTBELL,
+	ZM_ITEM_HEIRLOOMKNOT,
+	ZM_ITEM_STASISSTONE,
+	// Berries -- held consumables
+	ZM_ITEM_ROSEWELLBERRY,
+	ZM_ITEM_CLEANSEBERRY,
+	ZM_ITEM_EMBERPIPBERRY,
+	ZM_ITEM_FROSTPIPBERRY,
+	ZM_ITEM_BUFFERFLAME,
+	ZM_ITEM_BUFFERTIDE,
+	// Evolution stones (param = stone variant)
+	ZM_ITEM_FLARESTONE,
+	ZM_ITEM_TIDESTONE,
+	ZM_ITEM_VOLTSTONE,
+	ZM_ITEM_MOONSTONE,
+	ZM_ITEM_DUSKSTONE,
+	// Field items
+	ZM_ITEM_WARDSCENT,
+	// TMs -- teach a move (effect TEACH_MOVE, m_eTaughtMove set); reusable
+	ZM_ITEM_TM_TITANBEAM,
+	ZM_ITEM_TM_CLOSEBOUT,
+	ZM_ITEM_TM_TOXICLANCE,
+	ZM_ITEM_TM_FAULTLINE,
+	ZM_ITEM_TM_DELUGEBEAM,
+	ZM_ITEM_TM_SUNLANCE,
+	ZM_ITEM_TM_THUNDERPEAL,
+	ZM_ITEM_TM_HAILSPEAR,
+	ZM_ITEM_TM_MAGMAFALL,
+	ZM_ITEM_TM_CYCLONEPEAL,
+	ZM_ITEM_TM_PSYSPIRAL,
+	ZM_ITEM_TM_BUZZDRONE,
+	ZM_ITEM_TM_MONOLITHFALL,
+	ZM_ITEM_TM_WRAITHLASH,
+	ZM_ITEM_TM_SKYSUNDER,
+	ZM_ITEM_TM_FOULPLOY,
+	ZM_ITEM_TM_HEAVYPRESS,
+	ZM_ITEM_TM_PRISMBEAM,
+	ZM_ITEM_TM_STATICSNARE,
+	ZM_ITEM_TM_BLIGHTDOSE,
+	ZM_ITEM_TM_HEXFLAME,
+	ZM_ITEM_TM_RAINCALL,
+	ZM_ITEM_TM_SUNFLARE,
+	ZM_ITEM_TM_SANDSTIR,
+	ZM_ITEM_TM_BULWARK,
+	// Key items -- gameplay gating, no bag/battle effect
+	ZM_ITEM_ANGLEROD,
+	ZM_ITEM_TRAILBIKE,
+	ZM_ITEM_REGIONMAP,
+	ZM_ITEM_SEEKSCOPE,
+	ZM_ITEM_BADGECASE,
+	ZM_ITEM_EGGVOUCHER,
+
+	ZM_ITEM_COUNT,
+	ZM_ITEM_NONE = ZM_ITEM_COUNT   // "no item" sentinel (empty bag / held slots)
+};
+
+// One item row. m_uEffectParam is effect-kind-specific: HEAL_HP/RESTORE_PP read
+// it as an amount; CATCH as a catch multiplier x10; EV_BOOST/BATTLE_STAT_BOOST/
+// HELD_CHOICE/BERRY_PINCH_BOOST as a ZM_STAT index; HELD_TYPE_BOOST/
+// BERRY_TYPE_RESIST as a ZM_TYPE index; EVOLVE as a stone variant; else 0.
+// m_eTaughtMove is the move a TM teaches (ZM_MOVE_NONE for every non-TM).
+struct ZM_ItemData
+{
+	ZM_ITEM_ID		m_eId;
+	const char*		m_szName;
+	ZM_ITEM_CATEGORY	m_eCategory;
+	u_int			m_uBuyPrice;      // 0 == not purchasable (key / story / free items)
+	u_int			m_uSellPrice;     // <= buy price; 0 for key items
+	ZM_ITEM_EFFECT	m_eEffect;
+	u_int			m_uEffectParam;   // kind-specific (amount / stat idx / type idx / mult)
+	bool			m_bConsumable;    // consumed on use (balls/medicine/berries/battle/evo/field)
+	ZM_MOVE_ID		m_eTaughtMove;    // TM: taught move; ZM_MOVE_NONE otherwise
+};
+
+// Table accessors (bounds-asserted). GetItemData indexes by ZM_ITEM_ID.
+const ZM_ItemData&	ZM_GetItemData(ZM_ITEM_ID eId);
+u_int				ZM_GetItemCount();                 // == ZM_ITEM_COUNT
+const char*			ZM_GetItemName(ZM_ITEM_ID eId);   // "NONE" out of range
+const char*			ZM_ItemCategoryToString(ZM_ITEM_CATEGORY eCategory);

--- a/Games/Zenithmon/Tests/ZM_Tests_Items.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_Items.cpp
@@ -1,0 +1,228 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_Items -- schema integrity of the item table (category ZM_Data). The
+// item rows are inert until the S2/S5 bag + battle logic interprets
+// ZM_ITEM_EFFECT, so this suite locks the schema: index consistency, per-field
+// ranges, the category/effect/price/consumable cross-rules, that every TM
+// teaches a REAL move, and that every effect kind + category is populated. See
+// DecisionLog ZM-D-024.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_Types.h"
+#include "Zenithmon/Source/Data/ZM_MoveData.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"   // ZM_STAT_COUNT
+#include "Zenithmon/Source/Data/ZM_ItemData.h"
+
+#include <cstring>
+
+namespace
+{
+	constexpr u_int uEXPECTED_ITEMS = 90;
+
+	const ZM_ItemData& It(u_int uIndex)
+	{
+		return ZM_GetItemData((ZM_ITEM_ID)uIndex);
+	}
+
+	bool CategoryIsConsumable(ZM_ITEM_CATEGORY eCat)
+	{
+		switch (eCat)
+		{
+		case ZM_ITEM_CATEGORY_BALL:
+		case ZM_ITEM_CATEGORY_MEDICINE:
+		case ZM_ITEM_CATEGORY_BATTLE:
+		case ZM_ITEM_CATEGORY_BERRY:
+		case ZM_ITEM_CATEGORY_EVO:
+		case ZM_ITEM_CATEGORY_FIELD:
+			return true;
+		default:   // HELD, TM, KEY
+			return false;
+		}
+	}
+
+	bool EffectUsesStatParam(ZM_ITEM_EFFECT e)
+	{
+		return e == ZM_ITEM_EFFECT_EV_BOOST
+			|| e == ZM_ITEM_EFFECT_BATTLE_STAT_BOOST
+			|| e == ZM_ITEM_EFFECT_HELD_CHOICE
+			|| e == ZM_ITEM_EFFECT_BERRY_PINCH_BOOST;
+	}
+
+	bool EffectUsesTypeParam(ZM_ITEM_EFFECT e)
+	{
+		return e == ZM_ITEM_EFFECT_HELD_TYPE_BOOST
+			|| e == ZM_ITEM_EFFECT_BERRY_TYPE_RESIST;
+	}
+}
+
+// The roster is the expected size and the table is index-consistent.
+ZENITH_TEST(ZM_Data, Items_CountAndSelfConsistent)
+{
+	ZENITH_ASSERT_EQ(ZM_GetItemCount(), uEXPECTED_ITEMS);
+	ZENITH_ASSERT_EQ((u_int)ZM_ITEM_COUNT, uEXPECTED_ITEMS);
+	ZENITH_ASSERT_EQ((u_int)ZM_ITEM_NONE, (u_int)ZM_ITEM_COUNT);
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)It(i).m_eId, i, "item row %u has mismatched m_eId", i);
+	}
+}
+
+// Every name is present and unique.
+ZENITH_TEST(ZM_Data, Items_NamesUniqueNonEmpty)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		const char* szA = It(i).m_szName;
+		ZENITH_ASSERT_NOT_NULL(szA);
+		ZENITH_ASSERT_TRUE(szA[0] != '\0', "item %u has an empty name", i);
+		for (u_int j = i + 1; j < ZM_ITEM_COUNT; ++j)
+		{
+			ZENITH_ASSERT_FALSE(strcmp(szA, It(j).m_szName) == 0,
+				"duplicate item name '%s' at %u and %u", szA, i, j);
+		}
+	}
+}
+
+// Category and effect enums are in range.
+ZENITH_TEST(ZM_Data, Items_EnumFieldsValid)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		ZENITH_ASSERT_TRUE(It(i).m_eCategory < ZM_ITEM_CATEGORY_COUNT, "%s bad category", It(i).m_szName);
+		ZENITH_ASSERT_TRUE(It(i).m_eEffect < ZM_ITEM_EFFECT_COUNT, "%s bad effect", It(i).m_szName);
+	}
+}
+
+// Sell price never exceeds buy price; key items are priceless and effectless.
+ZENITH_TEST(ZM_Data, Items_PricesAndKeyContract)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		const ZM_ItemData& x = It(i);
+		ZENITH_ASSERT_LE(x.m_uSellPrice, x.m_uBuyPrice, "%s sells for more than it buys", x.m_szName);
+		if (x.m_eCategory == ZM_ITEM_CATEGORY_KEY)
+		{
+			ZENITH_ASSERT_EQ(x.m_uBuyPrice, 0u, "key item %s has a price", x.m_szName);
+			ZENITH_ASSERT_EQ(x.m_uSellPrice, 0u, "key item %s is sellable", x.m_szName);
+			ZENITH_ASSERT_EQ((u_int)x.m_eEffect, (u_int)ZM_ITEM_EFFECT_NONE, "key item %s has an effect", x.m_szName);
+		}
+	}
+}
+
+// The consumable flag matches the category's semantics.
+ZENITH_TEST(ZM_Data, Items_ConsumableByCategory)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		const ZM_ItemData& x = It(i);
+		ZENITH_ASSERT_EQ(x.m_bConsumable, CategoryIsConsumable(x.m_eCategory),
+			"%s consumable flag disagrees with its category", x.m_szName);
+	}
+}
+
+// TMs (and only TMs) teach a real move; non-TMs never carry a taught move.
+ZENITH_TEST(ZM_Data, Items_TmTeachesRealMove)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		const ZM_ItemData& x = It(i);
+		if (x.m_eCategory == ZM_ITEM_CATEGORY_TM)
+		{
+			ZENITH_ASSERT_EQ((u_int)x.m_eEffect, (u_int)ZM_ITEM_EFFECT_TEACH_MOVE, "TM %s wrong effect", x.m_szName);
+			ZENITH_ASSERT_TRUE(x.m_eTaughtMove < ZM_MOVE_COUNT, "TM %s teaches a non-move", x.m_szName);
+		}
+		else
+		{
+			ZENITH_ASSERT_NE((u_int)x.m_eEffect, (u_int)ZM_ITEM_EFFECT_TEACH_MOVE, "%s is not a TM but teaches", x.m_szName);
+			ZENITH_ASSERT_EQ((u_int)x.m_eTaughtMove, (u_int)ZM_MOVE_NONE, "%s carries a taught move", x.m_szName);
+		}
+	}
+}
+
+// Balls (and only balls) capture; catch multiplier is at least 1.0x (x10).
+ZENITH_TEST(ZM_Data, Items_BallContract)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		const ZM_ItemData& x = It(i);
+		if (x.m_eCategory == ZM_ITEM_CATEGORY_BALL)
+		{
+			ZENITH_ASSERT_EQ((u_int)x.m_eEffect, (u_int)ZM_ITEM_EFFECT_CATCH, "ball %s wrong effect", x.m_szName);
+			ZENITH_ASSERT_GE(x.m_uEffectParam, 10u, "ball %s catch multiplier < 1.0x", x.m_szName);
+		}
+		else
+		{
+			ZENITH_ASSERT_NE((u_int)x.m_eEffect, (u_int)ZM_ITEM_EFFECT_CATCH, "%s catches but is not a ball", x.m_szName);
+		}
+	}
+}
+
+// Effect params that index a stat / type are in range for that enum.
+ZENITH_TEST(ZM_Data, Items_EffectParamRanges)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		const ZM_ItemData& x = It(i);
+		if (EffectUsesStatParam(x.m_eEffect))
+		{
+			ZENITH_ASSERT_LT(x.m_uEffectParam, (u_int)ZM_STAT_COUNT, "%s stat param out of range", x.m_szName);
+		}
+		if (EffectUsesTypeParam(x.m_eEffect))
+		{
+			ZENITH_ASSERT_LT(x.m_uEffectParam, (u_int)ZM_TYPE_COUNT, "%s type param out of range", x.m_szName);
+		}
+		if (x.m_eEffect == ZM_ITEM_EFFECT_HEAL_HP)
+		{
+			ZENITH_ASSERT_GT(x.m_uEffectParam, 0u, "%s heals 0 HP", x.m_szName);
+		}
+	}
+}
+
+// Every effect kind is exercised by at least one item.
+ZENITH_TEST(ZM_Data, Items_EveryEffectKindUsed)
+{
+	for (u_int e = 0; e < ZM_ITEM_EFFECT_COUNT; ++e)
+	{
+		bool bFound = false;
+		for (u_int i = 0; i < ZM_ITEM_COUNT && !bFound; ++i)
+		{
+			bFound = ((u_int)It(i).m_eEffect == e);
+		}
+		ZENITH_ASSERT_TRUE(bFound, "no item uses effect kind %u", e);
+	}
+}
+
+// Every category is populated.
+ZENITH_TEST(ZM_Data, Items_EveryCategoryUsed)
+{
+	for (u_int c = 0; c < ZM_ITEM_CATEGORY_COUNT; ++c)
+	{
+		bool bFound = false;
+		for (u_int i = 0; i < ZM_ITEM_COUNT && !bFound; ++i)
+		{
+			bFound = ((u_int)It(i).m_eCategory == c);
+		}
+		ZENITH_ASSERT_TRUE(bFound, "category %s (%u) has no items",
+			ZM_ItemCategoryToString((ZM_ITEM_CATEGORY)c), c);
+	}
+}
+
+// Accessors + category stringifier honour their contracts.
+ZENITH_TEST(ZM_Data, Items_AccessorAndToStringContract)
+{
+	for (u_int i = 0; i < ZM_ITEM_COUNT; ++i)
+	{
+		ZENITH_ASSERT_STREQ(ZM_GetItemName((ZM_ITEM_ID)i), It(i).m_szName);
+	}
+	ZENITH_ASSERT_STREQ(ZM_GetItemName(ZM_ITEM_NONE), "NONE");
+
+	for (u_int c = 0; c < ZM_ITEM_CATEGORY_COUNT; ++c)
+	{
+		const char* sz = ZM_ItemCategoryToString((ZM_ITEM_CATEGORY)c);
+		ZENITH_ASSERT_NOT_NULL(sz);
+		ZENITH_ASSERT_FALSE(strcmp(sz, "INVALID") == 0, "category %u stringifies as INVALID", c);
+	}
+	ZENITH_ASSERT_STREQ(ZM_ItemCategoryToString(ZM_ITEM_CATEGORY_COUNT), "INVALID");
+}


### PR DESCRIPTION
## S1 data core -- `ZM_ItemData`

Roadmap S1 box 4. Adds the item table that catching (S2/S5), the mart (S6), held-item battle hooks (S2), and TM teaching all reference. **Data + schema only** -- the bag/use/held-hook/catch logic that interprets `ZM_ITEM_EFFECT` is S2/S5, mirroring the MoveData boundary (ZM-D-022 / ZM-D-024).

### What landed
- `Source/Data/ZM_ItemData.h/.cpp` -- a compiled `const ZM_ItemData` table of **90 items** plus the schema:
  - `ZM_ITEM_ID` (90, save-stable) + `ZM_ITEM_NONE` sentinel
  - `ZM_ITEM_CATEGORY` (9): ball / medicine / battle / held / berry / evo / **TM** / key / field
  - `ZM_ITEM_EFFECT` (**34** executor tags): heal / revive / status-cure / PP / catch / EV / level-up / teach-move / evolve / battle-boost / held-passives / berries / repel
  - per row: category, buy + sell price, effect + kind-specific param, consumable flag, and (for the **25 TMs**) a taught `ZM_MOVE_ID`
  - accessors + `ZM_ItemCategoryToString`
- `Tests/ZM_Tests_Items.cpp` -- **11 `ZM_Data` cases**: index self-consistency, unique names, enum validity, price sanity (`sell <= buy`) + key-item contract (priceless + effectless), consumable-flag-matches-category, **TM-teaches-a-real-move** (and only TMs teach), ball-only `CATCH` with multiplier `>= 1.0x`, stat/type param ranges, **every effect kind used** + **every category populated**, accessor + ToString contracts.

### Notes
- The 25 TMs each reference a real `ZM_MOVE_ID` (validated) -- this is the TM/tutor learnset seam the learnset box deferred (ZM-D-023).
- Original names throughout (Scope.md: zero Nintendo IP); compiled `const` C array (ZM-D-009). Roster validated offline before building.

### Gate
- `zenith build Zenithmon` (Vulkan_Debug_True) green; D3D12_False link proof builds in CI.
- Boot unit gate: **1130 ran / 1129 passed / 0 failed / 1 skipped** (pre-existing quarantined engine test). `zm-tests` baseline bumped **1119 -> 1130**.
- `zenith test Zenithmon --headless`: `ZM_Boot_Test` 1 passed / 0 failed, exit 0.
- Docs: Roadmap box ticked `[x]`, DecisionLog **ZM-D-024**, Status refreshed.

Next: `ZM_AbilityData` stubs + `ZM_NatureData` (Roadmap S1 box 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
