### PR TITLE
feat(zm): S1 - ZM_WorldSpec skeleton (keystone world table) + referential-integrity tests

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1152
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1163
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,38 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-029 -- ZM_WorldSpec ships as SCHEMA + an 8-scene proving set; the full world is appended at S9/S10
+
+- **Decision:** the keystone world table (ZM-D-005) lands its SCHEMA plus a small
+  proving set, not the full world. `ZM_WorldSpec` (`Source/Data/ZM_WorldSpec.{h,
+  cpp}`): one row per scene -- id / name / build index / `ZM_SCENE_KIND` (9 kinds:
+  frontend/town/route/interior/gym/battle/tower/league/victory_road) / terrain set
+  / warp connections (`ZM_SceneConnection` = target scene + spawn tag) / offered
+  spawn tags / encounter table (`ZM_EncounterSlot` = species + level band +
+  weight). Per-scene connection/tag/encounter arrays are static, referenced by
+  pointer + count. The 8 proving scenes (FrontEnd 0, Battle 1, Dawnmere, Route 1,
+  Thornacre, Player's Home, Aster's Lab, Gym 1) exercise every column. Accessors:
+  `ZM_GetWorldSpec` / `ZM_GetSceneName` / `ZM_FindSceneByBuildIndex` /
+  `ZM_SceneKindToString`. The full ~40-scene world is authored at S9/S10 by
+  APPENDING rows (`ZM_SCENE_ID` is save-stable, append-only).
+- **Why:** everything from S3 on (warps, encounters, gating, terrain authoring)
+  flows through this table, so the schema + a referential-integrity test suite
+  must exist first -- it is the enforcer that keeps ~40 scenes honest before any
+  are baked. Shipping only the schema + proving set keeps S1 headless-data-only
+  while locking the structure S3+ builds against.
+- **Tests that lock it:** `Tests/ZM_Tests_WorldSpec.cpp` (category `ZM_Data`, 11
+  cases) -- index self-consistency, unique names, unique build indices anchored
+  (FrontEnd 0 / Battle 1), valid kinds, terrain-by-kind (outdoor has terrain,
+  indoor does not), spawn tags non-empty + unique per scene, **every connection
+  resolves to a real target + a spawn tag that target offers**, encounters
+  route-only with real species + valid level bands + positive weight, **every
+  non-Battle scene reachable from FrontEnd**, build-index round-trip, accessor +
+  ToString. The graph was pre-validated offline before building. Boot suite 1163
+  ran / 0 failed; baseline bumped 1152 -> 1163.
+- **Reversibility:** easy -- additive `Source/Data/` files; the world grows by
+  appending rows. Build-index assignments are cheap to change until S3 warps start
+  referencing them through this table.
+
 ## 2026-07-10 -- ZM-D-028 -- Loop policy: local gate is the quality bar; auto-merge on zm-tests green; do NOT wait on / idle-watch CI
 
 - **Decision (user-directed):** the autonomous loop must not sit blocking on CI.

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -35,7 +35,7 @@
 - [x] `ZM_ItemData` (90 items + 25 TMs) -- compiled `ZM_ItemData` table over a 9-value `ZM_ITEM_CATEGORY` (ball/medicine/battle/held/berry/evo/TM/key/field) + 34-kind `ZM_ITEM_EFFECT`; per-row buy/sell/effect+param/consumable/taught-move; TMs reference real `ZM_MOVE_ID`s. Data + schema only (bag/battle executor is S2/S5). 11 `ZM_Data` tests incl. every-effect-kind coverage (PR #152, ZM-D-024).
 - [x] `ZM_AbilityData` stubs (50 abilities: id/name/description + `ZM_ABILITY_HOOK` surface bitmask; fn-pointer hook bodies deferred to S2, ZM-D-026) + `ZM_NatureData` (25: exact 5x5 raised/lowered grid + `ZM_GetNatureStatPercent`, ZM-D-025). 12 `ZM_Data` tests (PR #153).
 - [x] `ZM_StatCalc` (Gen-III+ integer stat formulas: HP + other-five with nature %, all integer-exact) + `ZM_BattleRNG` (PCG32 seeded RNG: Next/RandBelow/RandRange/Chance, deterministic). 10 `ZM_Data` tests incl. stat golden vectors + a golden PCG32 stream (PR #154, ZM-D-027).
-- [ ] `ZM_WorldSpec` skeleton (the keystone declarative world table)
+- [x] `ZM_WorldSpec` skeleton (the keystone declarative world table) -- schema (`ZM_SCENE_ID`/`ZM_SCENE_KIND`/`ZM_SceneConnection`/`ZM_EncounterSlot`/`ZM_WorldSpec` row: name/build-index/kind/terrain/connections+spawn-tags/encounters) + an 8-scene proving set (FrontEnd/Battle/Dawnmere/Route1/Thornacre/2 interiors/Gym1). 11 `ZM_Data` referential-integrity tests (warps + spawn tags + encounters resolve, reachable from FrontEnd). Full world appended at S9/S10 (PR #156, ZM-D-029).
 - [ ] `ZM_DataRegistry` (name->ID indices + validation); `ZM_Tests_Data` schema-enforcer suite
 
 *Gate:* ~90 unit tests (chart matrix vs golden, stat/exp formula vectors, registry integrity).

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,37 +1,34 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 data core: boxes 1-6 of 8 done. Box 7 (WorldSpec skeleton) next, then box 8 (DataRegistry) closes S1.**
+**Last updated:** 2026-07-10 -- **S1 data core: boxes 1-7 of 8 done. Box 8 (ZM_DataRegistry) CLOSES S1.**
 
 **Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
-## Build
+## CI / merge policy (NEW 2026-07-10, ZM-D-028)
 
-GREEN. `Vulkan_vs2022_Debug_Win64_True` clean via `zenith build Zenithmon`. D3D12_False link proof runs in CI.
+**Do NOT wait on / idle-watch CI.** The full LOCAL gate is the quality bar: `zenith build` + boot unit gate (`Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N`, runs the ZM_* unit tests `zenith test` skips) + `zenith test --headless`, all green before push. After opening a PR, enable auto-merge (`zenith_gh.ps1 pr merge <n> --auto --squash --delete-branch`) -- it lands when the required `zm-tests` check passes; `--admin`/bypass is blocked by the harness. Fill the CI window designing/prototyping the next task. See StartPrompts.md.
 
-## Tests
+## Build / Tests
 
-- Unit (T0, category `ZM_Data`): **1152 ran, 1151 passed, 0 failed, 1 skipped** at boot (the skip is the pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 82 `ZM_*` (9 type + 24 species + 16 move + 11 item + 6 nature + 6 ability + 4 statcalc + 6 rng) + 1068 engine + 2 boot.
-- Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0.
-- CI runs the unit suite via `run_unit_gate.ps1` (ZM-D-019). **Baseline is now 1152** in `zm-tests.yml`.
+- Build GREEN (`Vulkan_vs2022_Debug_Win64_True`). D3D12_False link proof in CI.
+- Unit (T0, `ZM_Data`): **1163 ran, 1162 passed, 0 failed, 1 skipped** (skip = pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 93 `ZM_*` (9 type + 24 species + 16 move + 11 item + 6 nature + 6 ability + 4 statcalc + 6 rng + 11 worldspec) + 1068 engine + 2 boot.
+- Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0. **Baseline is 1163** in `zm-tests.yml`.
 
-## What landed (S1 data core: 6/8 boxes)
+## What landed (S1 data core: 7/8 boxes)
 
-- Box 1 type chart (#147); Box 2 species roster+stats+learnsets (#148/#149/#151, DONE); Box 3 moves (#150); Box 4 items (#152); Box 5 abilities+natures (#153).
-- **Box 6 (PR #154, this iteration):** `ZM_StatCalc` (Gen-III+ integer stat formulas + nature %) + `ZM_BattleRNG` (PCG32 seeded RNG). 10 `ZM_Data` tests incl. stat golden vectors + a golden PCG32 stream (ZM-D-027).
+- Box 1 types (#147); Box 2 species roster+stats+learnsets (#148/#149/#151); Box 3 moves (#150); Box 4 items (#152); Box 5 abilities+natures (#153); Box 6 StatCalc+RNG (#154).
+- **This session:** CI-policy docs (PR #155, ZM-D-028) + **Box 7 `ZM_WorldSpec` skeleton (PR #156, ZM-D-029)** -- world-table schema + 8-scene proving set + 11 referential-integrity tests. NOTE: #156 (worldspec) is stacked on #155 (policy); both auto-merge in order.
 
 ## Current task
 
-None in flight (once PR #154 merges). **Next Roadmap task: `ZM_WorldSpec` skeleton** -- Roadmap S1 box 7, the KEYSTONE declarative world table (ZM-D-005). For S1 this is the SCHEMA + a small proving set, NOT the full ~40 scenes (that's S9/S10):
-- A `ZM_WorldSpec` row per scene: name, build index, scene kind (FrontEnd/Town/Route/Interior/Gym/Battle/Tower), terrain-set name, connections (warp edges w/ target build index + spawn tag), optional encounter-table ref + rate, trainer/shop/gym refs, story-flag gate. Define the enums + struct + a compiled table with the handful of scenes that exist conceptually now (FrontEnd idx 0, Battle idx 1, Dawnmere, Route 1, a lab interior -- enough to exercise every column).
-- Referential-integrity tests: every warp target build index resolves to a real WorldSpec row, every spawn tag referenced exists, every encounter species is a real `ZM_SPECIES_ID`, build indices unique. This is the schema enforcer that keeps the world honest before S3+ author real scenes.
-Then box 8 `ZM_DataRegistry` (name->ID indices across all tables + a cross-table `ZM_Tests_Data` schema-enforcer suite) CLOSES S1. **S1 gate:** ~90 unit tests (currently 82 `ZM_*`), no visual check.
+None in flight (once #155 + #156 merge). **Next Roadmap task: `ZM_DataRegistry` -- Roadmap S1 box 8, which CLOSES S1.** Build name->ID lookup indices across the data tables (`ZM_FindSpeciesByName` / move / item / ability / nature / scene -> the ID or the NONE sentinel; case-insensitive optional) + a unified cross-table `ZM_Tests_DataRegistry` schema-enforcer suite that asserts the tables are MUTUALLY consistent: every species `m_eEvolvesTo` resolves (or is NONE), every TM's taught move resolves, every WorldSpec encounter species resolves, every derived learnset move resolves, name lookups round-trip + reject unknowns, no cross-table ID confusion. Then S1 is DONE.
+- **S1 gate:** ~90 unit tests (currently 93 `ZM_*`), chart/stat/registry integrity -- NO visual check, so the loop does NOT hard-stop at the S1 gate; after box 8 it proceeds to S2 (battle engine, headless, ~370 tests). First visual gate is S3.
 
 ## Notes for the next agent
 
-- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever you add/remove `ZM_*` unit tests. Currently **1152**.
-- Verify unit tests via a boot: `Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N`. See Q-2026-07-10-004.
-- **`ZM_BattleRNG` is the ONLY sanctioned RNG** in game logic (ZM-D-027, PCG32, header-only, deterministic from seed). `ZM_StatCalc` is the integer stat math (no floats). S2's battle engine builds on both. The golden PCG32 stream pins the exact algorithm -- do not change the constants/seeding without re-deriving the golden vectors.
-- **S1 patterns:** big data tables + golden vectors are prototyped/validated in scratchpad Python BEFORE building (moves/items/abilities rosters; stat + PCG32 golden values) -- committed C++ is source of truth (ZM-D-009). "Data now, executor later" for move/item/ability behaviour (S2). `ZM_STAT` lives in `ZM_SpeciesData.h`.
+- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever ZM_* unit tests change. Currently **1163**.
+- **DataRegistry is mostly LOOKUP + a cross-table test suite** -- much of the per-table integrity already exists (species/move/item/etc. suites). The NEW value is name->ID indices (for save-load, WorldSpec authoring, debug) + the CROSS-table checks (species evo targets, TM moves, encounter species) in one place. Keep it pure/headless.
+- **S1 patterns:** big tables + golden vectors prototyped/validated in scratchpad Python before building; "data now, executor later" for move/item/ability behaviour (S2); derived placeholders (base stats ZM-D-021, learnsets ZM-D-023) vs exact tables (natures ZM-D-025). `ZM_STAT` lives in `ZM_SpeciesData.h`. `ZM_BattleRNG` is the only sanctioned RNG.
 - **Working-dir gotcha:** Bash + PowerShell SHARE a cwd -- `Set-Location C:\dev\Zenith` before regen/build; avoid `cd`. Tracked `Tools/**/__pycache__/*.pyc` drift on build -- `git checkout --` them; never stage them.
 - Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`). Branch fresh off master.
 - **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored. Scope changes need a user DecisionLog entry FIRST.

--- a/Games/Zenithmon/Source/Data/ZM_WorldSpec.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_WorldSpec.cpp
@@ -1,0 +1,104 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_WorldSpec.h"
+
+// ============================================================================
+// ZM_WorldSpec -- the world table skeleton (DecisionLog ZM-D-029). Rows are in
+// ZM_SCENE_ID order; s_axScenes[i].m_eId == i is asserted by the tests. Per-scene
+// connection / spawn-tag / encounter arrays are static and referenced by
+// pointer + count. Referential integrity (every warp target + spawn tag +
+// encounter species resolves, all scenes reachable from FrontEnd) is locked by
+// Tests/ZM_Tests_WorldSpec.cpp.
+// ============================================================================
+
+namespace
+{
+#define ZM_ARRLEN(a) ((u_int)(sizeof(a) / sizeof((a)[0])))
+
+	// -- warp connections (target scene + the spawn tag reached there) --
+	const ZM_SceneConnection s_axConnFrontEnd[]  = { { ZM_SCENE_DAWNMERE, "TownCenter" } };
+	const ZM_SceneConnection s_axConnDawnmere[]  = { { ZM_SCENE_ROUTE1, "FromDawnmere" }, { ZM_SCENE_PLAYERHOME, "Door" }, { ZM_SCENE_PROFLAB, "Door" } };
+	const ZM_SceneConnection s_axConnThornacre[] = { { ZM_SCENE_ROUTE1, "FromThornacre" }, { ZM_SCENE_GYM1, "Door" } };
+	const ZM_SceneConnection s_axConnRoute1[]    = { { ZM_SCENE_DAWNMERE, "FromRoute1" }, { ZM_SCENE_THORNACRE, "FromRoute1" } };
+	const ZM_SceneConnection s_axConnPlayerHome[]= { { ZM_SCENE_DAWNMERE, "FromHome" } };
+	const ZM_SceneConnection s_axConnProfLab[]   = { { ZM_SCENE_DAWNMERE, "FromLab" } };
+	const ZM_SceneConnection s_axConnGym1[]      = { { ZM_SCENE_THORNACRE, "FromGym" } };
+
+	// -- spawn tags each scene offers (inbound connections target these) --
+	const char* const s_aszTagsFrontEnd[]  = { "Start" };
+	const char* const s_aszTagsDawnmere[]  = { "TownCenter", "FromRoute1", "FromHome", "FromLab" };
+	const char* const s_aszTagsThornacre[] = { "FromRoute1", "FromGym" };
+	const char* const s_aszTagsRoute1[]    = { "FromDawnmere", "FromThornacre" };
+	const char* const s_aszTagsPlayerHome[]= { "Door" };
+	const char* const s_aszTagsProfLab[]   = { "Door" };
+	const char* const s_aszTagsGym1[]      = { "Door" };
+
+	// -- wild encounters (routes only) --
+	const ZM_EncounterSlot s_axEncRoute1[] = {
+		{ ZM_SPECIES_PIPWIT,  2, 4, 40 },
+		{ ZM_SPECIES_NIBBIN,  2, 4, 40 },
+		{ ZM_SPECIES_SPARKIT, 3, 5, 20 },
+	};
+
+	const ZM_WorldSpec s_axScenes[ZM_SCENE_COUNT] =
+	{
+		{ ZM_SCENE_FRONTEND,   "Title",            0,  ZM_SCENE_KIND_FRONTEND, "",          s_axConnFrontEnd,  ZM_ARRLEN(s_axConnFrontEnd),  s_aszTagsFrontEnd,  ZM_ARRLEN(s_aszTagsFrontEnd),  nullptr,        0 },
+		{ ZM_SCENE_BATTLE,     "Battlefield",      1,  ZM_SCENE_KIND_BATTLE,   "",          nullptr,           0,                            nullptr,            0,                             nullptr,        0 },
+		{ ZM_SCENE_DAWNMERE,   "Dawnmere Village", 2,  ZM_SCENE_KIND_TOWN,     "Dawnmere",  s_axConnDawnmere,  ZM_ARRLEN(s_axConnDawnmere),  s_aszTagsDawnmere,  ZM_ARRLEN(s_aszTagsDawnmere),  nullptr,        0 },
+		{ ZM_SCENE_THORNACRE,  "Thornacre Town",   3,  ZM_SCENE_KIND_TOWN,     "Thornacre", s_axConnThornacre, ZM_ARRLEN(s_axConnThornacre), s_aszTagsThornacre, ZM_ARRLEN(s_aszTagsThornacre), nullptr,        0 },
+		{ ZM_SCENE_ROUTE1,     "Route 1",          20, ZM_SCENE_KIND_ROUTE,    "Route1",    s_axConnRoute1,    ZM_ARRLEN(s_axConnRoute1),    s_aszTagsRoute1,    ZM_ARRLEN(s_aszTagsRoute1),    s_axEncRoute1,  ZM_ARRLEN(s_axEncRoute1) },
+		{ ZM_SCENE_PLAYERHOME, "Player's Home",    40, ZM_SCENE_KIND_INTERIOR, "",          s_axConnPlayerHome,ZM_ARRLEN(s_axConnPlayerHome),s_aszTagsPlayerHome,ZM_ARRLEN(s_aszTagsPlayerHome),nullptr,        0 },
+		{ ZM_SCENE_PROFLAB,    "Aster's Lab",      41, ZM_SCENE_KIND_INTERIOR, "",          s_axConnProfLab,   ZM_ARRLEN(s_axConnProfLab),   s_aszTagsProfLab,   ZM_ARRLEN(s_aszTagsProfLab),   nullptr,        0 },
+		{ ZM_SCENE_GYM1,       "Thornacre Gym",    42, ZM_SCENE_KIND_GYM,      "",          s_axConnGym1,      ZM_ARRLEN(s_axConnGym1),      s_aszTagsGym1,      ZM_ARRLEN(s_aszTagsGym1),      nullptr,        0 },
+	};
+
+#undef ZM_ARRLEN
+}
+
+const ZM_WorldSpec& ZM_GetWorldSpec(ZM_SCENE_ID eId)
+{
+	Zenith_Assert(eId < ZM_SCENE_COUNT, "ZM_GetWorldSpec: scene id out of range (%u)", (u_int)eId);
+	return s_axScenes[eId];
+}
+
+u_int ZM_GetSceneCount()
+{
+	return ZM_SCENE_COUNT;
+}
+
+const char* ZM_GetSceneName(ZM_SCENE_ID eId)
+{
+	if (eId >= ZM_SCENE_COUNT)
+	{
+		return "NONE";
+	}
+	return s_axScenes[eId].m_szName;
+}
+
+ZM_SCENE_ID ZM_FindSceneByBuildIndex(u_int uBuildIndex)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		if (s_axScenes[i].m_uBuildIndex == uBuildIndex)
+		{
+			return (ZM_SCENE_ID)i;
+		}
+	}
+	return ZM_SCENE_NONE;
+}
+
+const char* ZM_SceneKindToString(ZM_SCENE_KIND eKind)
+{
+	switch (eKind)
+	{
+	case ZM_SCENE_KIND_FRONTEND:     return "FRONTEND";
+	case ZM_SCENE_KIND_TOWN:         return "TOWN";
+	case ZM_SCENE_KIND_ROUTE:        return "ROUTE";
+	case ZM_SCENE_KIND_INTERIOR:     return "INTERIOR";
+	case ZM_SCENE_KIND_GYM:          return "GYM";
+	case ZM_SCENE_KIND_BATTLE:       return "BATTLE";
+	case ZM_SCENE_KIND_TOWER:        return "TOWER";
+	case ZM_SCENE_KIND_LEAGUE:       return "LEAGUE";
+	case ZM_SCENE_KIND_VICTORY_ROAD: return "VICTORY_ROAD";
+	default:                         return "INVALID";
+	}
+}

--- a/Games/Zenithmon/Source/Data/ZM_WorldSpec.h
+++ b/Games/Zenithmon/Source/Data/ZM_WorldSpec.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"   // ZM_SPECIES_ID
+
+// ============================================================================
+// ZM_WorldSpec -- the keystone declarative world table (S1 data core, SKELETON).
+// One row per scene: name, build index, kind, terrain set, warp connections
+// (with spawn tags), and (for routes) an encounter table. Tools walk it to
+// author terrains/scenes; runtime walks it for warps/encounters/gating. Spec:
+// Docs/GameDesignDocument.md + DecisionLog ZM-D-005 (keystone) / ZM-D-029.
+//
+// S1 ships the SCHEMA + a small proving set (the scenes that exist conceptually
+// now: FrontEnd, Battle, Dawnmere, Route 1, Thornacre, the two Dawnmere
+// interiors, Gym 1) -- enough to exercise every column and lock the referential-
+// integrity tests. The full ~40-scene world is authored at S9/S10 by APPENDING
+// rows (ZM_SCENE_ID is save-stable: append before ZM_SCENE_COUNT, never reorder).
+//
+// Compiled const table (ZM-D-009). Build indices follow ZM-D-012 (0 FrontEnd,
+// 1 Battle, towns/routes/interiors sparse). Names/tags are original (zero
+// Nintendo IP). Connections reference target scenes by ZM_SCENE_ID; the runtime
+// warp resolves the target's build index + the named spawn point (ZM-D-006).
+// ============================================================================
+
+// Scene category. Drives authoring (terrain vs interior), streaming, and the
+// runtime (encounter rolls only on ROUTE, additive load for BATTLE, ...).
+enum ZM_SCENE_KIND : u_int
+{
+	ZM_SCENE_KIND_FRONTEND,       // title screen (build index 0)
+	ZM_SCENE_KIND_TOWN,           // outdoor hub with buildings
+	ZM_SCENE_KIND_ROUTE,          // outdoor path with wild encounters
+	ZM_SCENE_KIND_INTERIOR,       // building interior
+	ZM_SCENE_KIND_GYM,            // gym interior
+	ZM_SCENE_KIND_BATTLE,         // additive battle scene (build index 1)
+	ZM_SCENE_KIND_TOWER,          // Battle Tower (post-game)
+	ZM_SCENE_KIND_LEAGUE,         // Elite Four / Champion rooms
+	ZM_SCENE_KIND_VICTORY_ROAD,   // pre-League gauntlet
+
+	ZM_SCENE_KIND_COUNT
+};
+
+// Every scene, in table order. IDs are contiguous 0..ZM_SCENE_COUNT-1 and the
+// row index equals the id (asserted by ZM_Tests_WorldSpec).
+enum ZM_SCENE_ID : u_int
+{
+	ZM_SCENE_FRONTEND,
+	ZM_SCENE_BATTLE,
+	ZM_SCENE_DAWNMERE,
+	ZM_SCENE_THORNACRE,
+	ZM_SCENE_ROUTE1,
+	ZM_SCENE_PLAYERHOME,
+	ZM_SCENE_PROFLAB,
+	ZM_SCENE_GYM1,
+
+	ZM_SCENE_COUNT,
+	ZM_SCENE_NONE = ZM_SCENE_COUNT   // "no scene" sentinel (unresolved build index)
+};
+
+// A warp edge: reaching m_szSpawnTag's spawn point in scene m_eTarget.
+struct ZM_SceneConnection
+{
+	ZM_SCENE_ID	m_eTarget;
+	const char*	m_szSpawnTag;   // must be a spawn tag the target scene offers
+};
+
+// One wild-encounter slot on a route: a species over a level band, weighted.
+struct ZM_EncounterSlot
+{
+	ZM_SPECIES_ID	m_eSpecies;
+	u_int			m_uMinLevel;
+	u_int			m_uMaxLevel;
+	u_int			m_uWeight;      // relative encounter weight (> 0)
+};
+
+// One scene row. The connection / spawn-tag / encounter arrays are per-scene
+// static tables referenced by pointer + count (empty => count 0, pointer may be
+// null). m_szTerrainSet is "" for scenes with no terrain (interiors, battle).
+struct ZM_WorldSpec
+{
+	ZM_SCENE_ID					m_eId;
+	const char*					m_szName;
+	u_int						m_uBuildIndex;
+	ZM_SCENE_KIND				m_eKind;
+	const char*					m_szTerrainSet;
+	const ZM_SceneConnection*	m_pxConnections;
+	u_int						m_uConnectionCount;
+	const char* const*			m_pszSpawnTags;
+	u_int						m_uSpawnTagCount;
+	const ZM_EncounterSlot*		m_pxEncounters;
+	u_int						m_uEncounterCount;
+};
+
+// Table accessors (bounds-asserted). GetWorldSpec indexes by ZM_SCENE_ID.
+const ZM_WorldSpec&	ZM_GetWorldSpec(ZM_SCENE_ID eId);
+u_int				ZM_GetSceneCount();                 // == ZM_SCENE_COUNT
+const char*			ZM_GetSceneName(ZM_SCENE_ID eId);   // "NONE" out of range
+
+// Resolve a runtime build index to its scene, or ZM_SCENE_NONE if none matches.
+ZM_SCENE_ID			ZM_FindSceneByBuildIndex(u_int uBuildIndex);
+
+const char*			ZM_SceneKindToString(ZM_SCENE_KIND eKind);

--- a/Games/Zenithmon/Tests/ZM_Tests_WorldSpec.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_WorldSpec.cpp
@@ -1,0 +1,213 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_WorldSpec -- referential integrity of the world table skeleton
+// (category ZM_Data). This is the schema enforcer that keeps the world honest as
+// scenes are appended (S9/S10): every warp target + spawn tag + encounter species
+// resolves, build indices are unique + anchored (FrontEnd 0, Battle 1), and every
+// non-Battle scene is reachable from FrontEnd. See DecisionLog ZM-D-029.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+#include "Zenithmon/Source/Data/ZM_WorldSpec.h"
+
+#include <cstring>
+
+namespace
+{
+	const ZM_WorldSpec& Sc(u_int i) { return ZM_GetWorldSpec((ZM_SCENE_ID)i); }
+
+	bool IsOutdoor(ZM_SCENE_KIND e) { return e == ZM_SCENE_KIND_TOWN || e == ZM_SCENE_KIND_ROUTE; }
+
+	bool SceneOffersTag(const ZM_WorldSpec& x, const char* szTag)
+	{
+		for (u_int i = 0; i < x.m_uSpawnTagCount; ++i)
+		{
+			if (strcmp(x.m_pszSpawnTags[i], szTag) == 0) { return true; }
+		}
+		return false;
+	}
+}
+
+ZENITH_TEST(ZM_Data, WorldSpec_CountAndSelfConsistent)
+{
+	ZENITH_ASSERT_EQ((u_int)ZM_SCENE_NONE, (u_int)ZM_SCENE_COUNT);
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)Sc(i).m_eId, i, "scene row %u has mismatched m_eId", i);
+	}
+}
+
+ZENITH_TEST(ZM_Data, WorldSpec_NamesUniqueNonEmpty)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		const char* szA = Sc(i).m_szName;
+		ZENITH_ASSERT_NOT_NULL(szA);
+		ZENITH_ASSERT_TRUE(szA[0] != '\0', "scene %u has an empty name", i);
+		for (u_int j = i + 1; j < ZM_SCENE_COUNT; ++j)
+		{
+			ZENITH_ASSERT_FALSE(strcmp(szA, Sc(j).m_szName) == 0, "duplicate scene name '%s'", szA);
+		}
+	}
+}
+
+// Build indices are unique; FrontEnd is 0 and Battle is 1 (ZM-D-012).
+ZENITH_TEST(ZM_Data, WorldSpec_BuildIndicesUniqueAndAnchored)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		for (u_int j = i + 1; j < ZM_SCENE_COUNT; ++j)
+		{
+			ZENITH_ASSERT_NE(Sc(i).m_uBuildIndex, Sc(j).m_uBuildIndex,
+				"scenes %s and %s share build index %u", Sc(i).m_szName, Sc(j).m_szName, Sc(i).m_uBuildIndex);
+		}
+	}
+	ZENITH_ASSERT_EQ(ZM_GetWorldSpec(ZM_SCENE_FRONTEND).m_uBuildIndex, 0u, "FrontEnd is not build index 0");
+	ZENITH_ASSERT_EQ(ZM_GetWorldSpec(ZM_SCENE_BATTLE).m_uBuildIndex, 1u, "Battle is not build index 1");
+	ZENITH_ASSERT_EQ((u_int)ZM_GetWorldSpec(ZM_SCENE_FRONTEND).m_eKind, (u_int)ZM_SCENE_KIND_FRONTEND);
+	ZENITH_ASSERT_EQ((u_int)ZM_GetWorldSpec(ZM_SCENE_BATTLE).m_eKind, (u_int)ZM_SCENE_KIND_BATTLE);
+}
+
+ZENITH_TEST(ZM_Data, WorldSpec_KindsValid)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		ZENITH_ASSERT_TRUE(Sc(i).m_eKind < ZM_SCENE_KIND_COUNT, "%s bad kind", Sc(i).m_szName);
+	}
+}
+
+// Outdoor scenes (town/route) name a terrain set; indoor/battle/frontend do not.
+ZENITH_TEST(ZM_Data, WorldSpec_TerrainByKind)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		const ZM_WorldSpec& x = Sc(i);
+		ZENITH_ASSERT_NOT_NULL(x.m_szTerrainSet);
+		const bool bHasTerrain = (x.m_szTerrainSet[0] != '\0');
+		if (IsOutdoor(x.m_eKind))
+		{
+			ZENITH_ASSERT_TRUE(bHasTerrain, "%s (outdoor) has no terrain set", x.m_szName);
+		}
+		else
+		{
+			ZENITH_ASSERT_FALSE(bHasTerrain, "%s (indoor) has a terrain set", x.m_szName);
+		}
+	}
+}
+
+// Spawn tags are non-empty and unique within a scene.
+ZENITH_TEST(ZM_Data, WorldSpec_SpawnTagsNonEmptyUnique)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		const ZM_WorldSpec& x = Sc(i);
+		for (u_int a = 0; a < x.m_uSpawnTagCount; ++a)
+		{
+			ZENITH_ASSERT_NOT_NULL(x.m_pszSpawnTags[a]);
+			ZENITH_ASSERT_TRUE(x.m_pszSpawnTags[a][0] != '\0', "%s has an empty spawn tag", x.m_szName);
+			for (u_int b = a + 1; b < x.m_uSpawnTagCount; ++b)
+			{
+				ZENITH_ASSERT_FALSE(strcmp(x.m_pszSpawnTags[a], x.m_pszSpawnTags[b]) == 0,
+					"%s repeats spawn tag '%s'", x.m_szName, x.m_pszSpawnTags[a]);
+			}
+		}
+	}
+}
+
+// Every connection targets a real scene and a spawn tag that scene actually offers.
+ZENITH_TEST(ZM_Data, WorldSpec_ConnectionsResolve)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		const ZM_WorldSpec& x = Sc(i);
+		for (u_int c = 0; c < x.m_uConnectionCount; ++c)
+		{
+			const ZM_SceneConnection& xConn = x.m_pxConnections[c];
+			ZENITH_ASSERT_TRUE(xConn.m_eTarget < ZM_SCENE_COUNT, "%s connects to a non-scene", x.m_szName);
+			ZENITH_ASSERT_NOT_NULL(xConn.m_szSpawnTag);
+			ZENITH_ASSERT_TRUE(SceneOffersTag(ZM_GetWorldSpec(xConn.m_eTarget), xConn.m_szSpawnTag),
+				"%s -> %s targets undeclared spawn tag '%s'", x.m_szName,
+				ZM_GetSceneName(xConn.m_eTarget), xConn.m_szSpawnTag);
+		}
+	}
+}
+
+// Encounters live only on routes; each slot references a real species, a valid
+// level band, and a positive weight.
+ZENITH_TEST(ZM_Data, WorldSpec_EncountersValid)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		const ZM_WorldSpec& x = Sc(i);
+		if (x.m_uEncounterCount > 0)
+		{
+			ZENITH_ASSERT_EQ((u_int)x.m_eKind, (u_int)ZM_SCENE_KIND_ROUTE, "%s has encounters but is not a route", x.m_szName);
+		}
+		for (u_int e = 0; e < x.m_uEncounterCount; ++e)
+		{
+			const ZM_EncounterSlot& xEnc = x.m_pxEncounters[e];
+			ZENITH_ASSERT_TRUE(xEnc.m_eSpecies < ZM_SPECIES_COUNT, "%s encounter is a non-species", x.m_szName);
+			ZENITH_ASSERT_GE(xEnc.m_uMinLevel, 1u, "%s encounter min level < 1", x.m_szName);
+			ZENITH_ASSERT_LE(xEnc.m_uMaxLevel, 100u, "%s encounter max level > 100", x.m_szName);
+			ZENITH_ASSERT_LE(xEnc.m_uMinLevel, xEnc.m_uMaxLevel, "%s encounter min > max", x.m_szName);
+			ZENITH_ASSERT_GT(xEnc.m_uWeight, 0u, "%s encounter has 0 weight", x.m_szName);
+		}
+	}
+}
+
+// Every non-Battle scene is reachable from FrontEnd by walking connections
+// (Battle is loaded additively, never warped to).
+ZENITH_TEST(ZM_Data, WorldSpec_AllReachableFromFrontEnd)
+{
+	bool abVisited[ZM_SCENE_COUNT] = { false };
+	ZM_SCENE_ID aeStack[ZM_SCENE_COUNT * 8];
+	u_int uSp = 0;
+	aeStack[uSp++] = ZM_SCENE_FRONTEND;
+	while (uSp > 0)
+	{
+		const ZM_SCENE_ID eCur = aeStack[--uSp];
+		if (abVisited[eCur]) { continue; }
+		abVisited[eCur] = true;
+		const ZM_WorldSpec& x = ZM_GetWorldSpec(eCur);
+		for (u_int c = 0; c < x.m_uConnectionCount; ++c)
+		{
+			const ZM_SCENE_ID eTgt = x.m_pxConnections[c].m_eTarget;
+			if (!abVisited[eTgt]) { aeStack[uSp++] = eTgt; }
+		}
+	}
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		if ((ZM_SCENE_ID)i == ZM_SCENE_BATTLE) { continue; }
+		ZENITH_ASSERT_TRUE(abVisited[i], "%s is unreachable from FrontEnd", Sc(i).m_szName);
+	}
+}
+
+// ZM_FindSceneByBuildIndex round-trips every scene and rejects unknown indices.
+ZENITH_TEST(ZM_Data, WorldSpec_FindByBuildIndex)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindSceneByBuildIndex(Sc(i).m_uBuildIndex), i,
+			"build index %u did not resolve back to %s", Sc(i).m_uBuildIndex, Sc(i).m_szName);
+	}
+	ZENITH_ASSERT_EQ((u_int)ZM_FindSceneByBuildIndex(9999u), (u_int)ZM_SCENE_NONE, "unknown index resolved");
+}
+
+ZENITH_TEST(ZM_Data, WorldSpec_AccessorAndToString)
+{
+	for (u_int i = 0; i < ZM_SCENE_COUNT; ++i)
+	{
+		ZENITH_ASSERT_STREQ(ZM_GetSceneName((ZM_SCENE_ID)i), Sc(i).m_szName);
+	}
+	ZENITH_ASSERT_STREQ(ZM_GetSceneName(ZM_SCENE_NONE), "NONE");
+
+	for (u_int k = 0; k < ZM_SCENE_KIND_COUNT; ++k)
+	{
+		const char* sz = ZM_SceneKindToString((ZM_SCENE_KIND)k);
+		ZENITH_ASSERT_NOT_NULL(sz);
+		ZENITH_ASSERT_FALSE(strcmp(sz, "INVALID") == 0, "scene kind %u stringifies as INVALID", k);
+	}
+	ZENITH_ASSERT_STREQ(ZM_SceneKindToString(ZM_SCENE_KIND_COUNT), "INVALID");
+}


### PR DESCRIPTION
## S1 data core -- `ZM_WorldSpec` skeleton (box 7)

Roadmap S1 box 7 -- the keystone declarative world table (ZM-D-005). Ships the **schema + an 8-scene proving set** (not the full world; that's appended at S9/S10).

> Stacked on #155 (CI-policy docs). Until #155 merges, this PR's diff shows both; after, it's WorldSpec-only.

### What landed
- `Source/Data/ZM_WorldSpec.h/.cpp` -- one row per scene:
  - id / name / build index / `ZM_SCENE_KIND` (9: frontend/town/route/interior/gym/battle/tower/league/victory_road) / terrain set
  - warp **connections** (`ZM_SceneConnection` = target scene + spawn tag) + the **spawn tags** each scene offers
  - route **encounter table** (`ZM_EncounterSlot` = species + level band + weight)
  - per-scene arrays are static, referenced by pointer + count
  - accessors + `ZM_FindSceneByBuildIndex` + `ZM_SceneKindToString`
- 8 proving scenes: FrontEnd (0), Battle (1), Dawnmere, Route 1, Thornacre, Player's Home, Aster's Lab, Gym 1 -- exercising every column.
- `Tests/ZM_Tests_WorldSpec.cpp` -- **11 `ZM_Data` referential-integrity cases**: index consistency, unique names + build indices anchored (FrontEnd 0 / Battle 1), terrain-by-kind, spawn tags non-empty + unique, **every connection resolves to a real target + a spawn tag that target offers**, encounters route-only with real species + valid bands + weight, **every non-Battle scene reachable from FrontEnd**, build-index round-trip, accessor/ToString. The graph was pre-validated offline.

### Gate (local-first per ZM-D-028)
- `zenith build Zenithmon` green; D3D12_False link proof in CI.
- Boot unit gate: **1163 ran / 1162 passed / 0 failed / 1 skipped**. `zm-tests` baseline bumped **1152 -> 1163**.
- `zenith test Zenithmon --headless`: exit 0.
- Docs: Roadmap box 7 ticked, DecisionLog **ZM-D-029**, Status refreshed.

Next: `ZM_DataRegistry` (Roadmap S1 box 8) closes S1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
