### PR TITLE
feat(zm): S1 - ZM_StatCalc (Gen-III+ integer stat formulas) + ZM_BattleRNG (PCG32)

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1142
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1152
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,35 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-027 -- ZM_StatCalc (Gen-III+ integer formulas) + ZM_BattleRNG (PCG32) are the sanctioned math + randomness
+
+- **Decision:** two pure-logic modules close most of the S1 formula surface.
+  `ZM_StatCalc` (`Source/Data/ZM_StatCalc.{h,cpp}`) is the Gen-III+ integer stat
+  formula -- `HP = ((2*base+IV+EV/4)*level)/100 + level + 10`; the other five =
+  `(((2*base+IV+EV/4)*level)/100 + 5) * naturePercent/100`, truncating divisions,
+  nature multiplier applied last via `ZM_GetNatureStatPercent` (ZM-D-025). No
+  floating point. `ZM_BattleRNG` (`Source/Data/ZM_BattleRNG.h`, header-only) is a
+  PCG32 generator (64-bit state, 32-bit output): `Next` / unbiased `RandBelow` /
+  `RandRange` / `Chance` / `ChancePercent`, deterministic from a seed. It is the
+  ONLY sanctioned randomness in game logic (never rand()/std::random).
+- **Why:** the battle engine (S2) is seeded and must replay bit-for-bit, so both
+  the stat math and the RNG must be integer-exact and reproducible. Landing them
+  in S1 (with golden vectors) gives S2 a locked, tested foundation. PCG32 is small,
+  fast, statistically strong, and trivially reproducible -- the standard choice for
+  a deterministic game RNG. Default-constructed RNGs are fixed-seeded so an
+  unseeded instance is never a hidden nondeterminism source.
+- **Tests that lock it:** `Tests/ZM_Tests_StatCalc.cpp` (4) -- HP + other-stat
+  golden vectors across level/IV/EV/nature, nature dispatch (HP nature-independent;
+  raise/lower/unaffected stats), monotonicity. `Tests/ZM_Tests_BattleRNG.cpp` (6)
+  -- **a golden 8-value stream pinning the exact PCG32 algorithm**, same-seed
+  determinism, distinct-seed divergence, RandBelow/RandRange bounds, and the
+  Chance/ChancePercent contract + ~50% frequency. All expected values were
+  precomputed in a scratchpad model and matched on the first build. Boot suite
+  1152 ran / 0 failed; baseline bumped 1142 -> 1152.
+- **Reversibility:** easy -- additive `Source/Data/` files, no other module
+  depends on them yet. The PCG32 constants + seeding sequence are load-bearing
+  (the golden stream pins them); changing them is a deliberate golden-vector edit.
+
 ## 2026-07-10 -- ZM-D-026 -- ZM_AbilityData ships roster + metadata + a declared HOOK-SURFACE bitmask; fn-pointer hook bodies are S2
 
 - **Decision:** the ~50-ability Roadmap sub-box lands as a compiled `const

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -34,7 +34,7 @@
 - [x] `ZM_MoveData` (218 moves as table rows over a 57-kind `ZM_MOVE_EFFECT` enum) -- data + schema only (`ZM_MOVE_ID`/`ZM_MOVE_CATEGORY`/`ZM_MOVE_TARGET`/`ZM_MOVE_EFFECT` + per-row power/acc/PP/priority/crit/contact/effect+chance+magnitude); 16 `ZM_Data` tests incl. every-effect-kind-used coverage lock (PR #150, ZM-D-022). The `ZM_MoveExecutor` that interprets the effect enum is S2.
 - [x] `ZM_ItemData` (90 items + 25 TMs) -- compiled `ZM_ItemData` table over a 9-value `ZM_ITEM_CATEGORY` (ball/medicine/battle/held/berry/evo/TM/key/field) + 34-kind `ZM_ITEM_EFFECT`; per-row buy/sell/effect+param/consumable/taught-move; TMs reference real `ZM_MOVE_ID`s. Data + schema only (bag/battle executor is S2/S5). 11 `ZM_Data` tests incl. every-effect-kind coverage (PR #152, ZM-D-024).
 - [x] `ZM_AbilityData` stubs (50 abilities: id/name/description + `ZM_ABILITY_HOOK` surface bitmask; fn-pointer hook bodies deferred to S2, ZM-D-026) + `ZM_NatureData` (25: exact 5x5 raised/lowered grid + `ZM_GetNatureStatPercent`, ZM-D-025). 12 `ZM_Data` tests (PR #153).
-- [ ] `ZM_StatCalc` (pure formulas) + `ZM_BattleRNG` (PCG32)
+- [x] `ZM_StatCalc` (Gen-III+ integer stat formulas: HP + other-five with nature %, all integer-exact) + `ZM_BattleRNG` (PCG32 seeded RNG: Next/RandBelow/RandRange/Chance, deterministic). 10 `ZM_Data` tests incl. stat golden vectors + a golden PCG32 stream (PR #154, ZM-D-027).
 - [ ] `ZM_WorldSpec` skeleton (the keystone declarative world table)
 - [ ] `ZM_DataRegistry` (name->ID indices + validation); `ZM_Tests_Data` schema-enforcer suite
 

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,6 +1,6 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 data core: boxes 1-5 of 8 done (types, species, moves, items, abilities+natures). Box 6 (StatCalc+RNG) next.**
+**Last updated:** 2026-07-10 -- **S1 data core: boxes 1-6 of 8 done. Box 7 (WorldSpec skeleton) next, then box 8 (DataRegistry) closes S1.**
 
 **Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
@@ -10,32 +10,29 @@ GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon`. D3D1
 
 ## Tests
 
-- Unit (T0, category `ZM_Data`): **1142 ran, 1141 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 72 `ZM_*` (9 type + 24 species + 16 move + 11 item + 6 nature + 6 ability) + 1068 engine + 2 boot.
+- Unit (T0, category `ZM_Data`): **1152 ran, 1151 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 82 `ZM_*` (9 type + 24 species + 16 move + 11 item + 6 nature + 6 ability + 4 statcalc + 6 rng) + 1068 engine + 2 boot.
 - Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
-- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1142** in `zm-tests.yml`.
+- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1152** in `zm-tests.yml`.
 
-## What landed (S1 data core)
+## What landed (S1 data core: 6/8 boxes)
 
-- **PR #147:** type chart (ZM-D-018).
-- **PR #148/#149/#151:** `ZM_SpeciesData` -- roster + derived base stats + derived learnsets (box DONE).
-- **PR #150:** `ZM_MoveData` (218 moves / 57-kind effect enum).
-- **PR #152:** `ZM_ItemData` (90 items / 34-kind effect enum / 25 TMs).
-- **PR #153 (this iteration):** `ZM_NatureData` (25, exact 5x5 grid; ZM-D-025) + `ZM_AbilityData` (50 abilities: roster + metadata + `ZM_ABILITY_HOOK` surface bitmask; hook bodies are S2; ZM-D-026). Box 5 DONE.
+- Box 1 type chart (#147); Box 2 species roster+stats+learnsets (#148/#149/#151, DONE); Box 3 moves (#150); Box 4 items (#152); Box 5 abilities+natures (#153).
+- **Box 6 (PR #154, this iteration):** `ZM_StatCalc` (Gen-III+ integer stat formulas + nature %) + `ZM_BattleRNG` (PCG32 seeded RNG). 10 `ZM_Data` tests incl. stat golden vectors + a golden PCG32 stream (ZM-D-027).
 
 ## Current task
 
-None in flight (once PR #153 merges). **Next Roadmap task: `ZM_StatCalc` (pure formulas) + `ZM_BattleRNG` (PCG32)** -- Roadmap S1 box 6. This is LOGIC, not a data table:
-- `ZM_StatCalc`: Gen-III+ integer stat formulas -- HP = `((2*base + IV + EV/4) * level)/100 + level + 10`; other five = `(((2*base + IV + EV/4) * level)/100 + 5) * naturePercent / 100` using `ZM_GetNatureStatPercent` (ZM-D-025). Golden-vector tests (level 1/50/100 x IV 0/31 x EV 0/252 x nature up/down/neutral, HP vs non-HP).
-- `ZM_BattleRNG`: PCG32 (seeded, deterministic) -- `Next()` / `RandRange(n)` / `Chance(percentOrNum, den)`; tests for determinism (same seed -> same stream), range bounds, and a distribution sanity check.
-Then box 7 `ZM_WorldSpec` (the keystone world table), box 8 `ZM_DataRegistry` (name->ID indices + cross-table validation) closes S1.
+None in flight (once PR #154 merges). **Next Roadmap task: `ZM_WorldSpec` skeleton** -- Roadmap S1 box 7, the KEYSTONE declarative world table (ZM-D-005). For S1 this is the SCHEMA + a small proving set, NOT the full ~40 scenes (that's S9/S10):
+- A `ZM_WorldSpec` row per scene: name, build index, scene kind (FrontEnd/Town/Route/Interior/Gym/Battle/Tower), terrain-set name, connections (warp edges w/ target build index + spawn tag), optional encounter-table ref + rate, trainer/shop/gym refs, story-flag gate. Define the enums + struct + a compiled table with the handful of scenes that exist conceptually now (FrontEnd idx 0, Battle idx 1, Dawnmere, Route 1, a lab interior -- enough to exercise every column).
+- Referential-integrity tests: every warp target build index resolves to a real WorldSpec row, every spawn tag referenced exists, every encounter species is a real `ZM_SPECIES_ID`, build indices unique. This is the schema enforcer that keeps the world honest before S3+ author real scenes.
+Then box 8 `ZM_DataRegistry` (name->ID indices across all tables + a cross-table `ZM_Tests_Data` schema-enforcer suite) CLOSES S1. **S1 gate:** ~90 unit tests (currently 82 `ZM_*`), no visual check.
 
 ## Notes for the next agent
 
-- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1142**.
+- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1152**.
 - Verify unit tests via a boot: `Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N`. See Q-2026-07-10-004.
-- **S1 patterns established:** (1) big data tables authored + validated in a scratchpad Python generator before building, coverage-locked (moves/items/abilities); committed C++ is the source of truth (ZM-D-009). (2) "Data now, executor later": move/item effect enums + the ability hook bitmask all name behaviour the S2 battle engine will implement -- every kind/hook is coverage-tested so S2 has subjects. (3) Derived placeholders (base stats ZM-D-021, learnsets ZM-D-023) vs exact real tables (natures ZM-D-025) -- pick per whether the set is closed.
-- **`ZM_STAT` lives in `ZM_SpeciesData.h`**; natures + StatCalc reference it (include that header). `ZM_GetNatureStatPercent` (ZM_NatureData.h) is the nature multiplier StatCalc consumes.
-- **Working-dir gotcha:** Bash and PowerShell SHARE a cwd here -- use `Set-Location C:\dev\Zenith` before regen/build; avoid `cd`. Tracked `Tools/**/__pycache__/*.pyc` drift on build -- `git checkout --` them; never stage them.
+- **`ZM_BattleRNG` is the ONLY sanctioned RNG** in game logic (ZM-D-027, PCG32, header-only, deterministic from seed). `ZM_StatCalc` is the integer stat math (no floats). S2's battle engine builds on both. The golden PCG32 stream pins the exact algorithm -- do not change the constants/seeding without re-deriving the golden vectors.
+- **S1 patterns:** big data tables + golden vectors are prototyped/validated in scratchpad Python BEFORE building (moves/items/abilities rosters; stat + PCG32 golden values) -- committed C++ is source of truth (ZM-D-009). "Data now, executor later" for move/item/ability behaviour (S2). `ZM_STAT` lives in `ZM_SpeciesData.h`.
+- **Working-dir gotcha:** Bash + PowerShell SHARE a cwd -- `Set-Location C:\dev\Zenith` before regen/build; avoid `cd`. Tracked `Tools/**/__pycache__/*.pyc` drift on build -- `git checkout --` them; never stage them.
 - Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`). Branch fresh off master.
 - **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored. Scope changes need a user DecisionLog entry FIRST.
 - Session discipline: replace this file each session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.

--- a/Games/Zenithmon/Source/Data/ZM_BattleRNG.h
+++ b/Games/Zenithmon/Source/Data/ZM_BattleRNG.h
@@ -1,0 +1,85 @@
+#pragma once
+
+// ============================================================================
+// ZM_BattleRNG -- the seeded, deterministic battle RNG (S1 data core). A PCG32
+// generator (O'Neill's permuted congruential generator): 64-bit state, 32-bit
+// output, statistically strong and exactly reproducible from a seed. Spec:
+// Docs/GameDesignDocument.md section 7 (ZM_BattleRNG, PCG32); DecisionLog ZM-D-027.
+//
+// The battle engine (S2) is "headless, synchronous, and seeded" -- every random
+// decision (accuracy, crit, damage roll, secondary-effect procs, AI tie-breaks,
+// catch shakes) draws from an instance of this, so a battle replays bit-for-bit
+// from its seed. This is the ONLY sanctioned randomness source in game logic;
+// never call rand()/std::random in rule code.
+// ============================================================================
+
+class ZM_BattleRNG
+{
+public:
+	// Default construction is deterministic (a fixed seed) so an unseeded RNG is
+	// never a hidden source of nondeterminism.
+	ZM_BattleRNG() { Seed(0x853C49E6748FEA9Bull, 0xDA3E39CB94B95BDBull); }
+	explicit ZM_BattleRNG(u_int64 ulSeed, u_int64 ulSeq = 54ull) { Seed(ulSeed, ulSeq); }
+
+	// (Re)seed the stream. ulSeq selects one of 2^63 distinct sequences.
+	void Seed(u_int64 ulSeed, u_int64 ulSeq = 54ull)
+	{
+		m_ulState = 0ull;
+		m_ulInc = (ulSeq << 1u) | 1u;
+		Next();
+		m_ulState += ulSeed;
+		Next();
+	}
+
+	// The core step: advance the state and return the next 32-bit output.
+	u_int32 Next()
+	{
+		const u_int64 ulOld = m_ulState;
+		m_ulState = ulOld * ulPCG32_MULTIPLIER + m_ulInc;
+		const u_int32 uXorShifted = (u_int32)(((ulOld >> 18u) ^ ulOld) >> 27u);
+		const u_int32 uRot = (u_int32)(ulOld >> 59u);
+		return (uXorShifted >> uRot) | (uXorShifted << ((0u - uRot) & 31u));
+	}
+
+	// Unbiased integer in [0, uBound) via rejection (removes modulo bias).
+	u_int RandBelow(u_int uBound)
+	{
+		Zenith_Assert(uBound > 0u, "ZM_BattleRNG::RandBelow: bound must be > 0");
+		const u_int32 uThreshold = (u_int32)(0u - uBound) % uBound;   // == 2^32 mod uBound
+		for (;;)
+		{
+			const u_int32 uX = Next();
+			if (uX >= uThreshold)
+			{
+				return (u_int)(uX % uBound);
+			}
+		}
+	}
+
+	// Inclusive integer in [uMin, uMax].
+	u_int RandRange(u_int uMin, u_int uMax)
+	{
+		Zenith_Assert(uMax >= uMin, "ZM_BattleRNG::RandRange: max < min");
+		return uMin + RandBelow(uMax - uMin + 1u);
+	}
+
+	// True with probability uNumerator / uDenominator. Chance(0, d) is never true;
+	// Chance(d, d) is always true.
+	bool Chance(u_int uNumerator, u_int uDenominator)
+	{
+		Zenith_Assert(uDenominator > 0u, "ZM_BattleRNG::Chance: denominator must be > 0");
+		return RandBelow(uDenominator) < uNumerator;
+	}
+
+	// True with probability uPercent / 100 (uPercent >= 100 is always true).
+	bool ChancePercent(u_int uPercent)
+	{
+		return Chance(uPercent, 100u);
+	}
+
+private:
+	static constexpr u_int64 ulPCG32_MULTIPLIER = 6364136223846793005ull;
+
+	u_int64	m_ulState = 0ull;
+	u_int64	m_ulInc = 1ull;
+};

--- a/Games/Zenithmon/Source/Data/ZM_StatCalc.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_StatCalc.cpp
@@ -1,0 +1,41 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_StatCalc.h"
+
+// ============================================================================
+// ZM_StatCalc -- Gen-III+ integer stat formulas (DecisionLog ZM-D-027). Golden
+// vectors in Tests/ZM_Tests_StatCalc.cpp pin the exact outputs.
+// ============================================================================
+
+namespace
+{
+	// The shared inner term: ((2*base + IV + EV/4) * level) / 100. Truncating
+	// division, done in the natural range (max ~ (2*255+31+63)*100/100 = 604).
+	u_int StatCore(u_int uBase, u_int uIV, u_int uEV, u_int uLevel)
+	{
+		return ((2u * uBase + uIV + uEV / 4u) * uLevel) / 100u;
+	}
+}
+
+u_int ZM_CalcHPStat(u_int uBase, u_int uIV, u_int uEV, u_int uLevel)
+{
+	Zenith_Assert(uLevel >= uZM_MIN_LEVEL && uLevel <= uZM_MAX_LEVEL, "ZM_CalcHPStat: level %u out of range", uLevel);
+	Zenith_Assert(uIV <= uZM_MAX_IV, "ZM_CalcHPStat: IV %u > 31", uIV);
+	return StatCore(uBase, uIV, uEV, uLevel) + uLevel + 10u;
+}
+
+u_int ZM_CalcOtherStat(u_int uBase, u_int uIV, u_int uEV, u_int uLevel, u_int uNaturePercent)
+{
+	Zenith_Assert(uLevel >= uZM_MIN_LEVEL && uLevel <= uZM_MAX_LEVEL, "ZM_CalcOtherStat: level %u out of range", uLevel);
+	Zenith_Assert(uIV <= uZM_MAX_IV, "ZM_CalcOtherStat: IV %u > 31", uIV);
+	const u_int uPreNature = StatCore(uBase, uIV, uEV, uLevel) + 5u;
+	return (uPreNature * uNaturePercent) / 100u;
+}
+
+u_int ZM_CalcStat(ZM_STAT eStat, u_int uBase, u_int uIV, u_int uEV, u_int uLevel, ZM_NATURE eNature)
+{
+	if (eStat == ZM_STAT_HP)
+	{
+		return ZM_CalcHPStat(uBase, uIV, uEV, uLevel);
+	}
+	return ZM_CalcOtherStat(uBase, uIV, uEV, uLevel, ZM_GetNatureStatPercent(eNature, eStat));
+}

--- a/Games/Zenithmon/Source/Data/ZM_StatCalc.h
+++ b/Games/Zenithmon/Source/Data/ZM_StatCalc.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"   // ZM_STAT
+#include "Zenithmon/Source/Data/ZM_NatureData.h"     // ZM_NATURE, ZM_GetNatureStatPercent
+
+// ============================================================================
+// ZM_StatCalc -- the Gen-III+ stat formulas (S1 data core), pure integer math.
+// Spec: Docs/GameDesignDocument.md section 7.1 (stats); DecisionLog ZM-D-027.
+//
+//   HP    = ((2*base + IV + EV/4) * level) / 100 + level + 10
+//   other = (((2*base + IV + EV/4) * level) / 100 + 5) * naturePercent / 100
+//
+// All divisions truncate (floor); the nature multiplier is the integer percent
+// from ZM_GetNatureStatPercent (110 / 90 / 100, ZM-D-025), applied last so the
+// x11/10 and x9/10 are exact. No floating point anywhere -- the battle engine
+// (S2) needs bit-exact reproducibility. HP ignores nature.
+// ============================================================================
+
+// Value ranges the formulas assume (the battle/data layers clamp to these).
+static const u_int uZM_MAX_IV          = 31u;   // per stat, 0..31
+static const u_int uZM_MAX_EV_PER_STAT = 252u;  // per stat cap
+static const u_int uZM_MAX_EV_TOTAL    = 510u;  // sum across the six stats
+static const u_int uZM_MIN_LEVEL       = 1u;
+static const u_int uZM_MAX_LEVEL       = 100u;
+
+// HP stat from base HP, IV, EV, level.
+u_int ZM_CalcHPStat(u_int uBase, u_int uIV, u_int uEV, u_int uLevel);
+
+// One of the five non-HP stats; uNaturePercent is 110 / 100 / 90.
+u_int ZM_CalcOtherStat(u_int uBase, u_int uIV, u_int uEV, u_int uLevel, u_int uNaturePercent);
+
+// Convenience: compute any stat for a species+nature, dispatching HP vs the rest
+// and pulling the nature multiplier automatically (HP is nature-independent).
+u_int ZM_CalcStat(ZM_STAT eStat, u_int uBase, u_int uIV, u_int uEV, u_int uLevel, ZM_NATURE eNature);

--- a/Games/Zenithmon/Tests/ZM_Tests_BattleRNG.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_BattleRNG.cpp
@@ -1,0 +1,106 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_BattleRNG -- determinism + distribution tests for the PCG32 battle
+// RNG (category ZM_Data). The golden stream pins the exact algorithm (so a
+// battle replays bit-for-bit from its seed); the rest lock the bounded/chance
+// helpers. See DecisionLog ZM-D-027.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_BattleRNG.h"
+
+// A fixed seed produces a fixed, known 32-bit stream (independently computed).
+ZENITH_TEST(ZM_Data, BattleRNG_GoldenStream)
+{
+	const u_int32 auGolden[8] = {
+		0x2C6B5AC7u, 0xDFB253B3u, 0xB40C9B72u, 0xBB17F46Fu,
+		0x5B46277Au, 0xAF30A295u, 0xA30728FAu, 0xBC192629u,
+	};
+	ZM_BattleRNG xRng(0x1234ull, 54ull);
+	for (u_int i = 0; i < 8; ++i)
+	{
+		ZENITH_ASSERT_EQ(xRng.Next(), auGolden[i], "PCG32 golden stream diverged at %u", i);
+	}
+}
+
+// Same seed -> identical streams.
+ZENITH_TEST(ZM_Data, BattleRNG_Deterministic)
+{
+	ZM_BattleRNG xA(0xABCDEF01ull);
+	ZM_BattleRNG xB(0xABCDEF01ull);
+	for (u_int i = 0; i < 64; ++i)
+	{
+		ZENITH_ASSERT_EQ(xA.Next(), xB.Next(), "same-seed streams diverged at %u", i);
+	}
+}
+
+// Different seeds -> different streams (they must not all coincide).
+ZENITH_TEST(ZM_Data, BattleRNG_DifferentSeedsDiffer)
+{
+	ZM_BattleRNG xA(1ull);
+	ZM_BattleRNG xB(2ull);
+	bool bAnyDiffer = false;
+	for (u_int i = 0; i < 8; ++i)
+	{
+		if (xA.Next() != xB.Next()) { bAnyDiffer = true; }
+	}
+	ZENITH_ASSERT_TRUE(bAnyDiffer, "distinct seeds produced identical streams");
+}
+
+// RandBelow(n) stays in [0, n); RandBelow(1) is always 0.
+ZENITH_TEST(ZM_Data, BattleRNG_RandBelowInRange)
+{
+	ZM_BattleRNG xRng(0x55AA55AAull);
+	const u_int auBounds[] = { 1u, 2u, 6u, 100u, 1000u };
+	for (u_int b = 0; b < sizeof(auBounds) / sizeof(auBounds[0]); ++b)
+	{
+		const u_int uBound = auBounds[b];
+		for (u_int i = 0; i < 2000; ++i)
+		{
+			const u_int uV = xRng.RandBelow(uBound);
+			ZENITH_ASSERT_LT(uV, uBound, "RandBelow(%u) returned %u", uBound, uV);
+		}
+	}
+	for (u_int i = 0; i < 32; ++i)
+	{
+		ZENITH_ASSERT_EQ(xRng.RandBelow(1u), 0u);
+	}
+}
+
+// RandRange(lo,hi) is inclusive; a degenerate range returns the single value.
+ZENITH_TEST(ZM_Data, BattleRNG_RandRangeInclusive)
+{
+	ZM_BattleRNG xRng(0x99887766ull);
+	for (u_int i = 0; i < 4000; ++i)
+	{
+		const u_int uV = xRng.RandRange(10u, 20u);
+		ZENITH_ASSERT_GE(uV, 10u);
+		ZENITH_ASSERT_LE(uV, 20u);
+	}
+	for (u_int i = 0; i < 16; ++i)
+	{
+		ZENITH_ASSERT_EQ(xRng.RandRange(7u, 7u), 7u);
+	}
+}
+
+// Chance contract: 0/d never true, d/d always true, and ~p over many trials.
+ZENITH_TEST(ZM_Data, BattleRNG_ChanceContract)
+{
+	ZM_BattleRNG xRng(0xDEADBEEFull);
+	for (u_int i = 0; i < 64; ++i)
+	{
+		ZENITH_ASSERT_FALSE(xRng.Chance(0u, 16u), "Chance(0,d) fired");
+		ZENITH_ASSERT_TRUE(xRng.Chance(16u, 16u), "Chance(d,d) missed");
+		ZENITH_ASSERT_FALSE(xRng.ChancePercent(0u), "ChancePercent(0) fired");
+		ZENITH_ASSERT_TRUE(xRng.ChancePercent(100u), "ChancePercent(100) missed");
+	}
+	// ~50% over 10000 deterministic trials, generous tolerance (no flakiness).
+	u_int uHits = 0;
+	for (u_int i = 0; i < 10000; ++i)
+	{
+		if (xRng.Chance(1u, 2u)) { ++uHits; }
+	}
+	ZENITH_ASSERT_GE(uHits, 4500u, "Chance(1,2) fired only %u/10000 times", uHits);
+	ZENITH_ASSERT_LE(uHits, 5500u, "Chance(1,2) fired %u/10000 times", uHits);
+}

--- a/Games/Zenithmon/Tests/ZM_Tests_StatCalc.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_StatCalc.cpp
@@ -1,0 +1,73 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_StatCalc -- golden-vector tests for the Gen-III+ stat formulas
+// (category ZM_Data). The expected values are hand/independently computed (see
+// the formula in ZM_StatCalc.h) so any drift in the integer math is caught as a
+// deliberate change. See DecisionLog ZM-D-027.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+#include "Zenithmon/Source/Data/ZM_NatureData.h"
+#include "Zenithmon/Source/Data/ZM_StatCalc.h"
+
+// HP = ((2*base + IV + EV/4) * level)/100 + level + 10
+ZENITH_TEST(ZM_Data, StatCalc_HpGoldenVectors)
+{
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(45,   0,   0,   5), 19u);
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(45,  31,   0,  50), 120u);
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(100, 31, 252, 100), 404u);
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(1,    0,   0,   1), 11u);
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(255, 31, 252, 100), 714u);
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(80,  31, 252,  50), 187u);
+	ZENITH_ASSERT_EQ(ZM_CalcHPStat(60,   0,   0, 100), 230u);
+}
+
+// other = (((2*base + IV + EV/4)*level)/100 + 5) * naturePercent/100
+ZENITH_TEST(ZM_Data, StatCalc_OtherGoldenVectors)
+{
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(100, 31,   0,  50, 100), 120u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(100, 31,   0,  50, 110), 132u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(100, 31,   0,  50,  90), 108u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(100, 31, 252, 100, 100), 299u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(100, 31, 252, 100, 110), 328u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(100, 31, 252, 100,  90), 269u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(50,   0,   0,  50, 100), 55u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(50,   0,   0,   1, 100), 6u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(120, 31, 252, 100, 110), 372u);
+	ZENITH_ASSERT_EQ(ZM_CalcOtherStat(70,  15, 100,  50,  90), 85u);
+}
+
+// ZM_CalcStat dispatches HP vs other and applies the nature to the right stats.
+ZENITH_TEST(ZM_Data, StatCalc_NatureDispatch)
+{
+	// HP ignores nature entirely.
+	ZENITH_ASSERT_EQ(ZM_CalcStat(ZM_STAT_HP, 100, 31, 252, 100, ZM_NATURE_RECKLESS),
+		ZM_CalcHPStat(100, 31, 252, 100));
+
+	// Reckless raises ATTACK (110%), lowers DEFENSE (90%), leaves the rest (100%).
+	ZENITH_ASSERT_EQ(ZM_CalcStat(ZM_STAT_ATTACK, 100, 31, 0, 50, ZM_NATURE_RECKLESS),
+		ZM_CalcOtherStat(100, 31, 0, 50, 110));
+	ZENITH_ASSERT_EQ(ZM_CalcStat(ZM_STAT_DEFENSE, 100, 31, 0, 50, ZM_NATURE_RECKLESS),
+		ZM_CalcOtherStat(100, 31, 0, 50, 90));
+	ZENITH_ASSERT_EQ(ZM_CalcStat(ZM_STAT_SPEED, 100, 31, 0, 50, ZM_NATURE_RECKLESS),
+		ZM_CalcOtherStat(100, 31, 0, 50, 100));
+
+	// A neutral nature is 100% on every stat.
+	ZENITH_ASSERT_EQ(ZM_CalcStat(ZM_STAT_ATTACK, 100, 31, 0, 50, ZM_NATURE_FERAL),
+		ZM_CalcOtherStat(100, 31, 0, 50, 100));
+}
+
+// Stats are non-decreasing in base / IV / EV / level.
+ZENITH_TEST(ZM_Data, StatCalc_Monotonic)
+{
+	ZENITH_ASSERT_LE(ZM_CalcOtherStat(100,  0, 0, 50, 100), ZM_CalcOtherStat(100, 31, 0, 50, 100));
+	ZENITH_ASSERT_LE(ZM_CalcOtherStat(100, 31, 0, 50, 100), ZM_CalcOtherStat(100, 31, 252, 50, 100));
+	ZENITH_ASSERT_LE(ZM_CalcOtherStat(100, 31, 0, 50, 100), ZM_CalcOtherStat(100, 31, 0, 100, 100));
+	ZENITH_ASSERT_LE(ZM_CalcOtherStat(50, 31, 0, 50, 100),  ZM_CalcOtherStat(120, 31, 0, 50, 100));
+	ZENITH_ASSERT_LE(ZM_CalcHPStat(45, 0, 0, 5), ZM_CalcHPStat(45, 0, 0, 50));
+	// The nature down-multiplier never raises a stat above neutral.
+	ZENITH_ASSERT_LE(ZM_CalcOtherStat(100, 31, 0, 50, 90), ZM_CalcOtherStat(100, 31, 0, 50, 100));
+	ZENITH_ASSERT_LE(ZM_CalcOtherStat(100, 31, 0, 50, 100), ZM_CalcOtherStat(100, 31, 0, 50, 110));
+}


### PR DESCRIPTION
## S1 data core -- `ZM_StatCalc` + `ZM_BattleRNG` (box 6)

Roadmap S1 box 6. The two pure-logic primitives the seeded battle engine (S2) is built on -- integer-exact stat math and a deterministic RNG.

### `ZM_StatCalc` -- Gen-III+ integer stat formulas
- `HP = ((2*base + IV + EV/4) * level)/100 + level + 10`
- other five = `(((2*base + IV + EV/4) * level)/100 + 5) * naturePercent/100`
- Truncating divisions; nature multiplier (110/90/100 from `ZM_GetNatureStatPercent`, ZM-D-025) applied last so it's exact. **No floating point.** `ZM_CalcStat(stat, ..., nature)` dispatches HP vs other and applies the nature automatically (HP is nature-independent).

### `ZM_BattleRNG` -- PCG32 seeded RNG (header-only)
- 64-bit state, 32-bit output; `Next` / unbiased `RandBelow` / `RandRange` / `Chance` / `ChancePercent`.
- Deterministic from a seed -> a battle replays bit-for-bit. **The only sanctioned randomness in game logic** (never `rand()`/`std::random`). Default construction is fixed-seeded so an unseeded RNG is never hidden nondeterminism.

### Tests (10 `ZM_Data`)
- StatCalc (4): HP + other-stat **golden vectors** across level/IV/EV/nature, nature dispatch (HP nature-independent; raised/lowered/unaffected stats), monotonicity.
- BattleRNG (6): a **golden 8-value PCG32 stream** pinning the exact algorithm, same-seed determinism, distinct-seed divergence, `RandBelow`/`RandRange` bounds, and the `Chance`/`ChancePercent` contract + ~50% frequency.
- All expected values were precomputed in a scratchpad model and matched on the first build.

### Gate
- `zenith build Zenithmon` (Vulkan_Debug_True) green; D3D12_False link proof in CI.
- Boot unit gate: **1152 ran / 1151 passed / 0 failed / 1 skipped** (pre-existing quarantined engine test). `zm-tests` baseline bumped **1142 -> 1152**.
- `zenith test Zenithmon --headless`: `ZM_Boot_Test` 1 passed / 0 failed, exit 0.
- Docs: Roadmap box 6 ticked `[x]`, DecisionLog **ZM-D-027**, Status refreshed.

Next: `ZM_WorldSpec` skeleton (Roadmap S1 box 7), then `ZM_DataRegistry` (box 8) closes S1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
