### PR TITLE
feat(zm): S1 - ZM_DataRegistry (name->ID lookups + cross-table enforcer) -- closes S1

### DIFF
--- a/.github/workflows/zm-tests.yml
+++ b/.github/workflows/zm-tests.yml
@@ -155,7 +155,7 @@ jobs:
           # registered count ran with 0 failed. Bump -Baseline when the ZM_* (or
           # engine) unit-test count changes -- see Docs/CIPolicy.md.
           $exe = 'Games\Zenithmon\Build\output\win64\vulkan_vs2022_debug_win64_true\zenithmon.exe'
-          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1163
+          pwsh -NoProfile -File Tools\run_unit_gate.ps1 -Exe $exe -Baseline 1172
           if ($LASTEXITCODE -ne 0) { Write-Error "boot unit tests failed (see log above)"; exit $LASTEXITCODE }
 
       - name: Run Zenithmon tests

--- a/Games/Zenithmon/Docs/DecisionLog.md
+++ b/Games/Zenithmon/Docs/DecisionLog.md
@@ -15,6 +15,29 @@ Tuning-value changes go in git history, not here.
 
 ---
 
+## 2026-07-10 -- ZM-D-030 -- ZM_DataRegistry (name->ID lookups + cross-table enforcer) closes S1
+
+- **Decision:** `ZM_DataRegistry` (`Source/Data/ZM_DataRegistry.{h,cpp}`) adds
+  reverse name->ID lookups for every S1 table -- `ZM_FindSpeciesByName` /
+  `...Move` / `...Item` / `...Ability` / `...Nature` / `...Scene` -- each an exact
+  case-sensitive scan returning the id or that table's NONE sentinel (NONE for
+  null/empty too). Linear scan (tables are <= ~220 rows; a hash index is a
+  trivial later swap behind the same signatures). This is the last S1 box; the
+  accompanying `ZM_Tests_DataRegistry` suite is the cross-table schema enforcer.
+- **Why:** the reverse lookups are needed by save/load (names <-> ids across
+  versions), WorldSpec/scene authoring, and debug/console tooling; and S1 needs a
+  single place that asserts the tables are MUTUALLY consistent (per-table suites
+  each check their own table, but nothing checked the references BETWEEN tables).
+- **Tests that lock it:** `Tests/ZM_Tests_DataRegistry.cpp` (category `ZM_Data`, 9
+  cases) -- name round-trip for all six tables (`Find(GetName(id)) == id`),
+  unknown/null/empty -> NONE, and the cross-table resolves: every species
+  evolution target, every TM's taught move, every WorldSpec encounter species, and
+  every derived learnset move resolve to real rows. Boot suite 1172 ran / 0 failed;
+  baseline bumped 1163 -> 1172. **S1 gate MET** (102 `ZM_*` unit tests vs the ~90
+  target; no visual check for S1).
+- **Reversibility:** easy -- additive `Source/Data/` files; swapping the linear
+  scans for a hash index is behind the stable Find signatures.
+
 ## 2026-07-10 -- ZM-D-029 -- ZM_WorldSpec ships as SCHEMA + an 8-scene proving set; the full world is appended at S9/S10
 
 - **Decision:** the keystone world table (ZM-D-005) lands its SCHEMA plus a small

--- a/Games/Zenithmon/Docs/Roadmap.md
+++ b/Games/Zenithmon/Docs/Roadmap.md
@@ -36,9 +36,9 @@
 - [x] `ZM_AbilityData` stubs (50 abilities: id/name/description + `ZM_ABILITY_HOOK` surface bitmask; fn-pointer hook bodies deferred to S2, ZM-D-026) + `ZM_NatureData` (25: exact 5x5 raised/lowered grid + `ZM_GetNatureStatPercent`, ZM-D-025). 12 `ZM_Data` tests (PR #153).
 - [x] `ZM_StatCalc` (Gen-III+ integer stat formulas: HP + other-five with nature %, all integer-exact) + `ZM_BattleRNG` (PCG32 seeded RNG: Next/RandBelow/RandRange/Chance, deterministic). 10 `ZM_Data` tests incl. stat golden vectors + a golden PCG32 stream (PR #154, ZM-D-027).
 - [x] `ZM_WorldSpec` skeleton (the keystone declarative world table) -- schema (`ZM_SCENE_ID`/`ZM_SCENE_KIND`/`ZM_SceneConnection`/`ZM_EncounterSlot`/`ZM_WorldSpec` row: name/build-index/kind/terrain/connections+spawn-tags/encounters) + an 8-scene proving set (FrontEnd/Battle/Dawnmere/Route1/Thornacre/2 interiors/Gym1). 11 `ZM_Data` referential-integrity tests (warps + spawn tags + encounters resolve, reachable from FrontEnd). Full world appended at S9/S10 (PR #156, ZM-D-029).
-- [ ] `ZM_DataRegistry` (name->ID indices + validation); `ZM_Tests_Data` schema-enforcer suite
+- [x] `ZM_DataRegistry` (name->ID lookups for species/move/item/ability/nature/scene, NONE on miss) + `ZM_Tests_DataRegistry` cross-table schema enforcer (name round-trips + every evolution/TM/encounter/learnset ref resolves). Closes S1 (PR #157, ZM-D-030).
 
-*Gate:* ~90 unit tests (chart matrix vs golden, stat/exp formula vectors, registry integrity).
+*Gate:* ~90 unit tests (chart matrix vs golden, stat/exp formula vectors, registry integrity). **MET 2026-07-10** -- 102 `ZM_*` `ZM_Data` unit tests (boot suite 1172 ran / 0 failed); no visual check for S1, so the loop proceeds to S2.
 
 ## S2 -- Battle engine headless (L) -- parallel with S3/S4, after S1
 

--- a/Games/Zenithmon/Docs/Shortfalls.md
+++ b/Games/Zenithmon/Docs/Shortfalls.md
@@ -4,9 +4,9 @@
 
 **Scope note (2026-07-09, S0):** at S0 essentially EVERYTHING is a gap -- the project is a booting skeleton. This doc is deliberately structured per major system with a one-line current-state each, so later sessions UPDATE lines in place rather than restructure. When a stage lands, replace that system's status line and add a dated note; do not reorder sections.
 
-**Verdict at a glance:**
-- **What works today:** boot skeleton only -- exe boots windowed + headless, FrontEnd scene (title text + placeholder bobbing cube), `Zenith_SaveData` initialised, test harness wired (unit 2/2, automated 1/1), CI workflow written. Approximately 0% of the shipping game.
-- **What's designed but unbuilt:** everything in the plan -- see [Roadmap.md](Roadmap.md) for the S1-S12 sequence and gates.
+**Verdict at a glance (updated 2026-07-10, S1 complete):**
+- **What works today:** boot skeleton + the **complete S1 data core** (§1.1) -- 18-type chart, 152-species dex, 218 moves, 90 items, 50 abilities, 25 natures, stat formulas + PCG32 RNG, WorldSpec skeleton, DataRegistry; 102 `ZM_Data` unit tests green. Still no gameplay: the data is inert until the S2 battle engine + S3 overworld consume it.
+- **What's designed but unbuilt:** the battle engine (S2) and everything downstream -- see [Roadmap.md](Roadmap.md) for the S2-S12 sequence and gates.
 - **Locked cuts (not gaps -- see Scope.md):** no audio (engine has none), no networking/multiplayer/trading, no Dynamax-analog, battle format singles only, documented volatile-status cuts (Substitute/Encore/Transform/weight moves).
 
 ---
@@ -15,8 +15,8 @@
 
 ### 1.1 Data core
 
-**Status: not started -- lands at S1.**
-No `Source/Data/` yet: no type chart (18 types), no species (~150), moves (~220), items, abilities (~50), natures (25), no `ZM_StatCalc`/`ZM_BattleRNG`, no `ZM_DataRegistry` validation, and -- most load-bearing -- no `ZM_WorldSpec` (the keystone declarative world table everything else walks). Data will be compiled `const` C arrays, not disk assets.
+**Status: COMPLETE (S1, 2026-07-10).**
+`Source/Data/` holds the full data core as compiled `const` C arrays: the 18-type chart (golden-locked), the 152-species dex (roster + DERIVED base stats + DERIVED level-up learnsets), 218 moves over a 57-kind `ZM_MOVE_EFFECT` enum, 90 items over a 34-kind `ZM_ITEM_EFFECT` enum (incl. 25 TMs -> real moves), 50 abilities (roster + `ZM_ABILITY_HOOK` surface bitmask), 25 natures (exact 5x5 grid), `ZM_StatCalc` (Gen-III+ integer formulas) + `ZM_BattleRNG` (PCG32, deterministic), `ZM_WorldSpec` (schema + 8-scene proving set), and `ZM_DataRegistry` (name->ID lookups + cross-table enforcer). 102 `ZM_Data` unit tests, all green. **Gaps carried FORWARD (by design, tracked):** the move/item effect enums + ability hooks are INERT data -- their executors are S2 (ZM-D-022/024/026); base stats + learnsets are systematic placeholders for the S11 balance pass (ZM-D-021/023); `ZM_WorldSpec` is a skeleton -- the full ~40-scene world is appended at S9/S10 (ZM-D-029).
 
 ### 1.2 Battle engine
 

--- a/Games/Zenithmon/Docs/Status.md
+++ b/Games/Zenithmon/Docs/Status.md
@@ -1,35 +1,37 @@
 # Zenithmon Status
 
-**Last updated:** 2026-07-10 -- **S1 data core: boxes 1-7 of 8 done. Box 8 (ZM_DataRegistry) CLOSES S1.**
+**Last updated:** 2026-07-10 -- **S1 DATA CORE COMPLETE (all 8 boxes). Next stage: S2 battle engine.**
 
 **Read this first each session.** Replaced every session end. [Roadmap.md](Roadmap.md) is the source of truth for what's next; [Questions.md](Questions.md) holds open decisions; [Shortfalls.md](Shortfalls.md) is the gap audit.
 
-## CI / merge policy (NEW 2026-07-10, ZM-D-028)
+## CI / merge policy (2026-07-10, ZM-D-028)
 
-**Do NOT wait on / idle-watch CI.** The full LOCAL gate is the quality bar: `zenith build` + boot unit gate (`Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N`, runs the ZM_* unit tests `zenith test` skips) + `zenith test --headless`, all green before push. After opening a PR, enable auto-merge (`zenith_gh.ps1 pr merge <n> --auto --squash --delete-branch`) -- it lands when the required `zm-tests` check passes; `--admin`/bypass is blocked by the harness. Fill the CI window designing/prototyping the next task. See StartPrompts.md.
+**Do NOT wait on / idle-watch CI.** The full LOCAL gate is the quality bar: `zenith build` + boot unit gate (`Tools/run_unit_gate.ps1 -Exe <exe> -Baseline N`, runs the ZM_* unit tests `zenith test` skips) + `zenith test --headless`, all green before push. After opening a PR, enable auto-merge (`zenith_gh.ps1 pr merge <n> --auto --squash --delete-branch`) -- lands when required `zm-tests` passes; `--admin`/bypass is blocked. Fill the CI window designing/prototyping the next task. See StartPrompts.md.
 
 ## Build / Tests
 
 - Build GREEN (`Vulkan_vs2022_Debug_Win64_True`). D3D12_False link proof in CI.
-- Unit (T0, `ZM_Data`): **1163 ran, 1162 passed, 0 failed, 1 skipped** (skip = pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = 93 `ZM_*` (9 type + 24 species + 16 move + 11 item + 6 nature + 6 ability + 4 statcalc + 6 rng + 11 worldspec) + 1068 engine + 2 boot.
-- Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0. **Baseline is 1163** in `zm-tests.yml`.
+- Unit (T0, `ZM_Data`): **1172 ran, 1171 passed, 0 failed, 1 skipped** (skip = pre-existing quarantined engine `RegistryWideNodeRoundTrip`). = **102 `ZM_*`** (9 type + 24 species + 16 move + 11 item + 6 nature + 6 ability + 4 statcalc + 6 rng + 11 worldspec + 9 registry) + 1068 engine + 2 boot.
+- Automated (P1): 1/1 (`ZM_Boot_Test`); `zenith test Zenithmon --headless` exits 0. **Baseline 1172** in `zm-tests.yml`.
 
-## What landed (S1 data core: 7/8 boxes)
+## What landed -- S1 COMPLETE (all in `Source/Data/`)
 
-- Box 1 types (#147); Box 2 species roster+stats+learnsets (#148/#149/#151); Box 3 moves (#150); Box 4 items (#152); Box 5 abilities+natures (#153); Box 6 StatCalc+RNG (#154).
-- **This session:** CI-policy docs (PR #155, ZM-D-028) + **Box 7 `ZM_WorldSpec` skeleton (PR #156, ZM-D-029)** -- world-table schema + 8-scene proving set + 11 referential-integrity tests. NOTE: #156 (worldspec) is stacked on #155 (policy); both auto-merge in order.
+types (#147) / species roster+stats+learnsets (#148/#149/#151) / moves (#150) / items (#152) / abilities+natures (#153) / StatCalc+RNG (#154) / CI-policy docs (#155) / WorldSpec skeleton (#156) / **DataRegistry (#157, this session, closes S1)**. S1 gate MET (102 ZM_Data tests vs ~90 target; no visual check).
+
+**In flight (auto-merging, stacked in order):** #155 (policy) -> #156 (worldspec) -> #157 (dataregistry). All locally gated green; auto-merge lands each when its `zm-tests` passes.
 
 ## Current task
 
-None in flight (once #155 + #156 merge). **Next Roadmap task: `ZM_DataRegistry` -- Roadmap S1 box 8, which CLOSES S1.** Build name->ID lookup indices across the data tables (`ZM_FindSpeciesByName` / move / item / ability / nature / scene -> the ID or the NONE sentinel; case-insensitive optional) + a unified cross-table `ZM_Tests_DataRegistry` schema-enforcer suite that asserts the tables are MUTUALLY consistent: every species `m_eEvolvesTo` resolves (or is NONE), every TM's taught move resolves, every WorldSpec encounter species resolves, every derived learnset move resolves, name lookups round-trip + reject unknowns, no cross-table ID confusion. Then S1 is DONE.
-- **S1 gate:** ~90 unit tests (currently 93 `ZM_*`), chart/stat/registry integrity -- NO visual check, so the loop does NOT hard-stop at the S1 gate; after box 8 it proceeds to S2 (battle engine, headless, ~370 tests). First visual gate is S3.
+None. **Next Roadmap task: S2 box 1 -- `ZM_BattleState` + `ZM_BattleEngine`** (the battle engine, a NEW STAGE). S2 is the biggest suite (~370 unit tests), all headless + seeded (uses `ZM_BattleRNG`). First box: `ZM_BattleState` (teams / active monster / field state) + `ZM_BattleEngine` (`Begin(config,seed)` -> `SubmitAction` -> `ResolveTurn()` emitting an append-only `ZM_BattleEvent` stream; NO UI/string formatting in the engine -- ZM-D-010). Then `ZM_MoveExecutor` (one switch over `ZM_MOVE_EFFECT`, now that the data exists), `ZM_DamageCalc`/`ZM_CatchCalc`/`ZM_StatusLogic`, abilities (wire the `ZM_ABILITY_HOOK` bodies), weather, exp/level/evolution, AI tiers, breeding, tower. See Roadmap S2 + MasterPlan.
+- **S2 has NO visual gate** (headless battle logic), so the loop keeps running through S2 autonomously. First visual gate is **S3** (overworld terrain/grass/camera).
 
 ## Notes for the next agent
 
-- **BUMP THE zm-tests BASELINE** (`.github/workflows/zm-tests.yml`, `run_unit_gate.ps1 -Baseline N`) in the SAME PR whenever ZM_* unit tests change. Currently **1163**.
-- **DataRegistry is mostly LOOKUP + a cross-table test suite** -- much of the per-table integrity already exists (species/move/item/etc. suites). The NEW value is name->ID indices (for save-load, WorldSpec authoring, debug) + the CROSS-table checks (species evo targets, TM moves, encounter species) in one place. Keep it pure/headless.
-- **S1 patterns:** big tables + golden vectors prototyped/validated in scratchpad Python before building; "data now, executor later" for move/item/ability behaviour (S2); derived placeholders (base stats ZM-D-021, learnsets ZM-D-023) vs exact tables (natures ZM-D-025). `ZM_STAT` lives in `ZM_SpeciesData.h`. `ZM_BattleRNG` is the only sanctioned RNG.
-- **Working-dir gotcha:** Bash + PowerShell SHARE a cwd -- `Set-Location C:\dev\Zenith` before regen/build; avoid `cd`. Tracked `Tools/**/__pycache__/*.pyc` drift on build -- `git checkout --` them; never stage them.
+- **This is the S1->S2 boundary.** The whole S1 data core (Source/Data/ZM_*.{h,cpp}) is the foundation S2 consumes: `ZM_SpeciesData`+`ZM_StatCalc`+natures/IVs/EVs build a monster's stats; `ZM_MoveData`+`ZM_MOVE_EFFECT` drive `ZM_MoveExecutor`; `ZM_AbilityData` hook bitmask tells you which hooks to wire; `ZM_BattleRNG` is the seeded RNG; `ZM_ItemData` for held items/catch. **Data now HAS its executor (S2).**
+- **BUMP THE zm-tests BASELINE** in the SAME PR whenever ZM_* unit tests change. Currently **1172**.
+- **S2 build tips:** the battle engine is pure headless C++ (ZM-D-010), emits `ZM_BattleEvent` (append-only), deterministic from seed -> scripted seeded scenarios assert EXACT event streams (characterization bedrock) + a 2000-battle fuzz soak (termination <500 turns, HP/PP/boost invariants). Prototype expected event streams offline (like the stat/PCG32 golden vectors) before building.
+- **S1 patterns to reuse:** big tables + golden vectors prototyped/validated in scratchpad Python before building; derived placeholders vs exact tables; every effect kind/hook coverage-locked. `ZM_STAT` in `ZM_SpeciesData.h`.
+- **Working-dir gotcha:** Bash + PowerShell SHARE a cwd -- `Set-Location C:\dev\Zenith` before regen/build. Tracked `Tools/**/__pycache__/*.pyc` drift on build -- `git checkout --` them; never stage.
 - Editing existing files needs NO regen; only NEW files do (`Build\regen.ps1`). Branch fresh off master.
 - **Hard rules (Scope.md):** `ZM_` prefix; original names / zero Nintendo IP; data = compiled C arrays; no audio/networking/Dynamax; singles only; baked assets git-ignored. Scope changes need a user DecisionLog entry FIRST.
-- Session discipline: replace this file each session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild.
+- Session discipline: replace this file each session end; tick Roadmap boxes only when merged + green; DecisionLog append-only; serial MSBuild; auto-merge (don't wait on CI).

--- a/Games/Zenithmon/Source/Data/ZM_DataRegistry.cpp
+++ b/Games/Zenithmon/Source/Data/ZM_DataRegistry.cpp
@@ -1,0 +1,78 @@
+#include "Zenith.h"
+#include "Zenithmon/Source/Data/ZM_DataRegistry.h"
+
+#include <cstring>
+
+// ============================================================================
+// ZM_DataRegistry -- linear-scan name->ID lookups (DecisionLog ZM-D-030). Each
+// scans its table's canonical names via the ZM_GetXName accessors. Cross-table
+// integrity is asserted by Tests/ZM_Tests_DataRegistry.cpp.
+// ============================================================================
+
+namespace
+{
+	bool NameMatches(const char* szCandidate, const char* szQuery)
+	{
+		return szCandidate != nullptr && strcmp(szCandidate, szQuery) == 0;
+	}
+}
+
+ZM_SPECIES_ID ZM_FindSpeciesByName(const char* szName)
+{
+	if (szName == nullptr || szName[0] == '\0') { return ZM_SPECIES_NONE; }
+	for (u_int i = 0; i < ZM_GetSpeciesCount(); ++i)
+	{
+		if (NameMatches(ZM_GetSpeciesName((ZM_SPECIES_ID)i), szName)) { return (ZM_SPECIES_ID)i; }
+	}
+	return ZM_SPECIES_NONE;
+}
+
+ZM_MOVE_ID ZM_FindMoveByName(const char* szName)
+{
+	if (szName == nullptr || szName[0] == '\0') { return ZM_MOVE_NONE; }
+	for (u_int i = 0; i < ZM_GetMoveCount(); ++i)
+	{
+		if (NameMatches(ZM_GetMoveName((ZM_MOVE_ID)i), szName)) { return (ZM_MOVE_ID)i; }
+	}
+	return ZM_MOVE_NONE;
+}
+
+ZM_ITEM_ID ZM_FindItemByName(const char* szName)
+{
+	if (szName == nullptr || szName[0] == '\0') { return ZM_ITEM_NONE; }
+	for (u_int i = 0; i < ZM_GetItemCount(); ++i)
+	{
+		if (NameMatches(ZM_GetItemName((ZM_ITEM_ID)i), szName)) { return (ZM_ITEM_ID)i; }
+	}
+	return ZM_ITEM_NONE;
+}
+
+ZM_ABILITY_ID ZM_FindAbilityByName(const char* szName)
+{
+	if (szName == nullptr || szName[0] == '\0') { return ZM_ABILITY_NONE; }
+	for (u_int i = 0; i < ZM_GetAbilityCount(); ++i)
+	{
+		if (NameMatches(ZM_GetAbilityName((ZM_ABILITY_ID)i), szName)) { return (ZM_ABILITY_ID)i; }
+	}
+	return ZM_ABILITY_NONE;
+}
+
+ZM_NATURE ZM_FindNatureByName(const char* szName)
+{
+	if (szName == nullptr || szName[0] == '\0') { return ZM_NATURE_COUNT; }
+	for (u_int i = 0; i < ZM_GetNatureCount(); ++i)
+	{
+		if (NameMatches(ZM_GetNatureName((ZM_NATURE)i), szName)) { return (ZM_NATURE)i; }
+	}
+	return ZM_NATURE_COUNT;
+}
+
+ZM_SCENE_ID ZM_FindSceneByName(const char* szName)
+{
+	if (szName == nullptr || szName[0] == '\0') { return ZM_SCENE_NONE; }
+	for (u_int i = 0; i < ZM_GetSceneCount(); ++i)
+	{
+		if (NameMatches(ZM_GetSceneName((ZM_SCENE_ID)i), szName)) { return (ZM_SCENE_ID)i; }
+	}
+	return ZM_SCENE_NONE;
+}

--- a/Games/Zenithmon/Source/Data/ZM_DataRegistry.h
+++ b/Games/Zenithmon/Source/Data/ZM_DataRegistry.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+#include "Zenithmon/Source/Data/ZM_MoveData.h"
+#include "Zenithmon/Source/Data/ZM_ItemData.h"
+#include "Zenithmon/Source/Data/ZM_AbilityData.h"
+#include "Zenithmon/Source/Data/ZM_NatureData.h"
+#include "Zenithmon/Source/Data/ZM_WorldSpec.h"
+
+// ============================================================================
+// ZM_DataRegistry -- name->ID lookup across every S1 data table (S1 data core,
+// the box that CLOSES S1). Spec: Docs/TestPlan.md 5.1 (registry integrity);
+// DecisionLog ZM-D-030.
+//
+// Each ZM_FindXByName returns the row's ID, or that table's NONE sentinel for an
+// unknown / null / empty name (exact, case-sensitive match on the canonical
+// name). These are the reverse of the ZM_GetXName accessors -- needed by
+// save/load, WorldSpec authoring, and debug/console tooling that speak names.
+// Lookups are a linear scan (the tables are small: <= ~220 rows); a hash index
+// is a trivial later optimisation behind the same signatures.
+//
+// The mutual consistency of the tables (every evolution target / TM move /
+// encounter species / learnset move resolves; every name round-trips) is the
+// schema-enforcer contract, locked by Tests/ZM_Tests_DataRegistry.cpp.
+// ============================================================================
+
+ZM_SPECIES_ID	ZM_FindSpeciesByName(const char* szName);   // ZM_SPECIES_NONE if not found
+ZM_MOVE_ID		ZM_FindMoveByName(const char* szName);      // ZM_MOVE_NONE
+ZM_ITEM_ID		ZM_FindItemByName(const char* szName);      // ZM_ITEM_NONE
+ZM_ABILITY_ID	ZM_FindAbilityByName(const char* szName);   // ZM_ABILITY_NONE
+ZM_NATURE		ZM_FindNatureByName(const char* szName);    // ZM_NATURE_COUNT
+ZM_SCENE_ID		ZM_FindSceneByName(const char* szName);     // ZM_SCENE_NONE

--- a/Games/Zenithmon/Tests/ZM_Tests_DataRegistry.cpp
+++ b/Games/Zenithmon/Tests/ZM_Tests_DataRegistry.cpp
@@ -1,0 +1,141 @@
+#include "Zenith.h"
+
+// ============================================================================
+// ZM_Tests_DataRegistry -- the cross-table schema enforcer (category ZM_Data),
+// the suite that CLOSES S1. It locks (a) that every name round-trips through the
+// ZM_FindXByName lookups and unknown/null names yield NONE, and (b) that the
+// tables are MUTUALLY consistent: every evolution target, TM move, wild-encounter
+// species, and derived learnset move resolves to a real row. See ZM-D-030.
+// ============================================================================
+
+#include "Core/Zenith_TestFramework.h"
+#include "Zenithmon/Source/Data/ZM_SpeciesData.h"
+#include "Zenithmon/Source/Data/ZM_MoveData.h"
+#include "Zenithmon/Source/Data/ZM_ItemData.h"
+#include "Zenithmon/Source/Data/ZM_AbilityData.h"
+#include "Zenithmon/Source/Data/ZM_NatureData.h"
+#include "Zenithmon/Source/Data/ZM_WorldSpec.h"
+#include "Zenithmon/Source/Data/ZM_Learnsets.h"
+#include "Zenithmon/Source/Data/ZM_DataRegistry.h"
+
+// Every species name resolves back to its own id.
+ZENITH_TEST(ZM_Data, Registry_SpeciesNameRoundTrip)
+{
+	for (u_int i = 0; i < ZM_GetSpeciesCount(); ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindSpeciesByName(ZM_GetSpeciesName((ZM_SPECIES_ID)i)), i,
+			"species name '%s' did not round-trip", ZM_GetSpeciesName((ZM_SPECIES_ID)i));
+	}
+}
+
+ZENITH_TEST(ZM_Data, Registry_MoveNameRoundTrip)
+{
+	for (u_int i = 0; i < ZM_GetMoveCount(); ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindMoveByName(ZM_GetMoveName((ZM_MOVE_ID)i)), i,
+			"move name '%s' did not round-trip", ZM_GetMoveName((ZM_MOVE_ID)i));
+	}
+}
+
+ZENITH_TEST(ZM_Data, Registry_ItemNameRoundTrip)
+{
+	for (u_int i = 0; i < ZM_GetItemCount(); ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindItemByName(ZM_GetItemName((ZM_ITEM_ID)i)), i,
+			"item name '%s' did not round-trip", ZM_GetItemName((ZM_ITEM_ID)i));
+	}
+}
+
+ZENITH_TEST(ZM_Data, Registry_AbilityNameRoundTrip)
+{
+	for (u_int i = 0; i < ZM_GetAbilityCount(); ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindAbilityByName(ZM_GetAbilityName((ZM_ABILITY_ID)i)), i,
+			"ability name '%s' did not round-trip", ZM_GetAbilityName((ZM_ABILITY_ID)i));
+	}
+}
+
+ZENITH_TEST(ZM_Data, Registry_NatureNameRoundTrip)
+{
+	for (u_int i = 0; i < ZM_GetNatureCount(); ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindNatureByName(ZM_GetNatureName((ZM_NATURE)i)), i,
+			"nature name '%s' did not round-trip", ZM_GetNatureName((ZM_NATURE)i));
+	}
+}
+
+ZENITH_TEST(ZM_Data, Registry_SceneNameRoundTrip)
+{
+	for (u_int i = 0; i < ZM_GetSceneCount(); ++i)
+	{
+		ZENITH_ASSERT_EQ((u_int)ZM_FindSceneByName(ZM_GetSceneName((ZM_SCENE_ID)i)), i,
+			"scene name '%s' did not round-trip", ZM_GetSceneName((ZM_SCENE_ID)i));
+	}
+}
+
+// Unknown, null, and empty names resolve to each table's NONE sentinel.
+ZENITH_TEST(ZM_Data, Registry_UnknownAndNullReturnNone)
+{
+	const char* szBogus = "ThisIsDefinitelyNotARealZenithmonName";
+	ZENITH_ASSERT_EQ((u_int)ZM_FindSpeciesByName(szBogus), (u_int)ZM_SPECIES_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindMoveByName(szBogus), (u_int)ZM_MOVE_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindItemByName(szBogus), (u_int)ZM_ITEM_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindAbilityByName(szBogus), (u_int)ZM_ABILITY_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindNatureByName(szBogus), (u_int)ZM_NATURE_COUNT);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindSceneByName(szBogus), (u_int)ZM_SCENE_NONE);
+
+	ZENITH_ASSERT_EQ((u_int)ZM_FindSpeciesByName(nullptr), (u_int)ZM_SPECIES_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindMoveByName(""), (u_int)ZM_MOVE_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindItemByName(nullptr), (u_int)ZM_ITEM_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindAbilityByName(""), (u_int)ZM_ABILITY_NONE);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindNatureByName(nullptr), (u_int)ZM_NATURE_COUNT);
+	ZENITH_ASSERT_EQ((u_int)ZM_FindSceneByName(""), (u_int)ZM_SCENE_NONE);
+}
+
+// Cross-table: every evolution target and every TM's taught move resolves.
+ZENITH_TEST(ZM_Data, Registry_EvolutionAndTmRefsResolve)
+{
+	for (u_int i = 0; i < ZM_GetSpeciesCount(); ++i)
+	{
+		const ZM_SpeciesData& x = ZM_GetSpeciesData((ZM_SPECIES_ID)i);
+		if (x.m_eEvolvesTo != ZM_SPECIES_NONE)
+		{
+			ZENITH_ASSERT_EQ((u_int)ZM_FindSpeciesByName(ZM_GetSpeciesName(x.m_eEvolvesTo)), (u_int)x.m_eEvolvesTo,
+				"%s evolves to an unresolvable species", x.m_szName);
+		}
+	}
+	for (u_int i = 0; i < ZM_GetItemCount(); ++i)
+	{
+		const ZM_ItemData& x = ZM_GetItemData((ZM_ITEM_ID)i);
+		if (x.m_eCategory == ZM_ITEM_CATEGORY_TM)
+		{
+			ZENITH_ASSERT_TRUE(x.m_eTaughtMove < ZM_MOVE_COUNT, "%s teaches a non-move", x.m_szName);
+			ZENITH_ASSERT_EQ((u_int)ZM_FindMoveByName(ZM_GetMoveName(x.m_eTaughtMove)), (u_int)x.m_eTaughtMove,
+				"%s teaches an unresolvable move", x.m_szName);
+		}
+	}
+}
+
+// Cross-table: every wild-encounter species and every derived learnset move resolves.
+ZENITH_TEST(ZM_Data, Registry_EncounterAndLearnsetRefsResolve)
+{
+	for (u_int s = 0; s < ZM_GetSceneCount(); ++s)
+	{
+		const ZM_WorldSpec& x = ZM_GetWorldSpec((ZM_SCENE_ID)s);
+		for (u_int e = 0; e < x.m_uEncounterCount; ++e)
+		{
+			const ZM_SPECIES_ID eSp = x.m_pxEncounters[e].m_eSpecies;
+			ZENITH_ASSERT_EQ((u_int)ZM_FindSpeciesByName(ZM_GetSpeciesName(eSp)), (u_int)eSp,
+				"%s has an unresolvable encounter species", x.m_szName);
+		}
+	}
+	for (u_int i = 0; i < ZM_GetSpeciesCount(); ++i)
+	{
+		const ZM_Learnset xLs = ZM_GetSpeciesLearnset((ZM_SPECIES_ID)i);
+		for (u_int k = 0; k < xLs.m_uCount; ++k)
+		{
+			ZENITH_ASSERT_TRUE(xLs.m_axMoves[k].m_eMove < ZM_MOVE_COUNT,
+				"%s learnset references a non-move", ZM_GetSpeciesName((ZM_SPECIES_ID)i));
+		}
+	}
+}


### PR DESCRIPTION
Roadmap S1 box 8 -- **closes S1**. Adds `ZM_DataRegistry` (Source/Data/ZM_DataRegistry.{h,cpp}): reverse name->ID lookups for every S1 table (species/move/item/ability/nature/scene), each returning the id or that table's NONE sentinel (NONE for null/empty). Linear scan (tables <= ~220 rows; hash index is a trivial later swap behind the same signatures).

`Tests/ZM_Tests_DataRegistry.cpp` (9 ZM_Data cases): name round-trip for all six tables, unknown/null/empty -> NONE, and the CROSS-table resolves -- every species evolution target, TM taught move, WorldSpec encounter species, and derived learnset move resolves to a real row. The schema enforcer.

**S1 DATA CORE COMPLETE** -- S1 gate MET (102 ZM_* unit tests vs ~90 target, no visual check). Local gate green (build + unit gate 1172/0-fail + headless). Roadmap box 8 ticked + gate MET; Shortfalls 1.1 updated; Status -> S2 next; DecisionLog ZM-D-030; baseline 1163 -> 1172.

> Stacked on #156 (worldspec); diff resolves to DataRegistry-only once #156 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)